### PR TITLE
MATE-59 : [FEAT] JWT 및 Spring Security 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
     // OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // Test Dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/mate/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/mate/common/config/SecurityConfig.java
@@ -1,20 +1,28 @@
 package com.example.mate.common.config;
 
+import com.example.mate.common.security.filter.JwtCheckFilter;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtCheckFilter jwtCheckFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -26,6 +34,8 @@ public class SecurityConfig {
                 )
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtCheckFilter,
+                        UsernamePasswordAuthenticationFilter.class)   // JWT 필터를 UsernamePasswordAuthenticationFilter 전에 추가
                 .authorizeHttpRequests(req ->
                         req.anyRequest().permitAll())
                 .build();

--- a/src/main/java/com/example/mate/common/security/auth/CustomUserPrincipal.java
+++ b/src/main/java/com/example/mate/common/security/auth/CustomUserPrincipal.java
@@ -1,0 +1,20 @@
+package com.example.mate.common.security.auth;
+
+import java.security.Principal;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomUserPrincipal implements Principal {
+
+    private final String userId;
+
+    @Getter
+    private final Long memberId;    // memberId 반환
+
+    // 사용자 ID 반환
+    @Override
+    public String getName() {
+        return this.userId;
+    }
+}

--- a/src/main/java/com/example/mate/common/security/filter/JwtCheckFilter.java
+++ b/src/main/java/com/example/mate/common/security/filter/JwtCheckFilter.java
@@ -1,0 +1,110 @@
+package com.example.mate.common.security.filter;
+
+import com.example.mate.common.security.auth.CustomUserPrincipal;
+import com.example.mate.common.security.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtCheckFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    // 필터링 적용하지 않을 URI 체크
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+
+        // TODO : 2024/11/28 - 각 도메인별로 인증이 필요없는 경로 추가
+
+        // 사용자 로그인, 회원가입 경로 인증 제외 (토큰 발급 경로)
+        if (isAuthExcludedPath(request)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    // 필터링 적용 - 액세스 토큰 확인
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String headerAuth = request.getHeader("Authorization");
+
+        // 액세스 토큰 유효성 검사
+        if (!isTokenValid(headerAuth)) {
+            handleException(response, new Exception("ACCESS TOKEN NOT FOUND"));
+            return;
+        }
+
+        // 토큰 유효성 검증 후 SecurityContext 설정
+        String accessToken = headerAuth.substring(7); // "Bearer " 제외한 토큰 저장
+        try {
+            Map<String, Object> claims = jwtUtil.validateToken(accessToken);
+            setAuthentication(claims);  // 인증 정보 설정
+            filterChain.doFilter(request, response); // 검증 결과 문제가 없는 경우 요청 처리
+        } catch (Exception e) {
+            handleException(response, e);
+        }
+    }
+
+    // 사용자 로그인 또는 회원가입 경로인지 확인
+    private boolean isAuthExcludedPath(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        String method = request.getMethod();
+
+        // 소셜 로그인/회원 가입 경로 인증 제외
+        if (requestURI.startsWith("/api/auth")) {
+            return true;
+        }
+
+        // mate 서비스 회원 가입/로그인 경로 인증 제외
+        if (requestURI.startsWith("/api/members/join") || requestURI.startsWith("/api/members/login")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    // 액세스 토큰 유효성 검사
+    private boolean isTokenValid(String headerAuth) {
+        return headerAuth != null && headerAuth.startsWith("Bearer ");
+    }
+
+    // SecurityContext에 인증 정보 설정
+    private void setAuthentication(Map<String, Object> claims) {
+        String userId = claims.get("userId").toString();
+        String[] roles = claims.get("role").toString().split(","); // role이 여러개일 수 있으므로
+        Long memberId = Long.valueOf(claims.get("memberId").toString());
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                new CustomUserPrincipal(userId, memberId),
+                null, // 이미 인증되었으므로 null
+                Arrays.stream(roles)
+                        .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                        .collect(Collectors.toList())
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authToken); // SecurityContext에 인증 정보 저장
+    }
+
+    // 403 Forbidden 에러 처리
+    public void handleException(HttpServletResponse response, Exception e) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.getWriter().println("{\"error\": \"" + e.getMessage() + "\"}");
+    }
+}

