### PR TITLE
MATE-46 : [FEAT] 굿즈거래 판매글 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -37,6 +37,8 @@ public enum ErrorCode {
   
     // Goods
     GOODS_IMAGES_ARE_EMPTY(HttpStatus.BAD_REQUEST, "G001", "굿즈 이미지는 최소 1개 이상을 업로드 할 수 있습니다."),
+    GOODS_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "G002", "해당 ID의 굿즈 판매글 정보를 찾을 수 없습니다"),
+    GOODS_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "G003", "판매글의 판매자가 아니라면, 판매글을 수정할 수 없습니다"),
 
     // FILE
     FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "F001", "빈 파일을 업로드할 수 없습니다. 파일 내용을 확인해주세요."),
@@ -45,6 +47,7 @@ public enum ErrorCode {
     FILE_UPLOAD_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "F004", "이미지 파일은 최대 10개까지 업로드 할 수 있습니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "F005", "이미지 파일만 업로드 가능합니다."),
     FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F006", "파일 업로드에 실패했습니다."),
+    FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F007", "파일 삭제에 실패했습니다."),
 
     // Age
     INVALID_AGE_VALUE(HttpStatus.BAD_REQUEST, "AGE001", "유효하지 않은 나이 값입니다."),

--- a/src/main/java/com/example/mate/common/utils/file/FileUploader.java
+++ b/src/main/java/com/example/mate/common/utils/file/FileUploader.java
@@ -17,6 +17,12 @@ public class FileUploader {
         return "upload/" + fileName;
     }
 
+    public static boolean deleteFile(String imageUrl) {
+        // TODO : 2024/11/28 - S3 파일 삭제 기능, 삭제 여부를 boolean 값으로 반환
+
+        return true;
+    }
+
     /**
      * 파일명에서 허용되지 않는 문자를 제거하고, UUID 를 추가한 새로운 파일명을 생성
      *

--- a/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
+++ b/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
@@ -14,7 +14,6 @@ import com.example.mate.domain.goods.service.GoodsService;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,7 +31,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/goods")
 @RequiredArgsConstructor
-@Slf4j
 public class GoodsController {
 
     private final GoodsService goodsService;
@@ -47,8 +45,23 @@ public class GoodsController {
             @RequestPart("files") List<MultipartFile> files,
             @PathVariable Long memberId
     ) {
-        log.info("request = {}", request);
         GoodsPostResponse response = goodsService.registerGoodsPost(memberId, request, files);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /*
+    굿즈 거래하기 상세 페이지 : 굿즈 거래글 수정
+    TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
+    "/api/goods/{goodsPostId}" 로 변경 예정
+     */
+    @PutMapping("/{memberId}/post/{goodsPostId}")
+    public ResponseEntity<ApiResponse<GoodsPostResponse>> updateGoodsPost(
+            @PathVariable Long memberId,
+            @PathVariable Long goodsPostId,
+            @RequestPart("data") GoodsPostRequest request,
+            @RequestPart("files") List<MultipartFile> files
+    ) {
+        GoodsPostResponse response = goodsService.updateGoodsPost(memberId, goodsPostId, request, files);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -97,19 +110,6 @@ public class GoodsController {
     @GetMapping("/{goodsPostId}")
     public ResponseEntity<GoodsPostResponse> getGoodsPost(@PathVariable Long goodsPostId) {
         return ResponseEntity.ok(GoodsPostResponse.createResponse(goodsPostId));
-    }
-
-    /*
-    굿즈 거래하기 상세 페이지 : 굿즈 거래글 수정
-    요청 Body를 form-data 형식으로 설정하여, Key를 값을 넣은 "data"와 사진 파일 "files"로 구분
-     */
-    @PutMapping("/{goodsPostId}")
-    public ResponseEntity<GoodsPostResponse> updateGoodsPost(
-            @PathVariable Long goodsPostId,
-            @RequestPart("data") GoodsPostRequest request,
-            @RequestPart("files") MultipartFile[] files
-    ) {
-        return ResponseEntity.ok(GoodsPostResponse.updateResponse(goodsPostId, request, files));
     }
 
     // 굿즈 거래하기 상세 페이지 : 굿즈 거래글 삭제

--- a/src/main/java/com/example/mate/domain/goods/entity/GoodsPost.java
+++ b/src/main/java/com/example/mate/domain/goods/entity/GoodsPost.java
@@ -89,4 +89,14 @@ public class GoodsPost {
             goodsPostImage.changePost(this);
         }
     }
+
+    // 굿즈 판매글 수정 메서드
+    public void update(GoodsPost post) {
+        this.teamId = post.getTeamId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.price = post.getPrice();
+        this.category = post.getCategory();
+        this.location = post.getLocation();
+    }
 }

--- a/src/main/java/com/example/mate/domain/goods/entity/GoodsPost.java
+++ b/src/main/java/com/example/mate/domain/goods/entity/GoodsPost.java
@@ -88,6 +88,7 @@ public class GoodsPost {
             this.goodsPostImages.add(goodsPostImage);
             goodsPostImage.changePost(this);
         }
+        this.goodsPostImages.get(0).setAsMainImage();
     }
 
     // 굿즈 판매글 수정 메서드

