### PR TITLE
MATE-4 : [FEAT] 경기 정보 관련 도메인 엔드포인트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -34,6 +35,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+	implementation 'org.slf4j:slf4j-api'
+	implementation 'ch.qos.logback:logback-classic'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/mate/Match.http
+++ b/src/main/java/com/example/mate/Match.http
@@ -1,0 +1,48 @@
+### [Match API] ###
+####################
+
+### 1. 전체 경기 조회 ###
+# 상단 배너용 기본 조회 (5개)
+# 현재 상태: 10개의 랜덤 경기 중 필터링하여 반환
+GET http://localhost:8000/api/matches
+Content-Type: application/json
+
+# 팀별 예정 경기 필터링
+### KIA 예정 경기
+GET http://localhost:8000/api/matches?teamId=1&status=SCHEDULED&limit=3
+Content-Type: application/json
+
+### LG 예정 경기
+GET http://localhost:8000/api/matches?teamId=2&status=SCHEDULED
+Content-Type: application/json
+
+# 상태별 필터링
+### 취소된 경기 조회
+# 현재 상태: 모든 경기가 SCHEDULED 상태로 생성됨
+GET http://localhost:8000/api/matches?status=CANCELED
+Content-Type: application/json
+
+### 종료된 경기 조회
+# 현재 상태: 모든 경기가 SCHEDULED 상태로 생성됨
+GET http://localhost:8000/api/matches?status=COMPLETED
+Content-Type: application/json
+
+### 구인글 작성용 특정 팀 경기 조회
+# 메이트 구인글 작성 시 응원 팀 예정 경기 선택에 사용
+GET http://localhost:8000/api/matches?teamId=2&status=SCHEDULED
+Content-Type: application/json
+
+### 2. 팀 경기 결과 조회 ###
+### KIA 최근 경기 결과
+# 메인 페이지의 팀 최근 전적 표시용
+# 현재 상태: 2개의 경기 데이터 생성 (홈 승리 1개, 원정 무승부 1개)
+GET http://localhost:8000/api/matches/1/results
+Content-Type: application/json
+
+
+### [Team API] ###
+#################
+
+### 1. 팀 순위 조회 ###
+GET http://localhost:8000/api/teams/rankings
+Content-Type: application/json

