### PR TITLE
MATE-5 : [FEAT] 소셜 로그인 엔드포인트 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/mate/domain/auth/controller/AuthController.java
@@ -1,0 +1,50 @@
+package com.example.mate.domain.auth.controller;
+
+import com.example.mate.domain.global.jwt.JwtToken;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    /*
+    TODO : 2024/11/12 - 네이버 소셜 로그인 및 회원가입
+    1. 인가 코드를 통해 토큰 정보 요청
+    2. 토큰을 통해 사용자 정보 요청
+    3. 사용자 정보 조회 -> 회원가입 or 로그인
+    4. 사용자 정보 Jwt 토큰으로 반환
+    */
+    @GetMapping("/login/naver")
+    public ResponseEntity<JwtToken> loginByNaver(@RequestParam String code) {
+        JwtToken jwtToken = JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .build();
+
+        return ResponseEntity.ok(jwtToken);
+    }
+
+    /*
+    TODO : 2024/11/12 - 구글 소셜 로그인 및 회원가입
+    1. 인가 코드를 통해 토큰 정보 요청
+    2. 토큰을 통해 사용자 정보 요청
+    3. 사용자 정보 조회 -> 회원가입 or 로그인
+    4. 사용자 정보 Jwt 토큰으로 반환
+    */
+    @GetMapping("/login/google")
+    public ResponseEntity<JwtToken> loginByGoogle(@RequestParam String code) {
+        JwtToken jwtToken = JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .build();
+
+        return ResponseEntity.ok(jwtToken);
+    }
+}
+

--- a/src/main/java/com/example/mate/domain/global/jwt/JwtToken.java
+++ b/src/main/java/com/example/mate/domain/global/jwt/JwtToken.java
@@ -1,0 +1,16 @@
+package com.example.mate.domain.global.jwt;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class JwtToken {
+
+    final String grantType;
+    final String accessToken;
+    final String refreshToken;
+}


### PR DESCRIPTION
## 💡 작업 내용
- [x] Jwt 토큰 클래스 생성
- [x] AuthController 클래스 생성
- [x] 네이버 소셜 로그인 엔드포인트 구현
- [x] 구글 소셜 로그인 엔드포인트 구현  

## 💡 자세한 설명
소셜 로그인 기능의 2가지 엔드포인트 구현했습니다.

## 📢 리뷰 요구 사항 (선택)
현재 JwtToken 클래스가 Jwt 토큰을 생성하여 직접 담는 역할, 토큰을 반환하는 DTO의 역할 2가지를 수행하게 될 것 같아  DTO 클래스를 따로 정의해야 할 지 고민이였습니다.. 
따로 정의했을 경우 필드 내용은 바뀌지 않기 때문에 불필요한 클래스를 생성하는 문제점도 생겨서 무엇이 맞는 판단인지 모르겠네요 ...

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?