--- a/src/main/java/com/example/mate/domain/goods/entity/GoodsPostImage.java
+++ b/src/main/java/com/example/mate/domain/goods/entity/GoodsPostImage.java
@@ -34,7 +34,15 @@ public class GoodsPostImage {
     @Column(name = "image_url", nullable = false, columnDefinition = "TEXT")
     private String imageUrl;
 
+    @Column(name = "is_main_image", nullable = false)
+    @Builder.Default
+    private Boolean isMainImage = false;
+
     public void changePost(GoodsPost post) {
         this.post = post;
+    }
+
+    public void setAsMainImage() {
+        this.isMainImage = true;
     }
 }

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostImageRepository.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostImageRepository.java
@@ -1,7 +1,18 @@
 package com.example.mate.domain.goods.repository;
 
 import com.example.mate.domain.goods.entity.GoodsPostImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GoodsPostImageRepository extends JpaRepository<GoodsPostImage, Long> {
+
+    @Modifying
+    @Query("DELETE FROM GoodsPostImage g WHERE g.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
+
+    @Query("SELECT g.imageUrl FROM GoodsPostImage g WHERE g.post.id = :postId")
+    List<String> getImageUrlsByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
@@ -108,8 +108,7 @@ public class GoodsService {
             GoodsPostImage savedImage = imageRepository.save(image);
             images.add(savedImage);
         }
-        // 대표사진 지정
-        images.get(0).setAsMainImage();
+
         return images;
     }
 }

--- a/src/test/java/com/example/mate/domain/goods/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goods/controller/GoodsControllerTest.java
@@ -103,4 +103,45 @@ class GoodsControllerTest {
 
         verify(goodsService).registerGoodsPost(eq(memberId), any(GoodsPostRequest.class), anyList());
     }
+
+    @Test
+    @DisplayName("굿즈 판매글 수정 - API 테스트")
+    void update_goods_post_success() throws Exception {
+        // given
+        Long memberId = 1L;
+        Long goodsPostId = 1L;
+        GoodsPostRequest postRequest = createGoodsPostRequest();
+        GoodsPostResponse response = createGoodsPostResponse();
+        List<MockMultipartFile> files = List.of(createFile(), createFile());
+
+        MockMultipartFile data = new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(postRequest)
+        );
+
+        given(goodsService.updateGoodsPost(eq(memberId), eq(goodsPostId), any(GoodsPostRequest.class), anyList()))
+                .willReturn(response);
+
+        // when
+        MockMultipartHttpServletRequestBuilder multipartRequest = multipart("/api/goods/{memberId}/post/{goodsPostId}", memberId, goodsPostId)
+                .file(data);
+        files.forEach(multipartRequest::file);
+        multipartRequest.with(request -> {
+            request.setMethod("PUT"); // PUT 메서드로 변경
+            return request;
+        });
+
+        // then
+        mockMvc.perform(multipartRequest)
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.id").value(response.getId()))
+                .andExpect(jsonPath("$.data.status").value(response.getStatus()))
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(goodsService).updateGoodsPost(eq(memberId), eq(goodsPostId), any(GoodsPostRequest.class), anyList());
+    }
 }