--- a/src/main/java/com/example/mate/domain/match/controller/MatchController.java
+++ b/src/main/java/com/example/mate/domain/match/controller/MatchController.java
@@ -1,0 +1,199 @@
+package com.example.mate.domain.match.controller;
+
+import com.example.mate.domain.match.dto.response.*;
+import com.example.mate.domain.match.model.TeamInfo;
+import com.example.mate.global.common.response.ApiResponse;
+import com.example.mate.global.exception.CustomException;
+import com.example.mate.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/matches")
+@Tag(name = "Match", description = "경기 관련 API")
+@RequiredArgsConstructor
+public class MatchController {
+    private static final int DEFAULT_ALL_MATCHES_LIMIT = 5;
+    private static final int DEFAULT_MY_TEAM_MATCHES_LIMIT = 3;
+    private static final int DEFAULT_HOME_GAMES = 2;
+    private static final int DEFAULT_AWAY_GAMES = 2;
+    private static final int MATCH_HOUR = 18;
+    private static final int MATCH_MINUTE = 30;
+
+    private static final float MIN_TEMP = 15.0f;
+    private static final float MAX_TEMP = 30.0f;
+    private static final int MAX_CLOUDINESS = 100;
+
+    private static final List<TeamInfo> TEAM_LIST = Arrays.asList(
+            new TeamInfo(1L, "KIA 타이거즈", "광주-기아 챔피언스 필드"),
+            new TeamInfo(2L, "LG 트윈스", "잠실야구장"),
+            new TeamInfo(3L, "NC 다이노스", "창원NC파크"),
+            new TeamInfo(4L, "SSG 랜더스", "인천SSG랜더스필드"),
+            new TeamInfo(5L, "kt wiz", "수원 kt wiz 파크"),
+            new TeamInfo(6L, "두산 베어스", "잠실야구장"),
+            new TeamInfo(7L, "롯데 자이언츠", "사직야구장"),
+            new TeamInfo(8L, "삼성 라이온즈", "대구삼성라이온즈파크"),
+            new TeamInfo(9L, "키움 히어로즈", "고척스카이돔"),
+            new TeamInfo(10L, "한화 이글스", "한화생명이글스파크")
+    );
+
+    @Operation(summary = "경기 조회", description = "경기 일정을 조회합니다. 팀ID 지정 시 해당 팀 경기만 조회됩니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<MatchResponse.Detail>>> getMatches(
+            @Parameter(description = "팀 ID")
+            @RequestParam(required = false) Long teamId,
+
+            @Parameter(description = "경기 상태 (SCHEDULED: 예정, COMPLETED: 종료, CANCELED: 취소)")
+            @RequestParam(required = false) String status,
+
+            @Parameter(description = "조회할 경기 수", example = "5")
+            @RequestParam(defaultValue = "5") @Positive int limit) {
+
+        // 10개의 랜덤 경기 생성
+        List<MatchResponse.Detail> matches = createRandomMatches(10);
+
+        // 팀ID로 필터링
+        matches = filterMatchesByTeam(matches, teamId);
+
+        // 상태로 필터링
+        matches = filterMatchesByStatus(matches, status);
+
+        // 정렬 및 개수 제한하여 반환
+        return ResponseEntity.ok(ApiResponse.success(
+                matches.stream()
+                        .sorted(Comparator.comparing(MatchResponse.Detail::getMatchTime))
+                        .limit(Math.min(limit, DEFAULT_ALL_MATCHES_LIMIT))
+                        .collect(Collectors.toList())
+        ));
+    }
+
+    @Operation(summary = "특정 팀의 경기 결과 조회", description = "특정 팀의 최근 경기 결과를 조회합니다.")
+    @GetMapping("/{teamId}/results")
+    public ResponseEntity<ApiResponse<List<MatchResponse.Simple>>> getTeamResults(
+            @PathVariable @Positive Long teamId,
+            @RequestParam(defaultValue = "2") @Positive int limit) {
+
+        TeamInfo team = getTeamById(teamId);
+        List<MatchResponse.Simple> matches = createTeamResults(team);
+
+        return ResponseEntity.ok(ApiResponse.success(matches));
+    }
+
+    private List<MatchResponse.Detail> createRandomMatches(int count) {
+        List<MatchResponse.Detail> matches = new ArrayList<>();
+        for (int i = 1; i <= count; i++) {
+            TeamInfo homeTeam = getRandomTeam();
+            TeamInfo awayTeam;
+            do {
+                awayTeam = getRandomTeam();
+            } while (homeTeam.getId().equals(awayTeam.getId()));
+
+            matches.add(MatchResponse.Detail.builder()
+                    .id((long) i)
+                    .homeTeam(createTeamSimple(homeTeam))
+                    .awayTeam(createTeamSimple(awayTeam))
+                    .location(homeTeam.getStadium())
+                    .matchTime(LocalDateTime.now().plusDays(i)
+                            .withHour(MATCH_HOUR)
+                            .withMinute(MATCH_MINUTE))
+                    .isCanceled(false)
+                    .status(MatchResponse.MatchStatus.SCHEDULED)
+                    .weather(createRandomWeather())
+                    .build());
+        }
+        return matches;
+    }
+
+    private List<MatchResponse.Simple> createTeamResults(TeamInfo team) {
+        List<MatchResponse.Simple> matches = new ArrayList<>();
+
+        // 홈 경기 결과 1개 생성
+        matches.add(MatchResponse.Simple.builder()
+                .id(1L)
+                .homeTeamId(team.getId())
+                .awayTeamId(2L)
+                .homeTeamName(team.getName())
+                .awayTeamName(getTeamById(2L).getName())
+                .location(team.getStadium())
+                .matchTime(LocalDateTime.now().minusDays(1))
+                .isCanceled(false)
+                .homeScore(3)
+                .awayScore(1)
+                .status(MatchResponse.MatchStatus.COMPLETED)
+                .result(MatchResponse.MatchResult.WIN)
+                .build());
+
+        // 원정 경기 결과 1개 생성
+        matches.add(MatchResponse.Simple.builder()
+                .id(2L)
+                .homeTeamId(3L)
+                .awayTeamId(team.getId())
+                .homeTeamName(getTeamById(3L).getName())
+                .awayTeamName(team.getName())
+                .location(getTeamById(3L).getStadium())
+                .matchTime(LocalDateTime.now().minusDays(2))
+                .isCanceled(false)
+                .homeScore(2)
+                .awayScore(2)
+                .status(MatchResponse.MatchStatus.COMPLETED)
+                .result(MatchResponse.MatchResult.DRAW)
+                .build());
+
+        return matches;
+    }
+
+    private List<MatchResponse.Detail> filterMatchesByTeam(List<MatchResponse.Detail> matches, Long teamId) {
+        if (teamId == null) return matches;
+        return matches.stream()
+                .filter(match -> match.getHomeTeam().getId().equals(teamId)
+                        || match.getAwayTeam().getId().equals(teamId))
+                .collect(Collectors.toList());
+    }
+
+    private List<MatchResponse.Detail> filterMatchesByStatus(List<MatchResponse.Detail> matches, String status) {
+        if (status == null) return matches;
+        return matches.stream()
+                .filter(match -> match.getStatus().name().equals(status))
+                .collect(Collectors.toList());
+    }
+
+    private WeatherResponse.Info createRandomWeather() {
+        Random random = new Random();
+        return WeatherResponse.Info.builder()
+                .temperature(random.nextFloat() * (MAX_TEMP - MIN_TEMP) + MIN_TEMP)
+                .pop(random.nextFloat() * MAX_CLOUDINESS)
+                .cloudiness(random.nextInt(MAX_CLOUDINESS + 1))
+                .wtTime(LocalDateTime.now())
+                .build();
+    }
+
+    private TeamInfo getRandomTeam() {
+        return TEAM_LIST.get(new Random().nextInt(TEAM_LIST.size()));
+    }
+
+    private TeamInfo getTeamById(Long teamId) {
+        return TEAM_LIST.stream()
+                .filter(team -> team.getId().equals(teamId))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private TeamResponse.Simple createTeamSimple(TeamInfo teamInfo) {
+        return TeamResponse.Simple.builder()
+                .id(teamInfo.getId())
+                .teamName(teamInfo.getName())
+                .logoImageUrl(String.format("http://example.com/teams/%d/logo.png", teamInfo.getId()))
+                .build();
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/controller/MatchController.java
+++ b/src/main/java/com/example/mate/domain/match/controller/MatchController.java
@@ -36,16 +36,16 @@ public class MatchController {
     private static final int MAX_CLOUDINESS = 100;
 
     private static final List<TeamInfo> TEAM_LIST = Arrays.asList(
-            new TeamInfo(1L, "KIA 타이거즈", "광주-기아 챔피언스 필드"),
-            new TeamInfo(2L, "LG 트윈스", "잠실야구장"),
-            new TeamInfo(3L, "NC 다이노스", "창원NC파크"),
-            new TeamInfo(4L, "SSG 랜더스", "인천SSG랜더스필드"),
-            new TeamInfo(5L, "kt wiz", "수원 kt wiz 파크"),
-            new TeamInfo(6L, "두산 베어스", "잠실야구장"),
-            new TeamInfo(7L, "롯데 자이언츠", "사직야구장"),
-            new TeamInfo(8L, "삼성 라이온즈", "대구삼성라이온즈파크"),
-            new TeamInfo(9L, "키움 히어로즈", "고척스카이돔"),
-            new TeamInfo(10L, "한화 이글스", "한화생명이글스파크")
+            new TeamInfo(1L, "KIA", "KIA 타이거즈", "광주-기아 챔피언스 필드"),
+            new TeamInfo(2L, "LG", "LG 트윈스", "잠실야구장"),
+            new TeamInfo(3L, "NC", "NC 다이노스", "창원NC파크"),
+            new TeamInfo(4L, "SSG", "SSG 랜더스", "인천SSG랜더스필드"),
+            new TeamInfo(5L, "KT", "kt wiz", "수원 kt wiz 파크"),
+            new TeamInfo(6L, "두산", "두산 베어스", "잠실야구장"),
+            new TeamInfo(7L, "롯데", "롯데 자이언츠", "사직야구장"),
+            new TeamInfo(8L, "삼성", "삼성 라이온즈", "대구삼성라이온즈파크"),
+            new TeamInfo(9L, "키움", "키움 히어로즈", "고척스카이돔"),
+            new TeamInfo(10L, "한화", "한화 이글스", "한화생명이글스파크")
     );
 
     @Operation(summary = "경기 조회", description = "경기 일정을 조회합니다. 팀ID 지정 시 해당 팀 경기만 조회됩니다.")
@@ -55,10 +55,7 @@ public class MatchController {
             @RequestParam(required = false) Long teamId,
 
             @Parameter(description = "경기 상태 (SCHEDULED: 예정, COMPLETED: 종료, CANCELED: 취소)")
-            @RequestParam(required = false) String status,
-
-            @Parameter(description = "조회할 경기 수", example = "5")
-            @RequestParam(defaultValue = "5") @Positive int limit) {
+            @RequestParam(required = false) String status) {
 
         // 10개의 랜덤 경기 생성
         List<MatchResponse.Detail> matches = createRandomMatches(10);
@@ -73,7 +70,7 @@ public class MatchController {
         return ResponseEntity.ok(ApiResponse.success(
                 matches.stream()
                         .sorted(Comparator.comparing(MatchResponse.Detail::getMatchTime))
-                        .limit(Math.min(limit, DEFAULT_ALL_MATCHES_LIMIT))
+                        .limit(DEFAULT_ALL_MATCHES_LIMIT)
                         .collect(Collectors.toList())
         ));
     }
@@ -123,8 +120,8 @@ public class MatchController {
                 .id(1L)
                 .homeTeamId(team.getId())
                 .awayTeamId(2L)
-                .homeTeamName(team.getName())
-                .awayTeamName(getTeamById(2L).getName())
+                .homeTeamName(team.getFullName())
+                .awayTeamName(getTeamById(2L).getFullName())
                 .location(team.getStadium())
                 .matchTime(LocalDateTime.now().minusDays(1))
                 .isCanceled(false)
@@ -139,8 +136,8 @@ public class MatchController {
                 .id(2L)
                 .homeTeamId(3L)
                 .awayTeamId(team.getId())
-                .homeTeamName(getTeamById(3L).getName())
-                .awayTeamName(team.getName())
+                .homeTeamName(getTeamById(3L).getFullName())
+                .awayTeamName(team.getFullName())
                 .location(getTeamById(3L).getStadium())
                 .matchTime(LocalDateTime.now().minusDays(2))
                 .isCanceled(false)
@@ -192,7 +189,7 @@ public class MatchController {
     private TeamResponse.Simple createTeamSimple(TeamInfo teamInfo) {
         return TeamResponse.Simple.builder()
                 .id(teamInfo.getId())
-                .teamName(teamInfo.getName())
+                .teamName(teamInfo.getFullName())
                 .logoImageUrl(String.format("http://example.com/teams/%d/logo.png", teamInfo.getId()))
                 .build();
     }

--- a/src/main/java/com/example/mate/domain/match/controller/TeamController.java
+++ b/src/main/java/com/example/mate/domain/match/controller/TeamController.java
@@ -1,0 +1,76 @@
+package com.example.mate.domain.match.controller;
+
+import com.example.mate.domain.match.dto.response.StadiumResponse;
+import com.example.mate.domain.match.dto.response.TeamResponse;
+import com.example.mate.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Tag(name = "Team", description = "팀 관련 API")
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+public class TeamController {
+    private static final int TOTAL_GAMES = 144;  // KBO 정규시즌 총 경기 수
+
+    @Operation(summary = "팀 순위 조회", description = "KBO 리그 전체 순위를 조회합니다.")
+    @GetMapping("/rankings")
+    public ResponseEntity<ApiResponse<List<TeamResponse.Detail>>> getTeamRankings() {
+        List<TeamResponse.Detail> rankings = Arrays.asList(
+                createTeamDetail(1L, "KIA 타이거즈", "광주-기아 챔피언스 필드", "광주광역시 북구", "126.8989", "35.1681",
+                        100, 90, 10, 0, 2.0),
+                createTeamDetail(2L, "LG 트윈스", "잠실야구장", "서울특별시 송파구", "127.0719", "37.5122",
+                        95, 85, 10, 0, 3.5),
+                createTeamDetail(3L, "NC 다이노스", "창원NC파크", "창원시 마산회원구", "128.5829", "35.2534",
+                        92, 82, 10, 0, 4.0),
+                createTeamDetail(4L, "SSG 랜더스", "인천SSG랜더스필드", "인천광역시 미추홀구", "126.6781", "37.4374",
+                        90, 78, 12, 0, 5.0),
+                createTeamDetail(5L, "kt wiz", "수원 kt wiz 파크", "수원시 장안구", "127.0355", "37.2994",
+                        88, 75, 13, 0, 6.0),
+                createTeamDetail(6L, "두산 베어스", "잠실야구장", "서울특별시 송파구", "127.0719", "37.5122",
+                        86, 72, 14, 0, 7.0),
+                createTeamDetail(7L, "롯데 자이언츠", "사직야구장", "부산광역시 동래구", "129.0639", "35.1947",
+                        84, 68, 16, 0, 8.0),
+                createTeamDetail(8L, "삼성 라이온즈", "대구삼성라이온즈파크", "대구광역시 수성구", "128.6814", "35.8409",
+                        82, 65, 17, 0, 9.0),
+                createTeamDetail(9L, "키움 히어로즈", "고척스카이돔", "서울특별시 구로구", "126.8669", "37.4982",
+                        80, 62, 18, 0, 10.0),
+                createTeamDetail(10L, "한화 이글스", "한화생명이글스파크", "대전광역시 중구", "127.4294", "36.3172",
+                        78, 58, 20, 0, 11.0)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(rankings));
+    }
+
+    private TeamResponse.Detail createTeamDetail(Long id, String teamName,
+                                                 String stadiumName, String location, String longitude, String latitude,
+                                                 int gamesPlayed, int wins, int draws, int losses, double gamesBehind) {
+        return TeamResponse.Detail.builder()
+                .id(id)
+                .teamName(teamName)
+                .logoImageUrl(String.format("http://example.com/teams/%d/logo.png", id))
+                .stadium(StadiumResponse.Info.builder()
+                        .id(id)
+                        .stadiumName(stadiumName)
+                        .location(location)
+                        .longitude(longitude)
+                        .latitude(latitude)
+                        .build())
+                .rank(id.intValue())
+                .gamesPlayed(gamesPlayed)
+                .totalGames(TOTAL_GAMES)
+                .wins(wins)
+                .draws(draws)
+                .losses(losses)
+                .gamesBehind(gamesBehind)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/dto/request/MatchRequest.java
+++ b/src/main/java/com/example/mate/domain/match/dto/request/MatchRequest.java
@@ -1,0 +1,42 @@
+package com.example.mate.domain.match.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class MatchRequest {
+    @Getter
+    @NoArgsConstructor
+    public static class Create {
+        @NotNull(message = "홈팀 ID는 필수입니다")
+        @Positive(message = "홈팀 ID는 양수여야 합니다")
+        private Long homeTeamId;
+
+        @NotNull(message = "원정팀 ID는 필수입니다")
+        @Positive(message = "원정팀 ID는 양수여야 합니다")
+        private Long awayTeamId;
+
+        @NotBlank(message = "경기장 위치는 필수입니다")
+        private String location;
+
+        @NotNull(message = "경기 시간은 필수입니다")
+        @Future(message = "경기 시간은 미래 시간이어야 합니다")
+        private LocalDateTime matchTime;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Update {
+        @NotNull(message = "경기 취소 여부는 필수입니다")
+        private Boolean isCanceled;
+
+        @PositiveOrZero(message = "홈팀 점수는 0 이상이어야 합니다")
+        private Integer homeScore;
+
+        @PositiveOrZero(message = "원정팀 점수는 0 이상이어야 합니다")
+        private Integer awayScore;
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/dto/request/StadiumRequest.java
+++ b/src/main/java/com/example/mate/domain/match/dto/request/StadiumRequest.java
@@ -1,0 +1,44 @@
+package com.example.mate.domain.match.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StadiumRequest {
+    @Getter
+    @NoArgsConstructor
+    public static class Create {
+        @NotBlank(message = "경기장 이름은 필수입니다")
+        private String stadiumName;
+
+        @NotBlank(message = "위치는 필수입니다")
+        private String location;
+
+        @NotBlank(message = "경도는 필수입니다")
+        @Pattern(regexp = "^-?([0-9]{1,3}\\.[0-9]+)$", message = "올바른 경도 형식이 아닙니다")
+        private String longitude;
+
+        @NotBlank(message = "위도는 필수입니다")
+        @Pattern(regexp = "^-?([0-9]{1,2}\\.[0-9]+)$", message = "올바른 위도 형식이 아닙니다")
+        private String latitude;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Update {
+        @NotBlank(message = "경기장 이름은 필수입니다")
+        private String stadiumName;
+
+        @NotBlank(message = "위치는 필수입니다")
+        private String location;
+
+        @Pattern(regexp = "^-?([0-9]{1,3}\\.[0-9]+)$", message = "올바른 경도 형식이 아닙니다")
+        private String longitude;
+
+        @Pattern(regexp = "^-?([0-9]{1,2}\\.[0-9]+)$", message = "올바른 위도 형식이 아닙니다")
+        private String latitude;
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/dto/request/TeamRequest.java
+++ b/src/main/java/com/example/mate/domain/match/dto/request/TeamRequest.java
@@ -1,0 +1,54 @@
+package com.example.mate.domain.match.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TeamRequest {
+    @Getter
+    @NoArgsConstructor
+    public static class Create {
+        @NotNull(message = "경기장 ID는 필수입니다")
+        @Positive(message = "경기장 ID는 양수여야 합니다")
+        private Long stadiumId;
+
+        @NotBlank(message = "팀 이름은 필수입니다")
+        private String teamName;
+
+        @NotBlank(message = "로고 이미지 URL은 필수입니다")
+        private String logoImageUrl;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Update {
+        @NotBlank(message = "팀 이름은 필수입니다")
+        private String teamName;
+
+        @NotBlank(message = "로고 이미지 URL은 필수입니다")
+        private String logoImageUrl;
+
+        @Positive(message = "순위는 양수여야 합니다")
+        private Integer rank;
+
+        @PositiveOrZero(message = "경기 수는 0 이상이어야 합니다")
+        private Integer gamesPlayed;
+
+        @Positive(message = "전체 경기 수는 양수여야 합니다")
+        private Integer totalGames;
+
+        @PositiveOrZero(message = "승리 수는 0 이상이어야 합니다")
+        private Integer wins;
+
+        @PositiveOrZero(message = "무승부 수는 0 이상이어야 합니다")
+        private Integer draws;
+
+        @PositiveOrZero(message = "패배 수는 0 이상이어야 합니다")
+        private Integer losses;
+
+        @PositiveOrZero(message = "게임차는 0 이상이어야 합니다")
+        private Double gamesBehind;
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/dto/request/WeatherRequest.java
+++ b/src/main/java/com/example/mate/domain/match/dto/request/WeatherRequest.java
@@ -1,0 +1,51 @@
+package com.example.mate.domain.match.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WeatherRequest {
+    @Getter
+    @NoArgsConstructor
+    public static class Create {
+        @NotNull(message = "경기 ID는 필수입니다")
+        @Positive(message = "경기 ID는 양수여야 합니다")
+        private Long matchId;
+
+        @NotNull(message = "기온은 필수입니다")
+        @DecimalMin(value = "-50.0", message = "기온은 -50도 이상이어야 합니다")
+        @DecimalMax(value = "50.0", message = "기온은 50도 이하여야 합니다")
+        private Float temperature;
+
+        @NotNull(message = "강수확률은 필수입니다")
+        @DecimalMin(value = "0.0", message = "강수확률은 0% 이상이어야 합니다")
+        @DecimalMax(value = "100.0", message = "강수확률은 100% 이하여야 합니다")
+        private Float pop;
+
+        @NotNull(message = "운량은 필수입니다")
+        @Min(value = 0, message = "운량은 0 이상이어야 합니다")
+        @Max(value = 100, message = "운량은 100 이하여야 합니다")
+        private Integer cloudiness;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Update {
+        @NotNull(message = "기온은 필수입니다")
+        @DecimalMin(value = "-50.0", message = "기온은 -50도 이상이어야 합니다")
+        @DecimalMax(value = "50.0", message = "기온은 50도 이하여야 합니다")
+        private Float temperature;
+
+        @NotNull(message = "강수확률은 필수입니다")
+        @DecimalMin(value = "0.0", message = "강수확률은 0% 이상이어야 합니다")
+        @DecimalMax(value = "100.0", message = "강수확률은 100% 이하여야 합니다")
+        private Float pop;
+
+        @NotNull(message = "운량은 필수입니다")
+        @Min(value = 0, message = "운량은 0 이상이어야 합니다")
+        @Max(value = 100, message = "운량은 100 이하여야 합니다")
+        private Integer cloudiness;
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/dto/response/MatchResponse.java
+++ b/src/main/java/com/example/mate/domain/match/dto/response/MatchResponse.java
@@ -1,0 +1,72 @@
+package com.example.mate.domain.match.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class MatchResponse {
+    public enum MatchStatus {
+        SCHEDULED("예정"),
+        COMPLETED("종료"),
+        CANCELED("취소");
+
+        private final String description;
+
+        MatchStatus(String description) {
+            this.description = description;
+        }
+    }
+
+    public enum MatchResult {
+        WIN("승"),
+        LOSE("패"),
+        DRAW("무");
+
+        private final String description;
+
+        MatchResult(String description) {
+            this.description = description;
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class Simple {  // 종료된 경기용 Response (@@팀의 최근 전적)
+        private Long id;
+        private Long homeTeamId;
+        private Long awayTeamId;
+        private String homeTeamName;
+        private String awayTeamName;
+        private String location;
+        private LocalDateTime matchTime;
+        private Boolean isCanceled;
+        private Integer homeScore;
+        private Integer awayScore;
+        private MatchStatus status;
+        private MatchResult result;
+
+    }
+
+    @Getter
+    @Builder
+    public static class Detail {  // 예정된 경기용 Response ( 상단 배너 )
+        private Long id;
+        private TeamResponse.Simple homeTeam;
+        private TeamResponse.Simple awayTeam;
+        private String location;
+        private LocalDateTime matchTime;
+        private Boolean isCanceled;
+        private MatchStatus status;
+        private WeatherResponse.Info weather;
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        public LocalDateTime getMatchTime() {
+            return matchTime;
+        }
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/dto/response/StadiumResponse.java
+++ b/src/main/java/com/example/mate/domain/match/dto/response/StadiumResponse.java
@@ -1,0 +1,19 @@
+package com.example.mate.domain.match.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StadiumResponse {
+    @Getter
+    @Builder
+    public static class Info {
+        private Long id;
+        private String stadiumName;
+        private String location;
+        private String longitude;
+        private String latitude;
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/dto/response/TeamResponse.java
+++ b/src/main/java/com/example/mate/domain/match/dto/response/TeamResponse.java
@@ -1,0 +1,33 @@
+package com.example.mate.domain.match.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TeamResponse {
+    @Getter
+    @Builder
+    public static class Simple {
+        private Long id;
+        private String teamName;
+        private String logoImageUrl;
+    }
+
+    @Getter
+    @Builder
+    public static class Detail {
+        private Long id;
+        private String teamName;
+        private String logoImageUrl;
+        private StadiumResponse.Info stadium;
+        private Integer rank;
+        private Integer gamesPlayed;
+        private Integer totalGames;
+        private Integer wins;
+        private Integer draws;
+        private Integer losses;
+        private Double gamesBehind;
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/dto/response/WeatherResponse.java
+++ b/src/main/java/com/example/mate/domain/match/dto/response/WeatherResponse.java
@@ -1,0 +1,26 @@
+package com.example.mate.domain.match.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class WeatherResponse {
+    @Getter
+    @Builder
+    public static class Info {
+        private Float temperature;
+        private Float pop;
+        private Integer cloudiness;
+        private LocalDateTime wtTime;
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        public LocalDateTime getWtTime() {
+            return wtTime;
+        }
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/model/TeamData.java
+++ b/src/main/java/com/example/mate/domain/match/model/TeamData.java
@@ -1,0 +1,31 @@
+package com.example.mate.domain.match.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TeamData {
+    private final Long id;
+    private final String name;
+    private final String stadiumName;
+    private final String location;
+    private final String longitude;
+    private final String latitude;
+
+    public static final List<TeamData> TEAM_LIST = Arrays.asList(
+            new TeamData(1L, "KIA 타이거즈", "광주-기아 챔피언스 필드", "광주광역시 북구", "126.8989", "35.1681"),
+            new TeamData(2L, "LG 트윈스", "잠실야구장", "서울특별시 송파구", "127.0719", "37.5122"),
+            new TeamData(3L, "NC 다이노스", "창원NC파크", "창원시 마산회원구", "128.5829", "35.2534"),
+            new TeamData(4L, "SSG 랜더스", "인천SSG랜더스필드", "인천광역시 미추홀구", "126.6781", "37.4374"),
+            new TeamData(5L, "kt wiz", "수원 kt wiz 파크", "수원시 장안구", "127.0355", "37.2994"),
+            new TeamData(6L, "두산 베어스", "잠실야구장", "서울특별시 송파구", "127.0719", "37.5122"),
+            new TeamData(7L, "롯데 자이언츠", "사직야구장", "부산광역시 동래구", "129.0639", "35.1947"),
+            new TeamData(8L, "삼성 라이온즈", "대구삼성라이온즈파크", "대구광역시 수성구", "128.6814", "35.8409"),
+            new TeamData(9L, "키움 히어로즈", "고척스카이돔", "서울특별시 구로구", "126.8669", "37.4982"),
+            new TeamData(10L, "한화 이글스", "한화생명이글스파크", "대전광역시 중구", "127.4294", "36.3172")
+    );
+}

--- a/src/main/java/com/example/mate/domain/match/model/TeamInfo.java
+++ b/src/main/java/com/example/mate/domain/match/model/TeamInfo.java
@@ -1,0 +1,12 @@
+package com.example.mate.domain.match.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TeamInfo {
+    private Long id;
+    private String name;
+    private String stadium;
+}

--- a/src/main/java/com/example/mate/domain/match/model/TeamInfo.java
+++ b/src/main/java/com/example/mate/domain/match/model/TeamInfo.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class TeamInfo {
     private Long id;
-    private String name;
+    private final String shortName;
+    private final String fullName;
     private String stadium;
 }

--- a/src/main/java/com/example/mate/global/common/response/ApiResponse.java
+++ b/src/main/java/com/example/mate/global/common/response/ApiResponse.java
@@ -1,0 +1,47 @@
+package com.example.mate.global.common.response;
+
+import com.example.mate.global.exception.ErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ApiResponse<T> {
+    private final String status;
+    private final String message;
+    private final T data;
+    private final LocalDateTime timestamp;
+    private final int code;
+
+    // 성공 응답
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .status("SUCCESS")
+                .data(data)
+                .timestamp(LocalDateTime.now())
+                .code(200)
+                .build();
+    }
+
+    // 에러 응답 - ErrorCode
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return ApiResponse.<T>builder()
+                .status("ERROR")
+                .message(errorCode.getMessage())
+                .timestamp(LocalDateTime.now())
+                .code(errorCode.getStatus().value())
+                .build();
+    }
+
+    // 에러 응답
+    public static <T> ApiResponse<T> error(String message, int code) {
+        return ApiResponse.<T>builder()
+                .status("ERROR")
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .code(code)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mate/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/mate/global/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.example.mate.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/mate/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/mate/global/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.example.mate.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Baseball Match API")
+                .version("v1.0.0")
+                .description("야구 경기 정보 제공 API 문서");
+
+        return new OpenAPI()
+                .info(info)
+                .servers(List.of(new Server().url("http://localhost:8000")));
+    }
+}

--- a/src/main/java/com/example/mate/global/exception/CustomException.java
+++ b/src/main/java/com/example/mate/global/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.example.mate.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/example/mate/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/mate/global/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.example.mate.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    // Common
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "Internal Server Error"),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C002", "Invalid Input Value"),
+
+    // Team 도메인
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "팀을 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/mate/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/mate/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.example.mate.global.exception;
+
+import com.example.mate.global.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import jakarta.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    // CustomException 처리
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+        log.error("CustomException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode));
+    }
+
+    // 모든 예외 타입 처리
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unexpected error: {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .internalServerError()
+                .body(ApiResponse.error(
+                        "서버 내부 오류가 발생했습니다.",
+                        HttpStatus.INTERNAL_SERVER_ERROR.value()
+                ));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,20 @@ spring:
       production:
       local: local
     active: local
+
+server:
+  port: 8000
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs
+  packages-to-scan: com.example.mate
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+
+logging:
+  level:
+    root: INFO
+    com.example.mate: DEBUG


### PR DESCRIPTION
## 💡 작업 내용

- [x] 상단 배너 경기 정보 관련 조회 엔드포인트 구현
- [x] 하단 해당 팀의 경기 전적 조회 엔드포인트 구현
- [x] 하단 전체 팀의 KBO 순위 조회 엔드포인트 구현

## 💡 자세한 설명
1. 마이팀을 선택하지 않은 경우 상단 배너에서 예정 경기 5개 조회
해당 반환값은 MatchResponse 내 Detail을 사용하였으며 해당 값은 날씨 값을 포함
엔드 포인트 : /api/matches?status=SCHEDULED&limit=5 

2. 마이팀을 선택한 경우 상단 배너에서 해당 팀의 예정 경기 3개 조회
해당 반환값은 MatchResponse 내 Detail을 사용하였으며 해당 값은 날씨 값을 포함
엔드 포인트 : /api/matches?teamId=1&status=SCHEDULED&limit=3

3. 구인글 작성 시 선택한 응원팀의 예정 경기 조회
해당 반환값은 MatchResponse 내 Detail을 사용하였으며 해당 값은 날씨 값을 포함
엔드 포인트 : /api/matches?teamId=1&status=SCHEDULED

4. 메인 페이지에서 특정 팀 카테고리에서의 해당 팀의 경기 전적 조회
해당 반환값은 MatchResponse 내 Simple을 사용하였으며 스코어를 포함
엔드 포인트 : /api/matches/1/results

5. 메인 페이지에서 전체 팀 카테고리에서 하단의 KBO 순위 조회
해당 반환값은 TeamResponse 내 Detail를 사용
엔드 포인트 : /api/teams/rankings

6. RequestDTO를 생성하였으나 현재 사용하지 않는 상태

7. 테스트 데이터는 model 폴더 안에 배치하여 controller 내에서 해당 클래스를 사용

8. Config 관련
- SecurityConfig : API 요청에 대한 시큐리티 설정 추가
- SwaggerConfig : Swagger 문서 관련 설정 추가

9. ApiResponse와 예외처리 관련
- 현재 MatchController와 TeamController는 ApiResponse를 통해 반환
- 도메인 별 ErrorCode 추가 필요
- GlobalExceptionHandler를 통해 Controller에 대한 예외처리 설정

10. 현재 Controller는 임의의 데이터를 생성하여 조회하기 때문에 이후 작업 시 조회 시 시간 순 나열에 대한 Repository 설정이 필요

11. Controller 테스트 코드 작성 필요

12. Controller API 요청 시 예외에 대한 응답값 확인이 추가적으로 필요할 것 같고 그에 따른 예외처리 관련 코드들도 추가해야 할 것 같다.

## 📗 참고 자료 (선택)
1. 컨트롤러 예외처리에 대한 참고자료 (GlobalExceptionHandler)
https://adjh54.tistory.com/79

## 📢 리뷰 요구 사항 (선택)
1. 예외처리 관련하여 파일 생성과 해당 파일에 대한 생성 목적에 따라 잘 이용하고 있는가?
2. Controller 내에서 try - catch 문 등을 통해 예외처리를 작업해야 할 것 같은데 이에 대해서 좀 더 깊게 고민하는 중

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?