### PR TITLE
MATE-45 : [FIX] 경기 정보 엔티티와 팀 기록 엔티티 일부 수정

### DIFF
--- a/src/main/java/com/example/mate/domain/match/entity/Match.java
+++ b/src/main/java/com/example/mate/domain/match/entity/Match.java
@@ -2,15 +2,25 @@ package com.example.mate.domain.match.entity;
 
 import com.example.mate.domain.constant.StadiumInfo;
 import com.example.mate.domain.constant.TeamInfo;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
+@Table(name = "`match`") // 테이블 이름을 backtick(`)으로 감싸서 사용
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Match {

--- a/src/main/java/com/example/mate/domain/match/entity/TeamRecord.java
+++ b/src/main/java/com/example/mate/domain/match/entity/TeamRecord.java
@@ -18,7 +18,7 @@ public class TeamRecord {
     @Column(name = "team_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "`rank`", nullable = false)  // 예약어인 rank를 backtick(`)으로 감싸서 사용
     private Integer rank;
 
     @Column


### PR DESCRIPTION
## 💡 작업 내용

- [x] `Match` 테이블명 수정
- [x] `TeaRecord`의 필드 `rank`의 컬럼명 수정

## 💡 자세한 설명

#### 1. 현재 develop 브랜치의 코드가 컴파일되면서 테이블이 제대로 생성되지 않습니다.
> `Match`와 `TeamRecord` 클래스의 엔티티가 생성되면서 문제 발생.

#### 2. 경기 정보 엔티티의 테이블명과 팀 기록 엔티티의 순위 필드 컬럼명이 MySQL 예약어와 충돌하여 컴파일 에러 발생.
> 각각 백틱으로 감싸 테이블명과 컬럼명을 지정하여 해결.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?