### PR TITLE
MATE-53 : [FEAT] 상단 배너 경기 정보 조회 기능 구현

### DIFF
--- a/http/Match.http
+++ b/http/Match.http
@@ -2,47 +2,13 @@
 ####################
 
 ### 1. 전체 경기 조회 ###
-# 상단 배너용 기본 조회 (5개)
-# 현재 상태: 10개의 랜덤 경기 중 필터링하여 반환
-GET http://localhost:8000/api/matches
+### 메인 배너용 경기 조회 (5개) (상단 배너)
+GET http://localhost:8000/api/matches/main
 Content-Type: application/json
 
-# 팀별 예정 경기 필터링
-### KIA 예정 경기
-GET http://localhost:8000/api/matches?teamId=1&status=SCHEDULED&limit=3
+### 팀별 경기 조회 (3개) (상단 배너)
+GET http://localhost:8000/api/matches/team/1
 Content-Type: application/json
-
-### LG 예정 경기
-GET http://localhost:8000/api/matches?teamId=2&status=SCHEDULED
-Content-Type: application/json
-
-# 상태별 필터링
-### 취소된 경기 조회
-# 현재 상태: 모든 경기가 SCHEDULED 상태로 생성됨
-GET http://localhost:8000/api/matches?status=CANCELED
-Content-Type: application/json
-
-### 종료된 경기 조회
-# 현재 상태: 모든 경기가 SCHEDULED 상태로 생성됨
-GET http://localhost:8000/api/matches?status=COMPLETED
-Content-Type: application/json
-
-### 구인글 작성용 특정 팀 경기 조회
-# 메이트 구인글 작성 시 응원 팀 예정 경기 선택에 사용
-GET http://localhost:8000/api/matches?teamId=2&status=SCHEDULED
-Content-Type: application/json
-
-### 2. 팀 경기 결과 조회 ###
-### KIA 최근 경기 결과
-# 메인 페이지의 팀 최근 전적 표시용
-# 현재 상태: 2개의 경기 데이터 생성 (홈 승리 1개, 원정 무승부 1개)
-GET http://localhost:8000/api/matches/1/results
-Content-Type: application/json
-
 
 ### [Team API] ###
 #################
-
-### 1. 팀 순위 조회 ###
-GET http://localhost:8000/api/teams/rankings
-Content-Type: application/json

--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -14,7 +14,10 @@ public enum ErrorCode {
 
     // Stadium
     STADIUM_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "S001", "해당 ID의 경기장 정보를 찾을 수 없습니다"),
