### PR TITLE
MATE-15 : [FEAT] 경기 정보 관련 엔티티 생성

### DIFF
--- a/src/main/java/com/example/mate/domain/constant/StadiumInfo.java
+++ b/src/main/java/com/example/mate/domain/constant/StadiumInfo.java
@@ -1,0 +1,53 @@
+package com.example.mate.domain.constant;
+
+import com.example.mate.global.exception.CustomException;
+import com.example.mate.global.exception.ErrorCode;
+
+import java.util.List;
+
+public final class StadiumInfo {
+
+    public static final class Stadium {
+        public final Long id;
+        public final String name;
+        public final String location;
+        public final String longitude;
+        public final String latitude;
+
+        private Stadium(Long id, String name, String location, String longitude, String latitude) {
+            this.id = id;
+            this.name = name;
+            this.location = location;
+            this.longitude = longitude;
+            this.latitude = latitude;
+        }
+    }
+
+    public static final Stadium GWANGJU = new Stadium(1L, "광주-기아 챔피언스 필드", "광주광역시 북구", "126.8891056", "35.1681242");
+    public static final Stadium JAMSIL = new Stadium(2L, "잠실야구장", "서울특별시 송파구", "127.071827", "37.5120673");
+    public static final Stadium CHANGWON = new Stadium(3L, "창원 NC 파크", "창원시 마산회원구", "128.5822292", "35.2225967");
+    public static final Stadium INCHEON = new Stadium(4L, "인천 SSG 랜더스필드", "인천광역시 미추홀구", "126.6932617", "37.4370423");
+    public static final Stadium SUWON = new Stadium(5L, "수원 kt wiz 파크", "수원시 장안구", "127.0096685", "37.2997553");
+    public static final Stadium SAJIK = new Stadium(6L, "사직야구장", "부산광역시 동래구", "129.0615183", "35.1940316");
+    public static final Stadium DAEGU = new Stadium(7L, "대구삼성라이온즈파크", "대구광역시 수성구", "128.6815273", "35.8411705");
+    public static final Stadium GOCHEOK = new Stadium(8L, "고척스카이돔", "서울특별시 구로구", "126.8670866", "37.498931");
+    public static final Stadium DAEJEON = new Stadium(9L, "한화생명이글스파크", "대전광역시 중구", "127.4291345", "36.3170789");
+
+    public static final List<Stadium> STADIUMS = List.of(
+            GWANGJU, JAMSIL, CHANGWON, INCHEON, SUWON, SAJIK, DAEGU, GOCHEOK, DAEJEON
+    );
+
+    public static Stadium getById(Long id) {
+        return STADIUMS.stream()
+                .filter(stadium -> stadium.id.equals(id))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.STADIUM_NOT_FOUND_BY_ID));
+    }
+
+    public static Stadium getByName(String name) {
+        return STADIUMS.stream()
+                .filter(stadium -> stadium.name.equals(name))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.STADIUM_NOT_FOUND_BY_NAME));
+    }
+}

