### PR TITLE
MATE-55 : [FEAT] KBO 구단 순위 제공 기능 구현

### DIFF
--- a/http/Match.http
+++ b/http/Match.http
@@ -17,3 +17,7 @@ Content-Type: application/json
 
 ### [Team API] ###
 #################
+
+### KBO 리그 전체 순위를 조회
+GET http://localhost:8000/api/teams/rankings
+Content-Type: application/json

--- a/src/main/java/com/example/mate/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/mate/common/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.example.mate.common.config;
 
-import com.example.mate.common.security.filter.JwtCheckFilter;
+//import com.example.mate.common.security.filter.JwtCheckFilter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,7 +22,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtCheckFilter jwtCheckFilter;
+//    private final JwtCheckFilter jwtCheckFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -34,8 +34,8 @@ public class SecurityConfig {
                 )
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(jwtCheckFilter,
-                        UsernamePasswordAuthenticationFilter.class)   // JWT 필터를 UsernamePasswordAuthenticationFilter 전에 추가
+//                .addFilterBefore(jwtCheckFilter,
+//                        UsernamePasswordAuthenticationFilter.class)   // JWT 필터를 UsernamePasswordAuthenticationFilter 전에 추가
                 .authorizeHttpRequests(req ->
                         req.anyRequest().permitAll())
                 .build();

--- a/src/main/java/com/example/mate/common/security/auth/CustomUserPrincipal.java
+++ b/src/main/java/com/example/mate/common/security/auth/CustomUserPrincipal.java
@@ -4,17 +4,17 @@ import java.security.Principal;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
-public class CustomUserPrincipal implements Principal {
-
-    private final String userId;
-
-    @Getter
-    private final Long memberId;    // memberId 반환
-
-    // 사용자 ID 반환
-    @Override
-    public String getName() {
-        return this.userId;
-    }
-}
+//@RequiredArgsConstructor
+//public class CustomUserPrincipal implements Principal {
+//
+//    private final String userId;
+//
+//    @Getter
+//    private final Long memberId;    // memberId 반환
+//
+//    // 사용자 ID 반환
+//    @Override
+//    public String getName() {
+//        return this.userId;
+//    }
+//}

--- a/src/main/java/com/example/mate/common/security/filter/JwtCheckFilter.java
+++ b/src/main/java/com/example/mate/common/security/filter/JwtCheckFilter.java
@@ -1,7 +1,7 @@
 package com.example.mate.common.security.filter;
 