--- a/src/main/java/com/example/mate/common/security/util/JwtUtil.java
+++ b/src/main/java/com/example/mate/common/security/util/JwtUtil.java
@@ -1,0 +1,49 @@
+package com.example.mate.common.security.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+    // 서명에 사용할 비밀 키 - application-local.yml 참조
+    @Value("${jwt.secret-key}")
+    private String key;
+
+    // JWT 서명을 위한 비밀 키 생성
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(key.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // JWT 문자열 생성. valueMap: JWT에 저장할 클레임 (payload), min: 만료 시간 (분 단위)
+    public String createToken(Map<String, Object> valueMap, int min) {
+        SecretKey key = getSigningKey();
+        Date now = new Date(); // 토큰 발행 시간
+
+        return Jwts.builder()
+                .setHeaderParam("alg", "HS256")
+                .setHeaderParam("typ", "JWT")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + Duration.ofMinutes(min).toMillis()))
+                .setClaims(valueMap)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // JWT 토큰의 서명을 검증하고 클레임 반환
+    public Map<String, Object> validateToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] JWT 및 Spring Security 설정
- [x] CustomUserPrincipal 구현

## 💡 자세한 설명

### JWT를 사용하기 위해 의존성 추가 및 Spring Seucirty 설정
> 커스텀 어노테이션을 통해 사용자 인증 값을 가져오려했지만, 구현의 어려움으로 수업 기반의 코드로 작성했습니다.

### JWT 관련

#### JwtUtil: JWT(JSON Web Token)를 생성하고 검증하는 기능을 제공하는 유틸리티 클래스

- `@Value("${jwt.secret-key}")` : JWT 서명에 사용되는 비밀 키입니다. `application-local.yml`에서 해당 키 값을 주입받아 사용합니다. **아래의 값을 반드시 넣어주세요**

```java
jwt:
  secret-key: "xk2+fIk2mX2V9I/0zI+4bTz5ZG9QvAox6g0f5pC9rcA="
```

-> 결과 : 
![스크린샷 2024-11-28 오후 2 34 07](https://github.com/user-attachments/assets/5da6c65c-f872-43e7-bd05-f29294683848)

- `getSigningKey()` : 
    - JWT 서명을 위한 비밀 키를 SecretKey 객체로 반환합니다.

- `createToken(Map<String, Object> valueMap, int min)` : 
    - JWT의 클레임을 담은 맵과 토큰 만료 시간(분)을 받아 JWT 토큰을 생성합니다. 

- `validateToken(String token)` : 
    - JWT의 서명을 검증하고, JWT에서 클레임을 추출하는 역할을 합니다.


#### JwtCheckFilter: JWT 액세스 토큰을 검사하고 인증 정보를 설정하는 필터 클래스

- `shouldNotFilter(HttpServletRequest request)` : 
    - 각 도메인별로 인증이 필요없는 경로가 있다면 추가해주시면 됩니다.

- 예시:
![스크린샷 2024-11-28 오후 2 59 30](https://github.com/user-attachments/assets/3f835ee5-cae8-4044-acf4-535230f90ec6)

#### CustomUserPrincipal: Spring Security에서 사용자 인증 정보를 표현하는 커스텀 클래스

- userId와 memberId를 기반으로 사용자의 정보를 담고 있습니다.


- **@AuthenticationPrinciapl을 파라미터에서 사용해 사용자 정보 꺼내는 방법** 예시 :
![스크린샷 2024-11-28 오후 3 04 36](https://github.com/user-attachments/assets/8a52bceb-5e95-4ca4-87b4-0234d12c5cfb)

- **@PreAuthorize를 통해 메서드 권한 설정 예시** : 
![스크린샷 2024-11-28 오후 3 05 50](https://github.com/user-attachments/assets/c34702e0-ddbc-4fd9-960b-3afc16b10b57)



## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?