### PR TITLE
MATE-24 : [FEAT] 메이트 게시글 작성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,20 +24,32 @@ repositories {
 }
 
 dependencies {
+	// Spring Boot Starters
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// Database
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
+
+	// Logging
+	implementation 'org.slf4j:slf4j-api'
+	implementation 'ch.qos.logback:logback-classic'
+
+	// API Documentation
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
+	// Test Dependencies
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
-	implementation 'org.slf4j:slf4j-api'
-	implementation 'ch.qos.logback:logback-classic'
+	testImplementation 'org.mockito:mockito-junit-jupiter'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testImplementation 'org.mockito:mockito-junit-jupiter'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -14,7 +14,33 @@ public enum ErrorCode {
 
     // Stadium
     STADIUM_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "S001", "해당 ID의 경기장 정보를 찾을 수 없습니다"),
-    STADIUM_NOT_FOUND_BY_NAME(HttpStatus.NOT_FOUND, "S002", "해당 이름의 경기장 정보를 찾을 수 없습니다");
+    STADIUM_NOT_FOUND_BY_NAME(HttpStatus.NOT_FOUND, "S002", "해당 이름의 경기장 정보를 찾을 수 없습니다"),
+
+    // Match
+    MATCH_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "MATCH_001", "해당 ID의 경기 정보를 찾을 수 없습니다."),
+
+    // Member
+    MEMBER_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "MEMBER_001", "해당 ID의 사용자를 찾을 수 없습니다."),
+
+    // Mate Post
+    INVALID_MATE_POST_PARTICIPANTS(HttpStatus.BAD_REQUEST, "MP001", "모집 인원은 2명에서 10명 사이여야 합니다."),
+    INVALID_MATE_POST_STATUS_CHANGE(HttpStatus.BAD_REQUEST, "MP002", "직관 완료된 게시글은 상태를 변경할 수 없습니다."),
+    INVALID_MATE_POST_COMPLETION(HttpStatus.BAD_REQUEST, "MP003", "모집완료 상태에서만 직관 완료가 가능합니다."),
+    MATE_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "MP004", "해당 ID의 메이트 게시글을 찾을 수 없습니다."),
+    UNAUTHORIZED_MATE_POST_ACCESS(HttpStatus.FORBIDDEN, "MP005", "해당 메이트 게시글에 대한 권한이 없습니다."),
+
+    // File
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "FILE001", "이미지 파일만 업로드 가능합니다."),
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F003", "파일 업로드에 실패했습니다."),
+
+    // Age
+    INVALID_AGE_VALUE(HttpStatus.BAD_REQUEST, "AGE001", "유효하지 않은 나이 값입니다."),
+
+    // Gender
+    INVALID_GENDER_VALUE(HttpStatus.BAD_REQUEST, "GENDER001", "유효하지 않은 성별 값입니다."),
+
+    // TransportType
+    INVALID_TRANSPORT_TYPE_VALUE(HttpStatus.BAD_REQUEST, "TRANSPORT001", "유효하지 않은 교통 수단 값입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/mate/domain/constant/Gender.java
+++ b/src/main/java/com/example/mate/domain/constant/Gender.java
@@ -1,5 +1,9 @@
 package com.example.mate.domain.constant;
 
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 @Getter
@@ -8,9 +12,20 @@ public enum Gender {
     MALE("남자만"),
     FEMALE("여자만");
 
+    @JsonValue
     private final String value;
 
     Gender(String value) {
         this.value = value;
+    }
+
+    @JsonCreator
+    public static Gender from(String value) {
+        for (Gender gender : Gender.values()) {
+            if (gender.value.equals(value)) {
+                return gender;
+            }
+        }
+        throw new CustomException(ErrorCode.INVALID_GENDER_VALUE);
     }
 }

--- a/src/main/java/com/example/mate/domain/constant/TeamInfo.java
+++ b/src/main/java/com/example/mate/domain/constant/TeamInfo.java
@@ -2,9 +2,7 @@ package com.example.mate.domain.constant;
 
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 

--- a/src/main/java/com/example/mate/domain/constant/TeamInfo.java
+++ b/src/main/java/com/example/mate/domain/constant/TeamInfo.java
@@ -46,4 +46,8 @@ public final class TeamInfo {
                 .findFirst()
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
     }
+
+    public static Boolean existById(Long id) {
+        return TEAMS.stream().anyMatch(team -> team.id.equals(id));
+    }
 }