-import com.example.mate.common.security.auth.CustomUserPrincipal;
-import com.example.mate.common.security.util.JwtUtil;
+//import com.example.mate.common.security.auth.CustomUserPrincipal;
+//import com.example.mate.common.security.util.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,94 +17,94 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Component
-@RequiredArgsConstructor
-public class JwtCheckFilter extends OncePerRequestFilter {
-
-    private final JwtUtil jwtUtil;
-
-    // 필터링 적용하지 않을 URI 체크
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-
-        // TODO : 2024/11/28 - 각 도메인별로 인증이 필요없는 경로 추가
-
-        // 사용자 로그인, 회원가입 경로 인증 제외 (토큰 발급 경로)
-        if (isAuthExcludedPath(request)) {
-            return true;
-        }
-
-        return false;
-    }
-
-    // 필터링 적용 - 액세스 토큰 확인
-    @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
-        String headerAuth = request.getHeader("Authorization");
-
-        // 액세스 토큰 유효성 검사
-        if (!isTokenValid(headerAuth)) {
-            handleException(response, new Exception("ACCESS TOKEN NOT FOUND"));
-            return;
-        }
-
-        // 토큰 유효성 검증 후 SecurityContext 설정
-        String accessToken = headerAuth.substring(7); // "Bearer " 제외한 토큰 저장
-        try {
-            Map<String, Object> claims = jwtUtil.validateToken(accessToken);
-            setAuthentication(claims);  // 인증 정보 설정
-            filterChain.doFilter(request, response); // 검증 결과 문제가 없는 경우 요청 처리
-        } catch (Exception e) {
-            handleException(response, e);
-        }
-    }
-
-    // 사용자 로그인 또는 회원가입 경로인지 확인
-    private boolean isAuthExcludedPath(HttpServletRequest request) {
-        String requestURI = request.getRequestURI();
-        String method = request.getMethod();
-
-        // 소셜 로그인/회원 가입 경로 인증 제외
-        if (requestURI.startsWith("/api/auth")) {
-            return true;
-        }
-
-        // mate 서비스 회원 가입/로그인 경로 인증 제외
-        if (requestURI.startsWith("/api/members/join") || requestURI.startsWith("/api/members/login")) {
-            return true;
-        }
-
-        return false;
-    }
-
-    // 액세스 토큰 유효성 검사
-    private boolean isTokenValid(String headerAuth) {
-        return headerAuth != null && headerAuth.startsWith("Bearer ");
-    }
-
-    // SecurityContext에 인증 정보 설정
-    private void setAuthentication(Map<String, Object> claims) {
-        String userId = claims.get("userId").toString();
-        String[] roles = claims.get("role").toString().split(","); // role이 여러개일 수 있으므로
-        Long memberId = Long.valueOf(claims.get("memberId").toString());
-
-        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                new CustomUserPrincipal(userId, memberId),
-                null, // 이미 인증되었으므로 null
-                Arrays.stream(roles)
-                        .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
-                        .collect(Collectors.toList())
-        );
-
-        SecurityContextHolder.getContext().setAuthentication(authToken); // SecurityContext에 인증 정보 저장
-    }
-
-    // 403 Forbidden 에러 처리
-    public void handleException(HttpServletResponse response, Exception e) throws IOException {
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        response.setContentType("application/json");
-        response.getWriter().println("{\"error\": \"" + e.getMessage() + "\"}");
-    }
-}
+//@Component
+//@RequiredArgsConstructor
+//public class JwtCheckFilter extends OncePerRequestFilter {
+//
+//    private final JwtUtil jwtUtil;
+//
+//    // 필터링 적용하지 않을 URI 체크
+//    @Override
+//    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+//
+//        // TODO : 2024/11/28 - 각 도메인별로 인증이 필요없는 경로 추가
+//
+//        // 사용자 로그인, 회원가입 경로 인증 제외 (토큰 발급 경로)
+//        if (isAuthExcludedPath(request)) {
+//            return true;
+//        }
+//
+//        return false;
+//    }
+//
+//    // 필터링 적용 - 액세스 토큰 확인
+//    @Override
+//    protected void doFilterInternal(HttpServletRequest request,
+//                                    HttpServletResponse response,
+//                                    FilterChain filterChain) throws ServletException, IOException {
+//        String headerAuth = request.getHeader("Authorization");
+//
+//        // 액세스 토큰 유효성 검사
+//        if (!isTokenValid(headerAuth)) {
+//            handleException(response, new Exception("ACCESS TOKEN NOT FOUND"));
+//            return;
+//        }
+//
+//        // 토큰 유효성 검증 후 SecurityContext 설정
+//        String accessToken = headerAuth.substring(7); // "Bearer " 제외한 토큰 저장
+//        try {
+//            Map<String, Object> claims = jwtUtil.validateToken(accessToken);
+//            setAuthentication(claims);  // 인증 정보 설정
+//            filterChain.doFilter(request, response); // 검증 결과 문제가 없는 경우 요청 처리
+//        } catch (Exception e) {
+//            handleException(response, e);
+//        }
+//    }
+//
+//    // 사용자 로그인 또는 회원가입 경로인지 확인
+//    private boolean isAuthExcludedPath(HttpServletRequest request) {
+//        String requestURI = request.getRequestURI();
+//        String method = request.getMethod();
+//
+//        // 소셜 로그인/회원 가입 경로 인증 제외
+//        if (requestURI.startsWith("/api/auth")) {
+//            return true;
+//        }
+//
+//        // mate 서비스 회원 가입/로그인 경로 인증 제외
+//        if (requestURI.startsWith("/api/members/join") || requestURI.startsWith("/api/members/login")) {
+//            return true;
+//        }
+//
+//        return false;
+//    }
+//
+//    // 액세스 토큰 유효성 검사
+//    private boolean isTokenValid(String headerAuth) {
+//        return headerAuth != null && headerAuth.startsWith("Bearer ");
+//    }
+//
+//    // SecurityContext에 인증 정보 설정
+//    private void setAuthentication(Map<String, Object> claims) {
+//        String userId = claims.get("userId").toString();
+//        String[] roles = claims.get("role").toString().split(","); // role이 여러개일 수 있으므로
+//        Long memberId = Long.valueOf(claims.get("memberId").toString());
+//
+//        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+//                new CustomUserPrincipal(userId, memberId),
+//                null, // 이미 인증되었으므로 null
+//                Arrays.stream(roles)
+//                        .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+//                        .collect(Collectors.toList())
+//        );
+//
+//        SecurityContextHolder.getContext().setAuthentication(authToken); // SecurityContext에 인증 정보 저장
+//    }
+//
+//    // 403 Forbidden 에러 처리
+//    public void handleException(HttpServletResponse response, Exception e) throws IOException {
+//        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+//        response.setContentType("application/json");
+//        response.getWriter().println("{\"error\": \"" + e.getMessage() + "\"}");
+//    }
+//}