-    STADIUM_NOT_FOUND_BY_NAME(HttpStatus.NOT_FOUND, "S002", "해당 이름의 경기장 정보를 찾을 수 없습니다");
+    STADIUM_NOT_FOUND_BY_NAME(HttpStatus.NOT_FOUND, "S002", "해당 이름의 경기장 정보를 찾을 수 없습니다"),
+
+    // Match
+    MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 경기를 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/mate/domain/match/controller/MatchController.java
+++ b/src/main/java/com/example/mate/domain/match/controller/MatchController.java
@@ -1,0 +1,44 @@
+package com.example.mate.domain.match.controller;
+
+import com.example.mate.common.response.ApiResponse;
+import com.example.mate.domain.match.dto.response.MatchResponse;
+import com.example.mate.domain.match.entity.MatchStatus;
+import com.example.mate.domain.match.service.MatchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/matches")
+@Tag(name = "Match", description = "경기 관련 API")
+@RequiredArgsConstructor
+public class MatchController {
+    private final MatchService matchService;
+
+    @Operation(summary = "메인 배너 경기 조회")
+    @GetMapping("/main")
+    public ResponseEntity<ApiResponse<List<MatchResponse>>> getMainBannerMatches() {
+
+        List<MatchResponse> matches = matchService.getMainBannerMatches();
+        System.out.println(matches);
+        return ResponseEntity.ok(ApiResponse.success(matches));
+    }
+
+    //
+    @Operation(summary = "팀별 경기 조회")
+    @GetMapping("/team/{teamId}")
+    public ResponseEntity<ApiResponse<List<MatchResponse>>> getTeamMatches(
+            @Parameter(description = "팀 ID") @PathVariable Long teamId) {
+        return ResponseEntity.ok(ApiResponse.success(matchService.getTeamMatches(teamId)));
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/controller/TeamController.java
+++ b/src/main/java/com/example/mate/domain/match/controller/TeamController.java
@@ -19,58 +19,58 @@ import java.util.List;
 @RequestMapping("/api/teams")
 @RequiredArgsConstructor
 public class TeamController {
-    private static final int TOTAL_GAMES = 144;  // KBO 정규시즌 총 경기 수
-
-    @Operation(summary = "팀 순위 조회", description = "KBO 리그 전체 순위를 조회합니다.")
-    @GetMapping("/rankings")
-    public ResponseEntity<ApiResponse<List<TeamResponse.Detail>>> getTeamRankings() {
-        List<TeamResponse.Detail> rankings = Arrays.asList(
-                createTeamDetail(1L, "KIA 타이거즈", "광주-기아 챔피언스 필드", "광주광역시 북구", "126.8989", "35.1681",
-                        100, 90, 10, 0, 2.0),
-                createTeamDetail(2L, "LG 트윈스", "잠실야구장", "서울특별시 송파구", "127.0719", "37.5122",
-                        95, 85, 10, 0, 3.5),
-                createTeamDetail(3L, "NC 다이노스", "창원NC파크", "창원시 마산회원구", "128.5829", "35.2534",
-                        92, 82, 10, 0, 4.0),
-                createTeamDetail(4L, "SSG 랜더스", "인천SSG랜더스필드", "인천광역시 미추홀구", "126.6781", "37.4374",
-                        90, 78, 12, 0, 5.0),
-                createTeamDetail(5L, "kt wiz", "수원 kt wiz 파크", "수원시 장안구", "127.0355", "37.2994",
-                        88, 75, 13, 0, 6.0),
-                createTeamDetail(6L, "두산 베어스", "잠실야구장", "서울특별시 송파구", "127.0719", "37.5122",
-                        86, 72, 14, 0, 7.0),
-                createTeamDetail(7L, "롯데 자이언츠", "사직야구장", "부산광역시 동래구", "129.0639", "35.1947",
-                        84, 68, 16, 0, 8.0),
-                createTeamDetail(8L, "삼성 라이온즈", "대구삼성라이온즈파크", "대구광역시 수성구", "128.6814", "35.8409",
-                        82, 65, 17, 0, 9.0),
-                createTeamDetail(9L, "키움 히어로즈", "고척스카이돔", "서울특별시 구로구", "126.8669", "37.4982",
-                        80, 62, 18, 0, 10.0),
-                createTeamDetail(10L, "한화 이글스", "한화생명이글스파크", "대전광역시 중구", "127.4294", "36.3172",
-                        78, 58, 20, 0, 11.0)
-        );
-
-        return ResponseEntity.ok(ApiResponse.success(rankings));
-    }
-
-    private TeamResponse.Detail createTeamDetail(Long id, String teamName,
-                                                 String stadiumName, String location, String longitude, String latitude,
-                                                 int gamesPlayed, int wins, int draws, int losses, double gamesBehind) {
-        return TeamResponse.Detail.builder()
-                .id(id)
-                .teamName(teamName)
-                .logoImageUrl(String.format("http://example.com/teams/%d/logo.png", id))
-                .stadium(StadiumResponse.Info.builder()
-                        .id(id)
-                        .stadiumName(stadiumName)
-                        .location(location)
-                        .longitude(longitude)
-                        .latitude(latitude)
-                        .build())
-                .rank(id.intValue())
-                .gamesPlayed(gamesPlayed)
-                .totalGames(TOTAL_GAMES)
-                .wins(wins)
-                .draws(draws)
-                .losses(losses)
-                .gamesBehind(gamesBehind)
-                .build();
-    }
+//    private static final int TOTAL_GAMES = 144;  // KBO 정규시즌 총 경기 수
+//
+//    @Operation(summary = "팀 순위 조회", description = "KBO 리그 전체 순위를 조회합니다.")
+//    @GetMapping("/rankings")
+//    public ResponseEntity<ApiResponse<List<TeamResponse.Detail>>> getTeamRankings() {
+//        List<TeamResponse.Detail> rankings = Arrays.asList(
+//                createTeamDetail(1L, "KIA 타이거즈", "광주-기아 챔피언스 필드", "광주광역시 북구", "126.8989", "35.1681",
+//                        100, 90, 10, 0, 2.0),
+//                createTeamDetail(2L, "LG 트윈스", "잠실야구장", "서울특별시 송파구", "127.0719", "37.5122",
+//                        95, 85, 10, 0, 3.5),
+//                createTeamDetail(3L, "NC 다이노스", "창원NC파크", "창원시 마산회원구", "128.5829", "35.2534",
+//                        92, 82, 10, 0, 4.0),
+//                createTeamDetail(4L, "SSG 랜더스", "인천SSG랜더스필드", "인천광역시 미추홀구", "126.6781", "37.4374",
+//                        90, 78, 12, 0, 5.0),
+//                createTeamDetail(5L, "kt wiz", "수원 kt wiz 파크", "수원시 장안구", "127.0355", "37.2994",
+//                        88, 75, 13, 0, 6.0),
+//                createTeamDetail(6L, "두산 베어스", "잠실야구장", "서울특별시 송파구", "127.0719", "37.5122",
+//                        86, 72, 14, 0, 7.0),
+//                createTeamDetail(7L, "롯데 자이언츠", "사직야구장", "부산광역시 동래구", "129.0639", "35.1947",
+//                        84, 68, 16, 0, 8.0),
+//                createTeamDetail(8L, "삼성 라이온즈", "대구삼성라이온즈파크", "대구광역시 수성구", "128.6814", "35.8409",
+//                        82, 65, 17, 0, 9.0),
+//                createTeamDetail(9L, "키움 히어로즈", "고척스카이돔", "서울특별시 구로구", "126.8669", "37.4982",
+//                        80, 62, 18, 0, 10.0),
+//                createTeamDetail(10L, "한화 이글스", "한화생명이글스파크", "대전광역시 중구", "127.4294", "36.3172",
+//                        78, 58, 20, 0, 11.0)
+//        );
+//
+//        return ResponseEntity.ok(ApiResponse.success(rankings));
+//    }
+//
+//    private TeamResponse.Detail createTeamDetail(Long id, String teamName,
+//                                                 String stadiumName, String location, String longitude, String latitude,
+//                                                 int gamesPlayed, int wins, int draws, int losses, double gamesBehind) {
+//        return TeamResponse.Detail.builder()
+//                .id(id)
+//                .teamName(teamName)
+//                .logoImageUrl(String.format("http://example.com/teams/%d/logo.png", id))
+//                .stadium(StadiumResponse.Info.builder()
+//                        .id(id)
+//                        .stadiumName(stadiumName)
+//                        .location(location)
+//                        .longitude(longitude)
+//                        .latitude(latitude)
+//                        .build())
+//                .rank(id.intValue())
+//                .gamesPlayed(gamesPlayed)
+//                .totalGames(TOTAL_GAMES)
+//                .wins(wins)
+//                .draws(draws)
+//                .losses(losses)
+//                .gamesBehind(gamesBehind)
+//                .build();
+//    }
 }

--- a/src/main/java/com/example/mate/domain/match/dto/response/StadiumResponse.java
+++ b/src/main/java/com/example/mate/domain/match/dto/response/StadiumResponse.java
@@ -1,19 +1,36 @@
 package com.example.mate.domain.match.dto.response;
 
+import com.example.mate.domain.constant.StadiumInfo;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StadiumResponse {
     @Getter
-    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Info {
         private Long id;
         private String stadiumName;
         private String location;
         private String longitude;
         private String latitude;
+
+        @Builder
+        private Info(StadiumInfo.Stadium stadium) {
+            this.id = stadium.id;
+            this.stadiumName = stadium.name;
+            this.location = stadium.location;
+            this.longitude = stadium.longitude;
+            this.latitude = stadium.latitude;
+        }
+
+        public static Info from(StadiumInfo.Stadium stadium) {
+            return Info.builder()
+                    .stadium(stadium)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/example/mate/domain/match/dto/response/TeamResponse.java
+++ b/src/main/java/com/example/mate/domain/match/dto/response/TeamResponse.java
@@ -1,26 +1,39 @@
 package com.example.mate.domain.match.dto.response;
 
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.entity.TeamRecord;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamResponse {
     @Getter
-    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Simple {
         private Long id;
         private String teamName;
-        private String logoImageUrl;
+
+        @Builder
+        public Simple(TeamInfo.Team team) {
+            this.id = team.id;
+            this.teamName = team.fullName;
+        }
+
+        public static Simple from(TeamInfo.Team team) {
+            return Simple.builder()
+                    .team(team)
+                    .build();
+        }
     }
 
     @Getter
-    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Detail {
         private Long id;
         private String teamName;
-        private String logoImageUrl;
         private StadiumResponse.Info stadium;
         private Integer rank;
         private Integer gamesPlayed;
@@ -29,5 +42,26 @@ public class TeamResponse {
         private Integer draws;
         private Integer losses;
         private Double gamesBehind;
+
+        @Builder
+        public Detail(TeamInfo.Team team, TeamRecord record) {
+            this.id = team.id;
+            this.teamName = team.fullName;
+            this.stadium = StadiumResponse.Info.from(team.homeStadium);
+            this.rank = record.getRank();
+            this.gamesPlayed = record.getGamesPlayed();
+            this.totalGames = record.getTotalGames();
+            this.wins = record.getWins();
+            this.draws = record.getDraws();
+            this.losses = record.getLosses();
+            this.gamesBehind = record.getGamesBehind();
+        }
+
+        public static Detail from(TeamInfo.Team team, TeamRecord record) {
+            return Detail.builder()
+                    .team(team)
+                    .record(record)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/example/mate/domain/match/dto/response/WeatherResponse.java
+++ b/src/main/java/com/example/mate/domain/match/dto/response/WeatherResponse.java
@@ -1,6 +1,8 @@
 package com.example.mate.domain.match.dto.response;
 
+import com.example.mate.domain.match.entity.Weather;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,19 +10,27 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeatherResponse {
     @Getter
-    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Info {
         private Float temperature;
         private Float pop;
         private Integer cloudiness;
         private LocalDateTime wtTime;
 
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-        public LocalDateTime getWtTime() {
-            return wtTime;
+        @Builder
+        private Info(Weather weather) {
+            this.temperature = weather.getTemperature();
+            this.pop = weather.getPop();
+            this.cloudiness = weather.getCloudiness();
+            this.wtTime = weather.getWtTime();
+        }
+
+        public static Info from(Weather weather) {
+            if (weather == null) return null;
+            return new Info(weather);
         }
     }
 }

--- a/src/main/java/com/example/mate/domain/match/entity/Match.java
+++ b/src/main/java/com/example/mate/domain/match/entity/Match.java
@@ -54,9 +54,10 @@ public class Match {
     private Weather weather;
 
     @Builder
-    public Match(Long homeTeamId, Long awayTeamId, Long stadiumId,
+    public Match(Long id, Long homeTeamId, Long awayTeamId, Long stadiumId,
                  LocalDateTime matchTime, Boolean isCanceled,
                  MatchStatus status) {
+        this.id = id;
         this.homeTeamId = homeTeamId;
         this.awayTeamId = awayTeamId;
         this.stadiumId = stadiumId;

--- a/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
@@ -1,0 +1,16 @@
+package com.example.mate.domain.match.repository;
+
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.match.entity.MatchStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MatchRepository extends JpaRepository<Match, Long> {
+    List<Match> findTop5ByOrderByMatchTimeDesc();
+    List<Match> findTop3ByHomeTeamIdOrAwayTeamIdOrderByMatchTimeDesc(Long homeTeamId, Long awayTeamId);
+}

--- a/src/main/java/com/example/mate/domain/match/service/MatchService.java
+++ b/src/main/java/com/example/mate/domain/match/service/MatchService.java
@@ -1,0 +1,38 @@
+package com.example.mate.domain.match.service;
+
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.dto.response.MatchResponse;
+import com.example.mate.domain.match.entity.MatchStatus;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.match.repository.MatchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MatchService {
+    private final MatchRepository matchRepository;
+
+    public List<MatchResponse> getMainBannerMatches() {
+        return matchRepository.findTop5ByOrderByMatchTimeDesc().stream()
+                .filter(match -> match.getMatchTime().isAfter(LocalDateTime.now()))
+                .map(match -> MatchResponse.from(match, null))  // 메인 배너는 특정 팀 시점이 없으므로 null
+                .collect(Collectors.toList());
+    }
+
+
+    public List<MatchResponse> getTeamMatches(Long teamId) {
+        TeamInfo.getById(teamId);  // 팀 존재 여부 확인
+
+        return matchRepository.findTop3ByHomeTeamIdOrAwayTeamIdOrderByMatchTimeDesc(teamId, teamId).stream()
+                .filter(match -> match.getMatchTime().isAfter(LocalDateTime.now()))
+                .map(match -> MatchResponse.from(match, teamId))  // 조회하는 팀 ID 전달
+                .collect(Collectors.toList());
+    }
+}
+

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -6,4 +6,3 @@ springdoc:
   packages-to-scan: com.example.mate
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
-

--- a/src/test/java/com/example/mate/domain/match/controller/MatchControllerTest.java
+++ b/src/test/java/com/example/mate/domain/match/controller/MatchControllerTest.java
@@ -1,0 +1,149 @@
+package com.example.mate.domain.match.controller;
+
+
+import com.example.mate.domain.constant.StadiumInfo;
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.dto.response.MatchResponse;
+
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.match.entity.MatchStatus;
+import com.example.mate.domain.match.service.MatchService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(MatchController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MatchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MatchService matchService;
+
+    @Test
+    @DisplayName("메인 배너 경기 조회 API 테스트")
+    void getMainBannerMatches() throws Exception {
+        // Given
+        List<MatchResponse> mockResponses = List.of(
+                MatchResponse.from(Match.builder()
+                        .homeTeamId(TeamInfo.KIA.id)
+                        .awayTeamId(TeamInfo.LG.id)
+                        .stadiumId(StadiumInfo.GWANGJU.id)
+                        .matchTime(LocalDateTime.now().plusDays(1))
+                        .isCanceled(false)
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                        null),
+                MatchResponse.from(Match.builder()
+                        .homeTeamId(TeamInfo.NC.id)
+                        .awayTeamId(TeamInfo.SSG.id)
+                        .stadiumId(StadiumInfo.CHANGWON.id)
+                        .matchTime(LocalDateTime.now().plusDays(2))
+                        .isCanceled(false)
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                        null),
+                MatchResponse.from(Match.builder()
+                        .homeTeamId(TeamInfo.DOOSAN.id)
+                        .awayTeamId(TeamInfo.KT.id)
+                        .stadiumId(StadiumInfo.JAMSIL.id)
+                        .matchTime(LocalDateTime.now().plusDays(3))
+                        .isCanceled(false)
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                        null),
+                MatchResponse.from(Match.builder()
+                        .homeTeamId(TeamInfo.SAMSUNG.id)
+                        .awayTeamId(TeamInfo.LOTTE.id)
+                        .stadiumId(StadiumInfo.DAEGU.id)
+                        .matchTime(LocalDateTime.now().plusDays(4))
+                        .isCanceled(false)
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                        null),
+                MatchResponse.from(Match.builder()
+                        .homeTeamId(TeamInfo.HANWHA.id)
+                        .awayTeamId(TeamInfo.KIWOOM.id)
+                        .stadiumId(StadiumInfo.DAEJEON.id)
+                        .matchTime(LocalDateTime.now().plusDays(5))
+                        .isCanceled(false)
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                        null)
+        );
+        when(matchService.getMainBannerMatches()).thenReturn(mockResponses);
+
+        // When & Then
+        mockMvc.perform(get("/api/matches/main")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data", hasSize(5)));
+    }
+
+    @Test
+    @DisplayName("팀별 경기 조회 API 테스트")
+    void getTeamMatches() throws Exception {
+        // Given
+        Long teamId = 1L;
+        List<MatchResponse> mockResponses = List.of(
+                MatchResponse.from(Match.builder()
+                        .homeTeamId(TeamInfo.KIA.id)
+                        .awayTeamId(TeamInfo.LG.id)
+                        .stadiumId(StadiumInfo.GWANGJU.id)
+                        .matchTime(LocalDateTime.now().plusDays(1))
+                        .isCanceled(false)
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                        null),
+                MatchResponse.from(Match.builder()
+                        .homeTeamId(TeamInfo.NC.id)
+                        .awayTeamId(TeamInfo.SSG.id)
+                        .stadiumId(StadiumInfo.CHANGWON.id)
+                        .matchTime(LocalDateTime.now().plusDays(2))
+                        .isCanceled(false)
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                        null),
+                MatchResponse.from(Match.builder()
+                        .homeTeamId(TeamInfo.DOOSAN.id)
+                        .awayTeamId(TeamInfo.KT.id)
+                        .stadiumId(StadiumInfo.JAMSIL.id)
+                        .matchTime(LocalDateTime.now().plusDays(3))
+                        .isCanceled(false)
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                        null)
+        );
+        when(matchService.getTeamMatches(teamId)).thenReturn(mockResponses);
+
+        // When & Then
+        mockMvc.perform(get("/api/matches/team/{teamId}", teamId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(3));
+    }
+}

--- a/src/test/java/com/example/mate/domain/match/integration/MatchIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/match/integration/MatchIntegrationTest.java
@@ -1,0 +1,121 @@
+package com.example.mate.domain.match.integration;
+
+import com.example.mate.domain.constant.StadiumInfo;
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.dto.request.MatchRequest;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.match.entity.MatchStatus;
+import com.example.mate.domain.match.repository.MatchRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class MatchIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MatchRepository matchRepository;
+
+    @BeforeEach
+    void setUp() {
+        matchRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("메인 배너 경기 조회 - 성공 (이후 경기만 조회)")
+    void getMainBannerMatches_Success() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime pastTime = now.minusDays(1);
+        LocalDateTime futureTime1 = now.plusDays(1);
+        LocalDateTime futureTime2 = now.plusDays(2);
+
+        Match pastMatch = createMatch(TeamInfo.KIA.id, TeamInfo.DOOSAN.id, StadiumInfo.GWANGJU.id, pastTime);
+        Match futureMatch1 = createMatch(TeamInfo.LG.id, TeamInfo.KT.id, StadiumInfo.JAMSIL.id, futureTime1);
+        Match futureMatch2 = createMatch(TeamInfo.SSG.id, TeamInfo.NC.id, StadiumInfo.INCHEON.id, futureTime2);
+        matchRepository.saveAll(Arrays.asList(pastMatch, futureMatch1, futureMatch2));
+
+        // when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/api/matches/main")
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("SUCCESS"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].homeTeam.id").value(TeamInfo.SSG.id))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].homeTeam.id").value(TeamInfo.LG.id));
+    }
+
+    @Test
+    @DisplayName("팀별 경기 조회 - 성공 (이후 경기만 조회)")
+    void getTeamMatches_Success() throws Exception {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime pastTime = now.minusDays(1);
+        LocalDateTime futureTime1 = now.plusDays(1);
+        LocalDateTime futureTime2 = now.plusDays(2);
+
+        Match pastMatch = createMatch(TeamInfo.LG.id, TeamInfo.KIA.id, StadiumInfo.JAMSIL.id, pastTime);
+        Match futureMatch1 = createMatch(TeamInfo.LG.id, TeamInfo.KT.id, StadiumInfo.JAMSIL.id, futureTime1);
+        Match futureMatch2 = createMatch(TeamInfo.LG.id, TeamInfo.NC.id, StadiumInfo.JAMSIL.id, futureTime2);
+        matchRepository.saveAll(Arrays.asList(pastMatch, futureMatch1, futureMatch2));
+
+        // when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/api/matches/team/{teamId}", TeamInfo.LG.id)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("SUCCESS"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].awayTeam.id").value(TeamInfo.NC.id))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].awayTeam.id").value(TeamInfo.KT.id));
+    }
+
+    @Test
+    @DisplayName("팀별 경기 조회 - 실패 (존재하지 않는 팀)")
+    void getTeamMatches_Fail_TeamNotFound() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/api/matches/team/{teamId}", 999L)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("ERROR"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("팀을 찾을 수 없습니다"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(404));
+    }
+
+    private Match createMatch(Long homeTeamId, Long awayTeamId, Long stadiumId, LocalDateTime matchTime) {
+        return Match.builder()
+                .homeTeamId(homeTeamId)
+                .awayTeamId(awayTeamId)
+                .stadiumId(stadiumId)
+                .matchTime(matchTime)
+                .isCanceled(false)
+                .status(MatchStatus.SCHEDULED)
+                .build();
+    }
+}

--- a/src/test/java/com/example/mate/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/com/example/mate/domain/match/service/MatchServiceTest.java
@@ -1,0 +1,118 @@
+package com.example.mate.domain.match.service;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.domain.constant.StadiumInfo;
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.dto.response.MatchResponse;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.match.entity.MatchStatus;
+import com.example.mate.domain.match.repository.MatchRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceTest {
+    @Mock
+    private MatchRepository matchRepository;
+    @InjectMocks
+    private MatchService matchService;
+
+    @Test
+    @DisplayName("메인 배너에 노출할 상위 5개 경기를 조회")
+    void getMainBannerMatches_ShouldReturnTop5Matches() {
+        // Given
+        List<Match> matches = createTestMatches();
+        when(matchRepository.findTop5ByOrderByMatchTimeDesc()).thenReturn(matches);
+
+        // When
+        List<MatchResponse> result = matchService.getMainBannerMatches();
+
+        // Then
+        assertThat(result).hasSize(5);
+        verify(matchRepository).findTop5ByOrderByMatchTimeDesc();
+    }
+
+    @Test
+    @DisplayName("특정 팀의 상위 3개 경기를 조회")
+    void getTeamMatches_ShouldReturnTop3MatchesForTeam() {
+        // Given
+        Long teamId = 1L;
+        List<Match> matches = createTestMatches().subList(0, 3);
+        when(matchRepository.findTop3ByHomeTeamIdOrAwayTeamIdOrderByMatchTimeDesc(teamId, teamId))
+                .thenReturn(matches);
+
+        // When
+        List<MatchResponse> result = matchService.getTeamMatches(teamId);
+
+        // Then
+        assertThat(result).hasSize(3);
+        verify(matchRepository).findTop3ByHomeTeamIdOrAwayTeamIdOrderByMatchTimeDesc(teamId, teamId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 팀 ID로 조회 시 TEAM_NOT_FOUND 예외가 발생")
+    void getTeamMatches_WithInvalidTeamId_ShouldThrowCustomException() {
+        // Given
+        Long invalidTeamId = 99L;
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> matchService.getTeamMatches(invalidTeamId));
+        assertEquals(ErrorCode.TEAM_NOT_FOUND, exception.getErrorCode());
+    }
+
+
+    private List<Match> createTestMatches() {
+        return List.of(
+                Match.builder()
+                        .homeTeamId(TeamInfo.KIA.id)
+                        .awayTeamId(TeamInfo.LG.id)
+                        .stadiumId(StadiumInfo.GWANGJU.id)
+                        .matchTime(LocalDateTime.now().plusDays(1))
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                Match.builder()
+                        .homeTeamId(TeamInfo.NC.id)
+                        .awayTeamId(TeamInfo.KIA.id)
+                        .stadiumId(StadiumInfo.CHANGWON.id)
+                        .matchTime(LocalDateTime.now().plusDays(2))
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                Match.builder()
+                        .homeTeamId(TeamInfo.KT.id)
+                        .awayTeamId(TeamInfo.DOOSAN.id)
+                        .stadiumId(StadiumInfo.SUWON.id)
+                        .matchTime(LocalDateTime.now().plusDays(3))
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                Match.builder()
+                        .homeTeamId(TeamInfo.SSG.id)
+                        .awayTeamId(TeamInfo.SAMSUNG.id)
+                        .stadiumId(StadiumInfo.INCHEON.id)
+                        .matchTime(LocalDateTime.now().plusDays(4))
+                        .status(MatchStatus.SCHEDULED)
+                        .build(),
+                Match.builder()
+                        .homeTeamId(TeamInfo.HANWHA.id)
+                        .awayTeamId(TeamInfo.LOTTE.id)
+                        .stadiumId(StadiumInfo.DAEJEON.id)
+                        .matchTime(LocalDateTime.now().plusDays(5))
+                        .status(MatchStatus.SCHEDULED)
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] Match 관련 ResponseDTO 수정
- [x] Match 관련 Controller, Service, Repository 작성
- [x] MatchServiceTest, MatchControllerTest, MatchIntegrationTest 작성

## 💡 자세한 설명
1. 팀 정보에서 이미지 삭제

2. 현재 RequestDTO는 사용하지 않는 상황
> 조회 API만 사용

3. 마이팀을 선택하지 않은 경우 메인 페이지 상단 배너 조회 API 구현
> 다가오는 경기 5개 제공

4. 특정 팀을 선택한 경우 메인 페이지 상단 배너 조회 API 구현
> 특정 팀의 경기를 다가오는 순으로 3개 제공

5. MatchResponse를 특정 팀의 경기 전적 조회 시에도 사용 가능
> 경기 결과(승,무,패)를 조회 팀 기준으로 제공하기 위해 계산 메서드 작성

참고 > TEST 관련 커밋 컨벤션을 FEAT으로 생성하는 실수

## 📗 참고 자료 (선택)
MySQL에서 테스트 데이터 생성하여 테스트 -> 크롤링 데이터 삽입 예정
MySQL 명령어
-- Weather 데이터
INSERT INTO weather (temperature, pop, cloudiness, wt_time) VALUES 
(22.5, 30.0, 40, NOW()),
(23.1, 20.0, 30, NOW()),
(21.8, 40.0, 60, NOW()),
(24.2, 10.0, 20, NOW()),
(25.0, 15.0, 25, NOW()),
(20.5, 50.0, 70, NOW()),
(22.0, 35.0, 45, NOW()),
(23.5, 25.0, 35, NOW());

-- Match 데이터 
INSERT INTO `match` (home_team_id, away_team_id, stadium_id, match_time, is_canceled, status, weather_id, home_score, away_score) VALUES
-- 예정된 경기
(1, 2, 1, NOW() + INTERVAL '1' DAY, false, 'SCHEDULED', 1, null, null),
(3, 1, 3, NOW() + INTERVAL '2' DAY, false, 'SCHEDULED', 2, null, null),
(1, 4, 1, NOW() + INTERVAL '3' DAY, false, 'SCHEDULED', 3, null, null),
(1, 6, 1, NOW() + INTERVAL '5' DAY, false, 'SCHEDULED', 4, null, null),
(5, 6, 5, NOW() + INTERVAL '4' DAY, false, 'SCHEDULED', 5, null, null),
-- 종료된 경기
(2, 3, 2, NOW() - INTERVAL '1' DAY, false, 'COMPLETED', 6, 5, 3),
(4, 5, 4, NOW() - INTERVAL '2' DAY, false, 'COMPLETED', 7, 2, 2),
(6, 1, 6, NOW() - INTERVAL '3' DAY, false, 'COMPLETED', 8, 1, 4);

-- TeamRecord 데이터
INSERT INTO team_record (team_id, `rank`, games_played, total_games, wins, draws, losses, games_behind) VALUES 
(1, 1, 50, 144, 32, 5, 13, 0.0),   -- KIA
(2, 2, 50, 144, 30, 7, 13, 2.0),   -- LG
(3, 3, 50, 144, 28, 8, 14, 4.0),   -- NC
(4, 4, 50, 144, 26, 6, 18, 6.0),   -- SSG
(5, 5, 50, 144, 25, 5, 20, 7.0),   -- KT
(6, 6, 50, 144, 23, 7, 20, 9.0);   -- DOOSAN

테스트 통과 화면
![image](https://github.com/user-attachments/assets/21c6ec67-4a46-41ad-ab15-9f90c5fd389d)

JPA 쿼리 메서드 사용
1. https://sproutinghye.tistory.com/63
2. https://lealea.tistory.com/208

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?