--- a/src/main/java/com/example/mate/domain/constant/TeamInfo.java
+++ b/src/main/java/com/example/mate/domain/constant/TeamInfo.java
@@ -1,0 +1,45 @@
+package com.example.mate.domain.constant;
+
+import com.example.mate.global.exception.CustomException;
+import com.example.mate.global.exception.ErrorCode;
+
+import java.util.List;
+
+public final class TeamInfo {
+
+    public static final class Team {
+        public final Long id;
+        public final String shortName;
+        public final String fullName;
+        public final StadiumInfo.Stadium homeStadium;
+
+        private Team(Long id, String shortName, String fullName, StadiumInfo.Stadium homeStadium) {
+            this.id = id;
+            this.shortName = shortName;
+            this.fullName = fullName;
+            this.homeStadium = homeStadium;
+        }
+    }
+
+    public static final Team KIA = new Team(1L, "KIA", "KIA 타이거즈", StadiumInfo.GWANGJU);
+    public static final Team LG = new Team(2L, "LG", "LG 트윈스", StadiumInfo.JAMSIL);
+    public static final Team NC = new Team(3L, "NC", "NC 다이노스", StadiumInfo.CHANGWON);
+    public static final Team SSG = new Team(4L, "SSG", "SSG 랜더스", StadiumInfo.INCHEON);
+    public static final Team KT = new Team(5L, "KT", "kt wiz", StadiumInfo.SUWON);
+    public static final Team DOOSAN = new Team(6L, "두산", "두산 베어스", StadiumInfo.JAMSIL);
+    public static final Team LOTTE = new Team(7L, "롯데", "롯데 자이언츠", StadiumInfo.SAJIK);
+    public static final Team SAMSUNG = new Team(8L, "삼성", "삼성 라이온즈", StadiumInfo.DAEGU);
+    public static final Team KIWOOM = new Team(9L, "키움", "키움 히어로즈", StadiumInfo.GOCHEOK);
+    public static final Team HANWHA = new Team(10L, "한화", "한화 이글스", StadiumInfo.DAEJEON);
+
+    public static final List<Team> TEAMS = List.of(
+            KIA, LG, NC, SSG, KT, DOOSAN, LOTTE, SAMSUNG, KIWOOM, HANWHA
+    );
+
+    public static Team getById(Long id) {
+        return TEAMS.stream()
+                .filter(team -> team.id.equals(id))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/entity/Match.java
+++ b/src/main/java/com/example/mate/domain/match/entity/Match.java
@@ -1,0 +1,75 @@
+package com.example.mate.domain.match.entity;
+
+import com.example.mate.domain.constant.StadiumInfo;
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.entity.MatchStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Match {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "home_team_id", nullable = false)
+    private Long homeTeamId;
+
+    @Column(name = "away_team_id", nullable = false)
+    private Long awayTeamId;
+
+    @Column(name = "stadium_id", nullable = false)
+    private Long stadiumId;
+
+    @Column(nullable = false)
+    private LocalDateTime matchTime;
+
+    private Boolean isCanceled;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MatchStatus status;
+
+    private Integer homeScore;
+    private Integer awayScore;
+
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "weather_id")
+    private Weather weather;
+
+    @Builder
+    public Match(Long homeTeamId, Long awayTeamId, Long stadiumId,
+                 LocalDateTime matchTime, Boolean isCanceled,
+                 MatchStatus status) {
+        this.homeTeamId = homeTeamId;
+        this.awayTeamId = awayTeamId;
+        this.stadiumId = stadiumId;
+        this.matchTime = matchTime;
+        this.isCanceled = isCanceled;
+        this.status = status;
+    }
+
+    // Stadium 정보 조회
+    public StadiumInfo.Stadium getStadium() {
+        return StadiumInfo.getById(this.stadiumId);
+    }
+
+    // 날씨 정보 업데이트
+    public void updateWeather(Weather weather) {
+        this.weather = weather;
+        weather.setMatch(this);
+    }
+
+    // 홈 팀의 경기장인지 확인
+    public boolean isHomeStadium() {
+        TeamInfo.Team homeTeam = TeamInfo.getById(this.homeTeamId);
+        return homeTeam.homeStadium.id.equals(this.stadiumId);
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/entity/Weather.java
+++ b/src/main/java/com/example/mate/domain/match/entity/Weather.java
@@ -1,0 +1,45 @@
+package com.example.mate.domain.match.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Weather {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Float temperature;
+
+    @Column
+    private Float pop;
+
+    @Column
+    private Integer cloudiness;
+
+    @Column
+    private LocalDateTime wtTime;
+
+    @OneToOne(mappedBy = "weather")
+    private Match match;
+
+    @Builder
+    public Weather(Float temperature, Float pop, Integer cloudiness, LocalDateTime wtTime) {
+        this.temperature = temperature;
+        this.pop = pop;
+        this.cloudiness = cloudiness;
+        this.wtTime = wtTime;
+    }
+
+    protected void setMatch(Match match) {
+        this.match = match;
+    }
+}

--- a/src/main/java/com/example/mate/entity/MatchResult.java
+++ b/src/main/java/com/example/mate/entity/MatchResult.java
@@ -1,0 +1,16 @@
+package com.example.mate.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum MatchResult {
+    WIN("승"),
+    LOSE("패"),
+    DRAW("무");
+
+    private final String description;
+
+    MatchResult(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/mate/entity/MatchStatus.java
+++ b/src/main/java/com/example/mate/entity/MatchStatus.java
@@ -1,0 +1,16 @@
+package com.example.mate.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum MatchStatus {
+    SCHEDULED("예정"),
+    COMPLETED("종료"),
+    CANCELED("취소");
+
+    private final String description;
+
+    MatchStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/mate/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/mate/global/exception/ErrorCode.java
@@ -9,8 +9,12 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "Internal Server Error"),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C002", "Invalid Input Value"),
 
-    // Team 도메인
-    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "팀을 찾을 수 없습니다");
+    // Team
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "팀을 찾을 수 없습니다"),
+
+    // Stadium
+    STADIUM_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "S001", "해당 ID의 경기장 정보를 찾을 수 없습니다"),
+    STADIUM_NOT_FOUND_BY_NAME(HttpStatus.NOT_FOUND, "S002", "해당 이름의 경기장 정보를 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## 💡 작업 내용

- [x] 경기 정보 엔티티 생성
- [x] 날씨 정보 엔티티 생성
- [x] 팀과 경기장 정보 상수로 생성

## 💡 자세한 설명
1. 경기 정보 엔티티 생성
> 경기 정보에서의 경기 장소는 stadium_Info에서 갖고옴
> 날씨 정보 업데이트 메서드 작성

2. 날씨 정보 엔티티 생성

3. 팀과 경기장 정보 상수로 생성
> 해당 내용은 변하지 않는 상수이기 때문에 엔티티로 생성하지 않음

4. Errorcode 추가

5. 경기 결과와 경기 상태의 Enum 파일 생성

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?