--- a/src/main/java/com/example/mate/common/security/util/JwtUtil.java
+++ b/src/main/java/com/example/mate/common/security/util/JwtUtil.java
@@ -11,39 +11,39 @@ import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-@Component
-public class JwtUtil {
-
-    // 서명에 사용할 비밀 키 - application-local.yml 참조
-    @Value("${jwt.secret-key}")
-    private String key;
-
-    // JWT 서명을 위한 비밀 키 생성
-    private SecretKey getSigningKey() {
-        return Keys.hmacShaKeyFor(key.getBytes(StandardCharsets.UTF_8));
-    }
-
-    // JWT 문자열 생성. valueMap: JWT에 저장할 클레임 (payload), min: 만료 시간 (분 단위)
-    public String createToken(Map<String, Object> valueMap, int min) {
-        SecretKey key = getSigningKey();
-        Date now = new Date(); // 토큰 발행 시간
-
-        return Jwts.builder()
-                .setHeaderParam("alg", "HS256")
-                .setHeaderParam("typ", "JWT")
-                .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + Duration.ofMinutes(min).toMillis()))
-                .setClaims(valueMap)
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
-    }
-
-    // JWT 토큰의 서명을 검증하고 클레임 반환
-    public Map<String, Object> validateToken(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(getSigningKey())
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-    }
-}
+//@Component
+//public class JwtUtil {
+//
+//    // 서명에 사용할 비밀 키 - application-local.yml 참조
+//    @Value("${jwt.secret-key}")
+//    private String key;
+//
+//    // JWT 서명을 위한 비밀 키 생성
+//    private SecretKey getSigningKey() {
+//        return Keys.hmacShaKeyFor(key.getBytes(StandardCharsets.UTF_8));
+//    }
+//
+//    // JWT 문자열 생성. valueMap: JWT에 저장할 클레임 (payload), min: 만료 시간 (분 단위)
+//    public String createToken(Map<String, Object> valueMap, int min) {
+//        SecretKey key = getSigningKey();
+//        Date now = new Date(); // 토큰 발행 시간
+//
+//        return Jwts.builder()
+//                .setHeaderParam("alg", "HS256")
+//                .setHeaderParam("typ", "JWT")
+//                .setIssuedAt(now)
+//                .setExpiration(new Date(now.getTime() + Duration.ofMinutes(min).toMillis()))
+//                .setClaims(valueMap)
+//                .signWith(key, SignatureAlgorithm.HS256)
+//                .compact();
+//    }
+//
+//    // JWT 토큰의 서명을 검증하고 클레임 반환
+//    public Map<String, Object> validateToken(String token) {
+//        return Jwts.parserBuilder()
+//                .setSigningKey(getSigningKey())
+//                .build()
+//                .parseClaimsJws(token)
+//                .getBody();
+//    }
+//}

--- a/src/main/java/com/example/mate/domain/match/controller/TeamController.java
+++ b/src/main/java/com/example/mate/domain/match/controller/TeamController.java
@@ -1,8 +1,8 @@
 package com.example.mate.domain.match.controller;
 
-import com.example.mate.domain.match.dto.response.StadiumResponse;
 import com.example.mate.domain.match.dto.response.TeamResponse;
 import com.example.mate.common.response.ApiResponse;
