### PR TITLE
MATE-21 : [FEAT] 팀 성적 엔티티 생성

### DIFF
--- a/src/main/java/com/example/mate/domain/match/entity/TeamRecord.java
+++ b/src/main/java/com/example/mate/domain/match/entity/TeamRecord.java
@@ -1,0 +1,71 @@
+package com.example.mate.domain.match.entity;
+
+import com.example.mate.domain.constant.TeamInfo;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamRecord {
+
+    @Id
+    @Column(name = "team_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer rank;
+
+    @Column
+    private Integer gamesPlayed;
+
+    @Column
+    private Integer totalGames;
+
+    @Column
+    private Integer wins;
+
+    @Column
+    private Integer draws;
+
+    @Column
+    private Integer losses;
+
+    @Column
+    private Double gamesBehind;
+
+    @Builder
+    public TeamRecord(TeamInfo.Team team, Integer rank, Integer gamesPlayed, Integer totalGames,
+                      Integer wins, Integer draws, Integer losses, Double gamesBehind) {
+
+        TeamInfo.getById(team.id);
+        this.id = team.id;
+        this.rank = rank;
+        this.gamesPlayed = gamesPlayed;
+        this.totalGames = totalGames;
+        this.wins = wins;
+        this.draws = draws;
+        this.losses = losses;
+        this.gamesBehind = gamesBehind;
+    }
+
+    // 팀 정보 조회
+    public TeamInfo.Team getTeamInfo() {
+        return TeamInfo.getById(this.id);
+    }
+
+    // 성적 정보 업데이트
+    public void updateRecord(Integer rank, Integer wins, Integer draws, Integer losses, Double gamesBehind) {
+        this.rank = rank;
+        this.wins = wins;
+        this.draws = draws;
+        this.losses = losses;
+        this.gamesBehind = gamesBehind;
+        this.gamesPlayed = wins + draws + losses;
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 팀 성적 엔티티 생성

## 💡 자세한 설명
1. 기존 상수인 TeamInfo에 매핑하여 팀 성적 엔티티 생성

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?