--- a/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
@@ -1,0 +1,7 @@
+package com.example.mate.domain.match.repository;
+
+import com.example.mate.domain.match.entity.Match;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchRepository extends JpaRepository<Match, Long> {
+}

--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -1,12 +1,19 @@
 package com.example.mate.domain.mate.controller;
 
-import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.common.response.ApiResponse;
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.mate.dto.request.*;
+import com.example.mate.domain.mate.dto.response.MatePostDetailResponse;
+import com.example.mate.domain.mate.dto.response.MatePostResponse;
+import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
+import com.example.mate.domain.mate.dto.response.MateReviewCreateResponse;
+import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.mate.entity.Status;
 import com.example.mate.domain.mate.entity.TransportType;
-import com.example.mate.common.response.PageResponse;
-import com.example.mate.domain.mate.dto.request.*;
-import com.example.mate.domain.mate.dto.response.*;
+import com.example.mate.domain.mate.service.MateService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -19,15 +26,19 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/mates")
 public class MateController {
 
+    private final MateService mateService;
+
     // 메이트 게시글 작성
     @PostMapping
-    public ResponseEntity<MatePostResponse> createMatePost(@AuthenticationPrincipal UserDetails userDetails,
-                                                                 @RequestPart("data") MatePostCreateRequest request,
-                                                                 @RequestPart("file") MultipartFile file) {
-        return ResponseEntity.ok(MatePostResponse.builder().id(1L).build());
+    public ResponseEntity<ApiResponse<MatePostResponse>> createMatePost(@Valid @RequestPart(value = "data") MatePostCreateRequest request,
+                                                                       @RequestPart(value = "file", required = false) MultipartFile file) {
+        //TODO - member 정보를 request가 아니라  @AuthenticationPrincipal Long memberId로 받도록 변경
+        MatePostResponse response = mateService.createMatePost(request, file);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 메이트 게시글 목록 조회(메인 페이지)

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MatePostCreateRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MatePostCreateRequest.java
@@ -20,7 +20,9 @@ import org.hibernate.validator.constraints.Length;
 public class MatePostCreateRequest {
     private Long memberId;
 
-    @NotNull(message = "팀 ID는 필수입니다.")
+    @NotNull(message = "팀 ID는 필수 입력 값입니다.")
+    @Min(value = 0, message = "팀 ID는 0 이상이어야 합니다.")
+    @Max(value = 10, message = "팀 ID는 10 이하이어야 합니다.")
     private Long teamId;
 
     @NotNull(message = "경기 ID는 필수입니다.")

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MatePostCreateRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MatePostCreateRequest.java
@@ -1,18 +1,50 @@
 package com.example.mate.domain.mate.dto.request;
 
-import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.mate.entity.TransportType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MatePostCreateRequest {
+    private Long memberId;
+
+    @NotNull(message = "팀 ID는 필수입니다.")
     private Long teamId;
+
+    @NotNull(message = "경기 ID는 필수입니다.")
     private Long matchId;
+
+    @NotBlank(message = "제목은 필수입니다.")
+    @Length(min = 1, max = 20, message = "제목은 1자 이상 20자 이하여야 합니다.")
     private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    @Length(min = 1, max = 500, message = "내용은 1자 이상 500자 이하여야 합니다.")
     private String content;
+
+    @NotNull(message = "연령대는 필수입니다.")
     private Age age;
+
+    @NotNull(message = "최대 참여 인원은 필수입니다.")
+    @Min(value = 2, message = "최대 참여 인원은 2명 이상이어야 합니다.")
+    @Max(value = 10, message = "최대 참여 인원은 10명 이하여야 합니다.")
     private Integer maxParticipants;
+
+    @NotNull(message = "성별은 필수입니다.")
     private Gender gender;
+
+    @NotNull(message = "이동 수단은 필수입니다.")
     private TransportType transportType;
 }

--- a/src/main/java/com/example/mate/domain/mate/entity/Age.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/Age.java
@@ -1,5 +1,9 @@
 package com.example.mate.domain.mate.entity;
 
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 @Getter
@@ -11,9 +15,19 @@ public enum Age {
     FORTIES("40대"),
     OVER_FIFTIES("50대이상");
 
+    @JsonValue
     private final String value;
 
     Age(String value) {
         this.value = value;
+    }
+
+    @JsonCreator
+    public static Age from(String value) {
+        for (Age age : Age.values()) {
+            if (age.value.equals(value))
+                return age;
+        }
+        throw new CustomException(ErrorCode.INVALID_AGE_VALUE);
     }
 }

--- a/src/main/java/com/example/mate/domain/mate/entity/MatePost.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/MatePost.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.mate.entity;
 
+import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.constant.Gender;
@@ -24,9 +25,8 @@ public class MatePost {
     @JoinColumn(name = "author_id", nullable = false)
     private Member author;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "team_id", nullable = false)
-//    private Team team;
+    @Column(name = "team_id", nullable = false)
+    private Long teamId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "match_id", nullable = false)
@@ -67,10 +67,15 @@ public class MatePost {
     @OneToOne(mappedBy = "post", cascade = CascadeType.ALL)
     private Visit visit;
 
+    // Team 정보 조회
+    public TeamInfo.Team getTeam() {
+        return TeamInfo.getById(this.teamId);
+    }
+
     // 게시글 전체 정보 수정
     public void updatePost(
-//            Team team,
-//            Match match,
+            Long teamId,
+            Match match,
             String imageUrl,
             String title,
             String content,
@@ -79,8 +84,8 @@ public class MatePost {
             Gender gender,
             TransportType transport
     ) {
-//        this.team = team;
-//        this.match = match;
+        this.teamId = teamId;
+        this.match = match;
         this.imageUrl = imageUrl;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/example/mate/domain/mate/entity/TransportType.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/TransportType.java
@@ -1,5 +1,9 @@
 package com.example.mate.domain.mate.entity;
 
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 @Getter
@@ -9,9 +13,20 @@ public enum TransportType {
     CAR("자차"),
     CARPOOL("카풀");
 
+    @JsonValue
     private final String value;
 
     TransportType(String value) {
         this.value = value;
+    }
+
+    @JsonCreator
+    public static TransportType from(String value) {
+        for (TransportType type : TransportType.values()) {
+            if (type.getValue().equals(value)) {
+                return type;
+            }
+        }
+        throw new CustomException(ErrorCode.INVALID_TRANSPORT_TYPE_VALUE);
     }
 }

--- a/src/main/java/com/example/mate/domain/mate/entity/Visit.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/Visit.java
@@ -24,9 +24,11 @@ public class Visit {
     private MatePost post;
 
     @OneToMany(mappedBy = "visit")
+    @Builder.Default
     private List<VisitPart> participants = new ArrayList<>();
 
     @OneToMany(mappedBy = "visit")
+    @Builder.Default
     private List<MateReview> reviews = new ArrayList<>();
 
     // 참여자 추가

--- a/src/main/java/com/example/mate/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateRepository.java
@@ -1,0 +1,9 @@
+package com.example.mate.domain.mate.repository;
+
+import com.example.mate.domain.mate.entity.MatePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MateRepository extends JpaRepository<MatePost, Long> {
+}

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -1,6 +1,7 @@
 package com.example.mate.domain.mate.service;
 
 import com.example.mate.common.error.CustomException;
+import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
 import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
@@ -15,8 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import static com.example.mate.common.error.ErrorCode.MATCH_NOT_FOUND_BY_ID;
-import static com.example.mate.common.error.ErrorCode.MEMBER_NOT_FOUND_BY_ID;
+import static com.example.mate.common.error.ErrorCode.*;
 
 @Service
 @Transactional
@@ -34,6 +34,10 @@ public class MateService {
 
         Match match = matchRepository.findById(request.getMatchId())
                 .orElseThrow(() -> new CustomException(MATCH_NOT_FOUND_BY_ID));
+
+        if (!TeamInfo.existById(request.getTeamId())) {
+            throw new CustomException(TEAM_NOT_FOUND);
+        }
 
         MatePost matePost = MatePost.builder()
                 .author(author)

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -1,0 +1,58 @@
+package com.example.mate.domain.mate.service;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.match.repository.MatchRepository;
+import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
+import com.example.mate.domain.mate.dto.response.MatePostResponse;
+import com.example.mate.domain.mate.entity.MatePost;
+import com.example.mate.domain.mate.entity.Status;
+import com.example.mate.domain.mate.repository.MateRepository;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.example.mate.common.error.ErrorCode.MATCH_NOT_FOUND_BY_ID;
+import static com.example.mate.common.error.ErrorCode.MEMBER_NOT_FOUND_BY_ID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MateService {
+
+    private final MateRepository mateRepository;
+    private final MatchRepository matchRepository;
+    private final MemberRepository memberRepository;
+
+    public MatePostResponse createMatePost(MatePostCreateRequest request, MultipartFile file) {
+        Member author = memberRepository.findById(request.getMemberId())
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND_BY_ID));
+
+
+        Match match = matchRepository.findById(request.getMatchId())
+                .orElseThrow(() -> new CustomException(MATCH_NOT_FOUND_BY_ID));
+
+        MatePost matePost = MatePost.builder()
+                .author(author)
+                .teamId(request.getTeamId())
+                .match(match)
+                .imageUrl(null) //TODO - image 서비스 배포 후 구현
+                .title(request.getTitle())
+                .content(request.getContent())
+                .status(Status.OPEN)
+                .maxParticipants(request.getMaxParticipants())
+                .age(request.getAge())
+                .gender(request.getGender())
+                .transport(request.getTransportType())
+                .build();
+        MatePost savedPost = mateRepository.save(matePost);
+
+        return MatePostResponse.builder()
+                .id(savedPost.getId())
+                .status(savedPost.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/example/mate/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/mate/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.example.mate.domain.member.repository;
+
+import com.example.mate.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
+++ b/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
@@ -1,0 +1,127 @@
+package com.example.mate.domain.mate.controller;
+
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
+import com.example.mate.domain.mate.dto.response.MatePostResponse;
+import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.domain.mate.entity.Status;
+import com.example.mate.domain.mate.entity.TransportType;
+import com.example.mate.domain.mate.service.MateService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MateController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MateService mateService;
+
+    private MatePostCreateRequest createMatePostRequest() {
+        return MatePostCreateRequest.builder()
+                .memberId(1L)
+                .teamId(1L)
+                .matchId(1L)
+                .title("테스트 제목")
+                .content("테스트 내용")
+                .age(Age.TWENTIES)
+                .maxParticipants(4)
+                .gender(Gender.FEMALE)
+                .transportType(TransportType.PUBLIC)
+                .build();
+    }
+
+    private MatePostResponse createMatePostResponse() {
+        return MatePostResponse.builder()
+                .id(1L)
+                .status(Status.OPEN)
+                .build();
+    }
+
+    @Test
+    @DisplayName("메이트 게시글 작성 성공")
+    void createMatePost_success() throws Exception {
+        // given
+        MatePostCreateRequest request = createMatePostRequest();
+        MatePostResponse response = createMatePostResponse();
+
+        MockMultipartFile data = new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "test image content".getBytes()
+        );
+
+        given(mateService.createMatePost(any(MatePostCreateRequest.class), any()))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(multipart("/api/mates")
+                        .file(file)
+                        .file(data))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.status").value("OPEN"))
+                .andExpect(jsonPath("$.code").value(200));
+    }
+
+    @Test
+    @DisplayName("메이트 게시글 작성 성공 - 이미지 없음")
+    void createMatePost_successWithoutImage() throws Exception {
+        // given
+        MatePostCreateRequest request = createMatePostRequest();
+        MatePostResponse response = createMatePostResponse();
+
+        MockMultipartFile data = new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+
+        given(mateService.createMatePost(any(MatePostCreateRequest.class), any()))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(multipart("/api/mates")
+                        .file(data))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.status").value("OPEN"))
+                .andExpect(jsonPath("$.code").value(200));
+    }
+}

--- a/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
@@ -1,0 +1,228 @@
+package com.example.mate.domain.mate.integration;
+
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.match.repository.MatchRepository;
+import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
+import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.domain.mate.entity.MatePost;
+import com.example.mate.domain.mate.entity.Status;
+import com.example.mate.domain.mate.entity.TransportType;
+import com.example.mate.domain.mate.repository.MateRepository;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class MateIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MatchRepository matchRepository;
+
+    @Autowired
+    private MateRepository mateRepository;
+
+    private Member testMember;
+    private Match testMatch;
+
+    @BeforeEach
+    void setUp() {
+        mateRepository.deleteAll();
+        matchRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        testMember = memberRepository.save(Member.builder()
+                .name("테스트유저")
+                .email("test@test.com")
+                .nickname("테스트계정")
+                .imageUrl("test.jpg")
+                .gender(Gender.FEMALE)
+                .age(25)
+                .manner(0.3f)
+                .build());
+
+        testMatch = matchRepository.save(Match.builder()
+                .homeTeamId(1L)
+                .awayTeamId(2L)
+                .stadiumId(1L)
+                .status(SCHEDULED)
+                .matchTime(LocalDateTime.now().plusDays(1))
+                .build());
+    }
+
+    private void assertMatePostEquals(MatePost actual, MatePostCreateRequest expected) {
+        assertThat(actual.getAuthor()).isEqualTo(testMember);
+        assertThat(actual.getTeamId()).isEqualTo(expected.getTeamId());
+        assertThat(actual.getMatch()).isEqualTo(testMatch);
+        assertThat(actual.getTitle()).isEqualTo(expected.getTitle());
+        assertThat(actual.getContent()).isEqualTo(expected.getContent());
+        assertThat(actual.getStatus()).isEqualTo(Status.OPEN);
+        assertThat(actual.getMaxParticipants()).isEqualTo(expected.getMaxParticipants());
+        assertThat(actual.getAge()).isEqualTo(expected.getAge());
+        assertThat(actual.getGender()).isEqualTo(expected.getGender());
+        assertThat(actual.getTransport()).isEqualTo(expected.getTransportType());
+    }
+
+    private void performErrorTest(MockMultipartFile data, String errorCode, int expectedStatus) throws Exception {
+        mockMvc.perform(multipart("/api/mates")
+                        .file(data))
+                .andExpect(status().is(expectedStatus))
+                .andExpect(jsonPath("$.status").value("ERROR"))
+                .andExpect(jsonPath("$.code").value(expectedStatus))
+                .andExpect(jsonPath("$.message").exists())
+                .andDo(print());
+
+        assertThat(mateRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("메이트 게시글 작성 성공")
+    void createMatePost_Success() throws Exception {
+        // given
+        MatePostCreateRequest request = MatePostCreateRequest.builder()
+                .memberId(testMember.getId())
+                .teamId(1L)
+                .matchId(testMatch.getId())
+                .title("통합 테스트 제목")
+                .content("통합 테스트 내용")
+                .age(Age.TWENTIES)
+                .maxParticipants(4)
+                .gender(Gender.FEMALE)
+                .transportType(TransportType.PUBLIC)
+                .build();
+
+        MockMultipartFile data = new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+
+        // when & then
+        mockMvc.perform(multipart("/api/mates")
+                        .file(data))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.status").value("OPEN"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andDo(print());
+
+        // DB 검증
+        List<MatePost> savedPosts = mateRepository.findAll();
+        assertThat(savedPosts).hasSize(1);
+        assertMatePostEquals(savedPosts.get(0), request);
+    }
+
+
+    @Test
+    @DisplayName("존재하지 않는 회원으로 메이트 게시글 작성 시 실패")
+    void createMatePost_WithInvalidMember() throws Exception {
+        // given
+        MatePostCreateRequest request = MatePostCreateRequest.builder()
+                .memberId(999L) // 존재하지 않는 회원 ID
+                .teamId(1L)
+                .matchId(testMatch.getId())
+                .title("통합 테스트 제목")
+                .content("통합 테스트 내용")
+                .age(Age.TWENTIES)
+                .maxParticipants(4)
+                .gender(Gender.FEMALE)
+                .transportType(TransportType.PUBLIC)
+                .build();
+
+        MockMultipartFile data = new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+
+        // when & then
+        performErrorTest(data, "MEMBER_NOT_FOUND_BY_ID", 404);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 경기로 메이트 게시글 작성 시 실패")
+    void createMatePost_WithInvalidMatch() throws Exception {
+        // given
+        MatePostCreateRequest request = MatePostCreateRequest.builder()
+                .memberId(testMember.getId())
+                .teamId(1L)
+                .matchId(999L) // 존재하지 않는 경기 ID
+                .title("통합 테스트 제목")
+                .content("통합 테스트 내용")
+                .age(Age.TWENTIES)
+                .maxParticipants(4)
+                .gender(Gender.FEMALE)
+                .transportType(TransportType.PUBLIC)
+                .build();
+
+        MockMultipartFile data = new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+
+        // when & then
+        performErrorTest(data, "MATCH_NOT_FOUND_BY_ID", 404);
+    }
+
+    @Test
+    @DisplayName("잘못된 요청 데이터로 메이트 게시글 작성 시 실패")
+    void createMatePost_WithInvalidRequest() throws Exception {
+        // given
+        MatePostCreateRequest request = MatePostCreateRequest.builder()
+                .memberId(testMember.getId())
+                .teamId(1L)
+                .matchId(testMatch.getId())
+                .title("") // 빈 제목
+                .content("통합 테스트 내용")
+                .age(Age.TWENTIES)
+                .maxParticipants(11) // 최대 인원 초과
+                .gender(null)
+                .transportType(TransportType.PUBLIC)
+                .build();
+
+        MockMultipartFile data = new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+
+        // when & then
+        performErrorTest(data, "INVALID_REQUEST", 500);
+    }
+}

--- a/src/test/java/com/example/mate/domain/mate/service/MateServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateServiceTest.java
@@ -1,0 +1,164 @@
+package com.example.mate.domain.mate.service;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.match.repository.MatchRepository;
+import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
+import com.example.mate.domain.mate.dto.response.MatePostResponse;
+import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.domain.mate.entity.MatePost;
+import com.example.mate.domain.mate.entity.Status;
+import com.example.mate.domain.mate.entity.TransportType;
+import com.example.mate.domain.mate.repository.MateRepository;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.example.mate.common.error.ErrorCode.MATCH_NOT_FOUND_BY_ID;
+import static com.example.mate.common.error.ErrorCode.MEMBER_NOT_FOUND_BY_ID;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MateServiceTest {
+
+    @InjectMocks
+    private MateService mateService;
+
+    @Mock
+    private MateRepository mateRepository;
+    @Mock
+    private MatchRepository matchRepository;
+    @Mock
+    private MemberRepository memberRepository;
+
+    private static final Long TEST_MEMBER_ID = 1L;
+    private static final Long TEST_MATCH_ID = 1L;
+
+    private Member createTestMember() {
+        return Member.builder()
+                .name("테스트유저")
+                .email("test@test.com")
+                .nickname("테스트계정")
+                .build();
+    }
+
+    private Match createTestMatch() {
+        return Match.builder()
+                .homeTeamId(1L)
+                .awayTeamId(2L)
+                .stadiumId(1L)
+                .matchTime(LocalDateTime.now().plusDays(1))
+                .build();
+    }
+
+    private MatePostCreateRequest createTestRequest() {
+        return MatePostCreateRequest.builder()
+                .memberId(TEST_MEMBER_ID)
+                .teamId(TEST_MATCH_ID)
+                .matchId(1L)
+                .title("테스트 제목")
+                .content("테스트 내용")
+                .age(Age.TWENTIES)
+                .maxParticipants(4)
+                .gender(Gender.FEMALE)
+                .transportType(TransportType.PUBLIC)
+                .build();
+    }
+
+    private MatePost createTestMatePost(Member author, Match match) {
+        return MatePost.builder()
+                .id(1L)
+                .author(author)
+                .teamId(1L)
+                .match(match)
+                .title("테스트 제목")
+                .content("테스트 내용")
+                .status(Status.OPEN)
+                .maxParticipants(4)
+                .age(Age.TWENTIES)
+                .gender(Gender.FEMALE)
+                .transport(TransportType.PUBLIC)
+                .build();
+    }
+
+    @Test
+    @DisplayName("메이트 게시글 작성 성공")
+    void createMatePost_Success() {
+        // given
+        Member testMember = createTestMember();
+        Match testMatch = createTestMatch();
+        MatePostCreateRequest request = createTestRequest();
+        MatePost matePost = createTestMatePost(testMember, testMatch);
+
+        given(memberRepository.findById(request.getMemberId()))
+                .willReturn(Optional.of(testMember));
+        given(matchRepository.findById(request.getMatchId()))
+                .willReturn(Optional.of(testMatch));
+        given(mateRepository.save(any(MatePost.class)))
+                .willReturn(matePost);
+
+        // when
+        MatePostResponse response = mateService.createMatePost(request, null);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(Status.OPEN);
+
+        verify(memberRepository).findById(TEST_MEMBER_ID);
+        verify(matchRepository).findById(TEST_MATCH_ID);
+        verify(mateRepository).save(any(MatePost.class));
+    }
+
+    @Test
+    @DisplayName("메이트 게시글 작성 실패 - 존재하지 않는 회원")
+    void createMatePost_FailWithInvalidMember() {
+        // given
+        MatePostCreateRequest request = createTestRequest();
+        given(memberRepository.findById(request.getMemberId()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> mateService.createMatePost(request, null));
+        assertThat(exception.getErrorCode()).isEqualTo(MEMBER_NOT_FOUND_BY_ID);
+
+        verify(memberRepository).findById(TEST_MEMBER_ID);
+        verify(matchRepository, never()).findById(any());
+        verify(mateRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("메이트 게시글 작성 실패 - 존재하지 않는 경기")
+    void createMatePost_FailWithInvalidMatch() {
+        // given
+        Member testMember = createTestMember();
+        MatePostCreateRequest request = createTestRequest();
+
+        given(memberRepository.findById(request.getMemberId()))
+                .willReturn(Optional.of(testMember));
+        given(matchRepository.findById(request.getMatchId()))
+                .willReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> mateService.createMatePost(request, null));
+        assertThat(exception.getErrorCode()).isEqualTo(MATCH_NOT_FOUND_BY_ID);
+
+        verify(memberRepository).findById(TEST_MEMBER_ID);
+        verify(matchRepository).findById(TEST_MATCH_ID);
+        verify(mateRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 메이트 게시글 작성 기능 구현
- [x] 단위 테스트. 통합 테스트 구현

## 💡 자세한 설명
### 메이트 게시글 작성 기능 구현

- **MateController**: 메이트 게시글 작성 API 엔드포인트 추가
  - `POST /api/mates`: 메이트 게시글을 작성하는 기능을 구현하였습니다.
  - 요청 데이터는 `MatePostCreateRequest` 객체를 통해 전달되며, 파일 업로드를 위한 `MultipartFile`도 지원합니다.
  - `@AuthenticationPrincipal`을 사용하여 현재 로그인한 사용자의 정보를 기반으로 게시글 작성자를 설정할 예정입니다.

- **MateService**: 게시글 작성 로직 구현
  - `createMatePost` 메서드에서 요청을 처리하고, 게시글을 데이터베이스에 저장합니다.
  - 작성자는 `memberId`를 통해 조회되며, 해당 ID가 존재하지 않을 경우 예외를 발생시킵니다.
  - 경기 정보는 `matchId`를 통해 조회되며, 유효성 검사를 수행합니다.

### 요청 DTO: MatePostCreateRequest

- 게시글 작성에 필요한 정보를 담고 있는 DTO 클래스입니다.
- 각 필드에 대해 유효성 검사를 위한 어노테이션을 추가하였습니다.
  - `@NotNull`, `@NotBlank`, `@Length`, `@Min`, `@Max` 등을 사용하여 필수 입력값 및 값의 범위를 검증합니다.

### Enum 클래스

- **Age**, **TransportType**, **Gender**: 각각의 선택지를 나타내는 Enum 클래스입니다.
  - 각 Enum 클래스는 `@JsonValue` 어노테이션을 사용하여 JSON 직렬화 시 반환할 값을 정의합니다.
  - `@JsonCreator` 어노테이션을 통해 문자열 값을 기반으로 Enum 값을 생성하는 메서드를 제공합니다. 이를 통해 클라이언트에서 전달된 문자열을 Enum으로 변환할 수 있습니다.

### TODO
- 현재 `memberId`를 요청에서 받아오고 있으나, 추후 `@AuthenticationPrincipal`을 사용하여 현재 로그인한 사용자의 ID로 변경할 예정입니다.
- 이미지 업로드 기능은 별도의 이미지 서비스 배포 후 구현할 계획입니다.

## 📗 참고 자료 (선택)
- @WebMvcTest에서 @MockBean(JpaMetamodelMappingContext.class) 사용 이유: https://giron.tistory.com/127
- 트러블슈팅 기록: [테스트 코드의 Enum 직렬화 에러와 해결 과정](https://www.notion.so/prgrms/Enum-3994545d50ac45898a03d7e3eaf76f79)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?