+import com.example.mate.domain.match.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -19,58 +19,12 @@ import java.util.List;
 @RequestMapping("/api/teams")
 @RequiredArgsConstructor
 public class TeamController {
-//    private static final int TOTAL_GAMES = 144;  // KBO 정규시즌 총 경기 수
-//
-//    @Operation(summary = "팀 순위 조회", description = "KBO 리그 전체 순위를 조회합니다.")
-//    @GetMapping("/rankings")
-//    public ResponseEntity<ApiResponse<List<TeamResponse.Detail>>> getTeamRankings() {
-//        List<TeamResponse.Detail> rankings = Arrays.asList(
-//                createTeamDetail(1L, "KIA 타이거즈", "광주-기아 챔피언스 필드", "광주광역시 북구", "126.8989", "35.1681",
-//                        100, 90, 10, 0, 2.0),
-//                createTeamDetail(2L, "LG 트윈스", "잠실야구장", "서울특별시 송파구", "127.0719", "37.5122",
-//                        95, 85, 10, 0, 3.5),
-//                createTeamDetail(3L, "NC 다이노스", "창원NC파크", "창원시 마산회원구", "128.5829", "35.2534",
-//                        92, 82, 10, 0, 4.0),
-//                createTeamDetail(4L, "SSG 랜더스", "인천SSG랜더스필드", "인천광역시 미추홀구", "126.6781", "37.4374",
-//                        90, 78, 12, 0, 5.0),
-//                createTeamDetail(5L, "kt wiz", "수원 kt wiz 파크", "수원시 장안구", "127.0355", "37.2994",
-//                        88, 75, 13, 0, 6.0),
-//                createTeamDetail(6L, "두산 베어스", "잠실야구장", "서울특별시 송파구", "127.0719", "37.5122",
-//                        86, 72, 14, 0, 7.0),
-//                createTeamDetail(7L, "롯데 자이언츠", "사직야구장", "부산광역시 동래구", "129.0639", "35.1947",
-//                        84, 68, 16, 0, 8.0),
-//                createTeamDetail(8L, "삼성 라이온즈", "대구삼성라이온즈파크", "대구광역시 수성구", "128.6814", "35.8409",
-//                        82, 65, 17, 0, 9.0),
-//                createTeamDetail(9L, "키움 히어로즈", "고척스카이돔", "서울특별시 구로구", "126.8669", "37.4982",
-//                        80, 62, 18, 0, 10.0),
-//                createTeamDetail(10L, "한화 이글스", "한화생명이글스파크", "대전광역시 중구", "127.4294", "36.3172",
-//                        78, 58, 20, 0, 11.0)
-//        );
-//
-//        return ResponseEntity.ok(ApiResponse.success(rankings));
-//    }
-//
-//    private TeamResponse.Detail createTeamDetail(Long id, String teamName,
-//                                                 String stadiumName, String location, String longitude, String latitude,
-//                                                 int gamesPlayed, int wins, int draws, int losses, double gamesBehind) {
-//        return TeamResponse.Detail.builder()
-//                .id(id)
-//                .teamName(teamName)
-//                .logoImageUrl(String.format("http://example.com/teams/%d/logo.png", id))
-//                .stadium(StadiumResponse.Info.builder()
-//                        .id(id)
-//                        .stadiumName(stadiumName)
-//                        .location(location)
-//                        .longitude(longitude)
-//                        .latitude(latitude)
-//                        .build())
-//                .rank(id.intValue())
-//                .gamesPlayed(gamesPlayed)
-//                .totalGames(TOTAL_GAMES)
-//                .wins(wins)
-//                .draws(draws)
-//                .losses(losses)
-//                .gamesBehind(gamesBehind)
-//                .build();
-//    }
+
+    private final TeamService teamService;
+    @Operation(summary = "팀 순위 조회", description = "KBO 리그 전체 순위를 조회합니다.")
+    @GetMapping("/rankings")
+    public ResponseEntity<ApiResponse<List<TeamResponse.Detail>>> getTeamRankings() {
+        List<TeamResponse.Detail> rankings = teamService.getTeamRankings();
+        return ResponseEntity.ok(ApiResponse.success(rankings));
+    }
 }