--- a/src/test/java/com/example/mate/domain/goods/entity/GoodsPostTest.java
+++ b/src/test/java/com/example/mate/domain/goods/entity/GoodsPostTest.java
@@ -1,0 +1,69 @@
+package com.example.mate.domain.goods.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GoodsPostTest {
+
+    @Test
+    @DisplayName("굿즈 판매글 이미지를 업로드 할 수 있다.")
+    void upload_post_Images() {
+        // given
+        GoodsPost goodsPost = GoodsPost.builder().title("title").price(10_000).build();
+        GoodsPostImage image = GoodsPostImage.builder().imageUrl("test.jpg").build();
+        GoodsPostImage image2 = GoodsPostImage.builder().imageUrl("test2.jpg").build();
+
+        // when
+        goodsPost.changeImages(List.of(image, image2));
+
+        // then
+        List<GoodsPostImage> actualPostImages = goodsPost.getGoodsPostImages();
+        assertThat(actualPostImages).hasSize(2);
+        assertThat(actualPostImages).containsExactlyInAnyOrder(image, image2);
+        assertThat(actualPostImages.get(0).getIsMainImage()).isTrue();
+        assertThat(actualPostImages.get(1).getIsMainImage()).isFalse();
+        assertThat(image.getPost()).isEqualTo(goodsPost);
+    }
+
+    @Test
+    @DisplayName("굿즈 판매글 이미지를 수정할 수 있다.")
+    void change_post_Images() {
+        // given
+        GoodsPost goodsPost = GoodsPost.builder().title("title").price(10_000).build();
+        GoodsPostImage image = GoodsPostImage.builder().imageUrl("test.jpg").build();
+        GoodsPostImage image2 = GoodsPostImage.builder().imageUrl("test2.jpg").build();
+        goodsPost.changeImages(List.of(image, image2));
+
+        GoodsPostImage newImage = GoodsPostImage.builder().imageUrl("new.jpg").build();
+        GoodsPostImage newImage2 = GoodsPostImage.builder().imageUrl("new2.jpg").build();
+
+        // when
+        goodsPost.changeImages(List.of(newImage, newImage2));
+
+        // then
+        List<GoodsPostImage> actualPostImages = goodsPost.getGoodsPostImages();
+        assertThat(actualPostImages).hasSize(2);
+        assertThat(actualPostImages).containsExactlyInAnyOrder(newImage, newImage2);
+        assertThat(actualPostImages.get(0).getIsMainImage()).isTrue();
+        assertThat(actualPostImages.get(1).getIsMainImage()).isFalse();
+        assertThat(newImage.getPost()).isEqualTo(goodsPost);
+    }
+
+    @Test
+    @DisplayName("비어 있는 이미지를 업로드하면 CustomException 이 발생한다.")
+    void should_throw_CustomException_when_post_Images_are_null() {
+        // given
+        GoodsPost goodsPost = GoodsPost.builder().title("title").price(10_000).build();
+
+        // when & then
+        assertThatThrownBy(() -> goodsPost.changeImages(List.of()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.GOODS_IMAGES_ARE_EMPTY.getMessage());
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 판매글 수정 기능 구현
- [x] 굿즈거래 엔티티 테스트 코드 작성
- [x] 굿즈거래 판매글 수정 테스트 코드 작성

## 💡 자세한 설명
#### 굿즈거래 판매글 수정 기능 구현 - `PUT /api/goods/{memberId}/post/{postId}`

```java
public GoodsPostResponse updateGoodsPost(Long memberId, Long goodsPostId, GoodsPostRequest request, List<MultipartFile> files) {
    // 사용자, 판매글 정보, 팀 정보, 이미지 파일 유효성 검증
    Member seller = getSellerAndValidate(memberId);
    GoodsPost goodsPost = getGoodsPostAndValidate(seller, goodsPostId);
    validateTeamInfo(request.getTeamId());
    FileValidator.validateGoodsPostImages(files);

    // 판매글 정보 업데이트
    GoodsPost updatedPost = GoodsPostRequest.toEntity(seller, request);
    goodsPost.update(updatedPost);
    deleteExistingImages(goodsPostId);      // 이 부분입니다!

    // 이미지 업로드 & 저장
    List<GoodsPostImage> images = saveImages(files, goodsPost);
    goodsPost.changeImages(images);

    return GoodsPostResponse.of(goodsPost);
}
```
#### 굿즈 판매글 수정 시 여러개의 이미지 파일 수정에 대한 고민 정리

1. 현재 구현 방식
- 모든 이미지를 삭제하고 새 이미지를 다시 저장하는 방식
- 장점
    - 구현이 간단하며, 동일성 비교에 따른 복잡성을 피할 수 있음
    - 모든 이미지가 항상 최신 상태로 저장되므로 데이터의 일관성을 유지하기 쉬움
- 단점:
    - 이미지 파일 수가 많아질수록 비효율적임.
    - 변경되지 않은 이미지도 삭제 후 재업로드되므로 리소스 낭비가 발생

2. 새로운 구현 방식 시도
- 새로운 이미지와 기존 이미지를 비교하여, 변경된 이미지만 저장하는 로직을 구현하려고 시도
- 실패한 이유
    -  이미지 동일성 판단의 어려움:
    -  단순히 파일 이름이나 경로만 비교하면 다른 이미지임에도 동일하게 판단될 수 있음
    -  파일 내용의 해시값(SHA-256 등)을 비교하는 방식은 구현이 복잡하며 성능 문제가 우려됨

> 현재 방식에 대한 효율성 문제
이미지 수가 많아질수록 삭제 및 저장 과정에서 시간과 리소스가 불필요하게 낭비될 가능성이 있음.

#### 대표 사진 지정 로직

```java
public class GoodsPost {
...
// 굿즈 판매글 이미지 업로드 및 수정 메서드
public void changeImages(List<GoodsPostImage> goodsPostImages) {
    if (goodsPostImages.isEmpty()) {
        throw new CustomException(ErrorCode.GOODS_IMAGES_ARE_EMPTY);
    }

    // 기존 이미지 전부 삭제
    this.goodsPostImages.clear();

    for (GoodsPostImage goodsPostImage : goodsPostImages) {
        this.goodsPostImages.add(goodsPostImage);
        goodsPostImage.changePost(this);
    }
    this.goodsPostImages.get(0).setAsMainImage();   // 이 부분입니다!
}

```
`GoodsPostImage` 클래스에 `isMainImage` 필드를 선언해서 첫번째 이미지를 메인 이미지로 설정했습니다!
추후에 ERD 에도 이미지에 컬럼에 추가하겠습니다!

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?