--- a/src/main/java/com/example/mate/domain/match/dto/response/TeamResponse.java
+++ b/src/main/java/com/example/mate/domain/match/dto/response/TeamResponse.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamResponse {
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -43,8 +41,7 @@ public class TeamResponse {
         private Integer losses;
         private Double gamesBehind;
 
-        @Builder
-        public Detail(TeamInfo.Team team, TeamRecord record) {
+        private Detail(TeamInfo.Team team, TeamRecord record) {
             this.id = team.id;
             this.teamName = team.fullName;
             this.stadium = StadiumResponse.Info.from(team.homeStadium);
@@ -58,10 +55,8 @@ public class TeamResponse {
         }
 
         public static Detail from(TeamInfo.Team team, TeamRecord record) {
-            return Detail.builder()
-                    .team(team)
-                    .record(record)
-                    .build();
+            return new Detail(team, record);
         }
+
     }
 }

--- a/src/main/java/com/example/mate/domain/match/repository/TeamRecordRepository.java
+++ b/src/main/java/com/example/mate/domain/match/repository/TeamRecordRepository.java
@@ -1,0 +1,12 @@
+package com.example.mate.domain.match.repository;
+
+import com.example.mate.domain.match.entity.TeamRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TeamRecordRepository extends JpaRepository<TeamRecord, Long> {
+    List<TeamRecord> findAllByOrderByRankAsc();
+}

--- a/src/main/java/com/example/mate/domain/match/service/TeamService.java
+++ b/src/main/java/com/example/mate/domain/match/service/TeamService.java
@@ -1,0 +1,30 @@
+package com.example.mate.domain.match.service;
+
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.dto.response.TeamResponse;
+import com.example.mate.domain.match.entity.TeamRecord;
+import com.example.mate.domain.match.repository.TeamRecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamService {
+    private final TeamRecordRepository teamRecordRepository;
+
+    public List<TeamResponse.Detail> getTeamRankings() {
+        List<TeamRecord> teamRecords = teamRecordRepository.findAllByOrderByRankAsc();
+
+        return teamRecords.stream()
+                .map(record -> {
+                    TeamInfo.Team team = TeamInfo.getById(record.getId());
+                    return TeamResponse.Detail.from(team, record);
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/example/mate/domain/match/controller/TeamControllerTest.java
+++ b/src/test/java/com/example/mate/domain/match/controller/TeamControllerTest.java
@@ -1,0 +1,79 @@
+package com.example.mate.domain.match.controller;
+
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.dto.response.TeamResponse;
+import com.example.mate.domain.match.entity.TeamRecord;
+import com.example.mate.domain.match.service.TeamService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TeamController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TeamControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TeamService teamService;
+
+    @Test
+    @DisplayName("팀 순위 조회 API 테스트")
+    void getTeamRankings() throws Exception {
+        // Given
+        List<TeamResponse.Detail> mockResponses = List.of(
+                createTeamResponse(TeamInfo.LG, 1, 86, 2, 56, 0.0),
+                createTeamResponse(TeamInfo.KT, 2, 81, 2, 61, 4.5),
+                createTeamResponse(TeamInfo.SSG, 3, 76, 2, 66, 8.5)
+        );
+
+        when(teamService.getTeamRankings()).thenReturn(mockResponses);
+
+        // When & Then
+        mockMvc.perform(get("/api/teams/rankings")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data", hasSize(3)))
+                .andExpect(jsonPath("$.data[0].rank").value(1))
+                .andExpect(jsonPath("$.data[0].wins").value(86))
+                .andExpect(jsonPath("$.data[1].rank").value(2))
+                .andExpect(jsonPath("$.data[2].rank").value(3));
+    }
+
+    private TeamResponse.Detail createTeamResponse(TeamInfo.Team team, int rank,
+                                                   int wins, int draws, int losses, double gamesBehind) {
+        TeamRecord record = TeamRecord.builder()
+                .team(team)
+                .rank(rank)
+                .gamesPlayed(wins + draws + losses)
+                .totalGames(144)
+                .wins(wins)
+                .draws(draws)
+                .losses(losses)
+                .gamesBehind(gamesBehind)
+                .build();
+
+        return TeamResponse.Detail.from(team, record);
+    }
+}

--- a/src/test/java/com/example/mate/domain/match/integration/TeamRecordIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/match/integration/TeamRecordIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.example.mate.domain.match.integration;
+
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.entity.TeamRecord;
+import com.example.mate.domain.match.repository.TeamRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class TeamRecordIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TeamRecordRepository teamRecordRepository;
+
+    @BeforeEach
+    void setUp() {
+        teamRecordRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("팀 순위 조회 통합 테스트 - 성공")
+    void getTeamRankings_Success() throws Exception {
+        // given
+        List<TeamRecord> teamRecords = Arrays.asList(
+                createTeamRecord(TeamInfo.LG, 1, 86, 2, 56, 0.0),
+                createTeamRecord(TeamInfo.KT, 2, 81, 2, 61, 4.5),
+                createTeamRecord(TeamInfo.SSG, 3, 76, 2, 66, 8.5)
+        );
+        teamRecordRepository.saveAll(teamRecords);
+
+        // when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/api/teams/rankings")
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("SUCCESS"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(3))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].rank").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].teamName").value(TeamInfo.LG.fullName))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].wins").value(86))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].rank").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[2].rank").value(3));
+    }
+
+    private TeamRecord createTeamRecord(TeamInfo.Team team, int rank,
+                                        int wins, int draws, int losses, double gamesBehind) {
+        return TeamRecord.builder()
+                .team(team)
+                .rank(rank)
+                .gamesPlayed(wins + draws + losses)
+                .totalGames(144)
+                .wins(wins)
+                .draws(draws)
+                .losses(losses)
+                .gamesBehind(gamesBehind)
+                .build();
+    }
+}

--- a/src/test/java/com/example/mate/domain/match/service/TeamServiceTest.java
+++ b/src/test/java/com/example/mate/domain/match/service/TeamServiceTest.java
@@ -1,0 +1,82 @@
+package com.example.mate.domain.match.service;
+
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.dto.response.TeamResponse;
+import com.example.mate.domain.match.entity.TeamRecord;
+import com.example.mate.domain.match.repository.TeamRecordRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+    @Mock
+    private TeamRecordRepository teamRecordRepository;
+    @InjectMocks
+    private TeamService teamService;
+
+    @Test
+    @DisplayName("팀 순위 조회 - 성공")
+    void getTeamRankings_Success() {
+        // Given
+        List<TeamRecord> teamRecords = createTeamRecords();
+        when(teamRecordRepository.findAllByOrderByRankAsc()).thenReturn(teamRecords);
+
+        // When
+        List<TeamResponse.Detail> result = teamService.getTeamRankings();
+
+        // Then
+        assertThat(result).hasSize(3);
+        verify(teamRecordRepository).findAllByOrderByRankAsc();
+
+        TeamResponse.Detail firstTeam = result.get(0);
+        assertThat(firstTeam.getRank()).isEqualTo(1);
+        assertThat(firstTeam.getWins()).isEqualTo(86);
+        assertThat(firstTeam.getDraws()).isEqualTo(2);
+        assertThat(firstTeam.getLosses()).isEqualTo(56);
+    }
+
+    private List<TeamRecord> createTeamRecords() {
+        return List.of(
+                TeamRecord.builder()
+                        .team(TeamInfo.LG)
+                        .rank(1)
+                        .gamesPlayed(144)
+                        .totalGames(144)
+                        .wins(86)
+                        .draws(2)
+                        .losses(56)
+                        .gamesBehind(0.0)
+                        .build(),
+                TeamRecord.builder()
+                        .team(TeamInfo.KT)
+                        .rank(2)
+                        .gamesPlayed(144)
+                        .totalGames(144)
+                        .wins(81)
+                        .draws(2)
+                        .losses(61)
+                        .gamesBehind(4.5)
+                        .build(),
+                TeamRecord.builder()
+                        .team(TeamInfo.SSG)
+                        .rank(3)
+                        .gamesPlayed(144)
+                        .totalGames(144)
+                        .wins(76)
+                        .draws(2)
+                        .losses(66)
+                        .gamesBehind(8.5)
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] KBO 구단 순위 제공 기능 구현

## 💡 자세한 설명
메인 페이지에서 전체 팀을 선택한 경우 하단에서 제공하는 전체 구단 순위 제공 기능 구현
> 현재 크롤링 기능을 구현하지 않은 상태이기 때문에 테스트 데이터 활용

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?