### PR TITLE
MATE-25 : [FEAT] 메인페이지 메이트 게시글 조회 기능 구현 및 테스트 환경 설정 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -16,6 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -42,19 +43,10 @@ public class MateController {
     }
 
     // 메이트 게시글 목록 조회(메인 페이지)
-    @GetMapping("/main")
-    public ResponseEntity<List<MatePostSummaryResponse>> getMatePostsMain(@RequestParam Long teamId) {
-        return ResponseEntity.ok(List.of(MatePostSummaryResponse.builder()
-                        .imageUrl("imageUrl")
-                        .title("12월 경기 메이트 찾아요")
-                        .status(Status.OPEN)
-                        .rivalTeamName("삼성")
-                        .rivalMatchTime(LocalDateTime.now())
-                        .maxParticipants(10)
-                        .age(Age.TWENTIES)
-                        .gender(Gender.MALE)
-                        .transportType(TransportType.PUBLIC)
-                        .build()));
+    @GetMapping(value = "/main", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<List<MatePostSummaryResponse>>> getMatePostsMain(@RequestParam(required = false) Long teamId) {
+        List<MatePostSummaryResponse> matePostMain = mateService.getMatePostMain(teamId);
+        return ResponseEntity.ok(ApiResponse.success(matePostMain));
     }
 
     // 메이트 게시글 목록 조회(메이트 페이지)

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MatePostCreateRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MatePostCreateRequest.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.mate.dto.request;
 
+import com.example.mate.common.utils.validator.ValidEnum;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.mate.entity.TransportType;
@@ -36,7 +37,7 @@ public class MatePostCreateRequest {
     @Length(min = 1, max = 500, message = "내용은 1자 이상 500자 이하여야 합니다.")
     private String content;
 
-    @NotNull(message = "연령대는 필수입니다.")
+    @ValidEnum(message = "연령대의 입력 값이 잘못되었습니다.", enumClass = Age.class)
     private Age age;
 
     @NotNull(message = "최대 참여 인원은 필수입니다.")
@@ -44,9 +45,9 @@ public class MatePostCreateRequest {
     @Max(value = 10, message = "최대 참여 인원은 10명 이하여야 합니다.")
     private Integer maxParticipants;
 
-    @NotNull(message = "성별은 필수입니다.")
+    @ValidEnum(message = "성별의 입력 값이 잘못되었습니다.", enumClass = Gender.class)
     private Gender gender;
 
-    @NotNull(message = "이동 수단은 필수입니다.")
+    @ValidEnum(message = "이동수단의 입력 값이 잘못되었습니다.", enumClass = TransportType.class)
     private TransportType transportType;
 }

--- a/src/main/java/com/example/mate/domain/mate/dto/response/MatePostResponse.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/response/MatePostResponse.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.mate.dto.response;
 
+import com.example.mate.domain.mate.entity.MatePost;
 import com.example.mate.domain.mate.entity.Status;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,4 +10,8 @@ import lombok.Getter;
 public class MatePostResponse {
     private Long id;
     private Status status;
+
+    public static MatePostResponse from(MatePost matePost) {
+        return MatePostResponse.builder().id(matePost.getId()).status(matePost.getStatus()).build();
+    }
 }

--- a/src/main/java/com/example/mate/domain/mate/dto/response/MatePostSummaryResponse.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/response/MatePostSummaryResponse.java
@@ -1,7 +1,10 @@
 package com.example.mate.domain.mate.dto.response;
 
-import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.domain.mate.entity.MatePost;
 import com.example.mate.domain.mate.entity.Status;
 import com.example.mate.domain.mate.entity.TransportType;
 import lombok.Builder;
@@ -23,4 +26,33 @@ public class MatePostSummaryResponse {
     private Age age;
     private Gender gender;
     private TransportType transportType;
+
+    public static MatePostSummaryResponse from(MatePost post) {
+        return MatePostSummaryResponse.builder()
+                .imageUrl(post.getImageUrl())
+                .title(post.getTitle())
+                .status(post.getStatus())
+                .rivalTeamName(getRivalTeamName(post))
+                .rivalMatchTime(post.getMatch().getMatchTime())
+                .location(post.getMatch().getStadium().name)
+                .maxParticipants(post.getMaxParticipants())
+                .age(post.getAge())
+                .gender(post.getGender())
+                .transportType(post.getTransport())
+                .build();
+    }
+
+    private static String getRivalTeamName(MatePost post) {
+        Match match = post.getMatch();
+        Long postTeamId = post.getTeamId(); // 게시글 작성자가 선택한 팀
+
+        // 게시글 작성자가 선택한 팀이 홈팀인 경우 원정팀이 상대팀
+        if (postTeamId.equals(match.getHomeTeamId())) {
+            return TeamInfo.getById(match.getAwayTeamId()).shortName;
+        }
+        // 게시글 작성자가 선택한 팀이 원정팀인 경우 홈팀이 상대팀
+        else {
+            return TeamInfo.getById(match.getHomeTeamId()).shortName;
+        }
+    }
 }

--- a/src/main/java/com/example/mate/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateRepository.java
@@ -1,9 +1,23 @@
 package com.example.mate.domain.mate.repository;
 
 import com.example.mate.domain.mate.entity.MatePost;
+import com.example.mate.domain.mate.entity.Status;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface MateRepository extends JpaRepository<MatePost, Long> {
+    @Query("""
+            SELECT mp FROM MatePost mp JOIN FETCH mp.match mt
+            WHERE (:teamId IS NULL OR mp.teamId = :teamId)
+            And mt.matchTime > :now AND mp.status IN :statuses
+            ORDER BY mt.matchTime ASC
+           """)
+    List<MatePost> findMainPagePosts(@Param("teamId") Long teamId, @Param("now") LocalDateTime now, @Param("statuses") List<Status> statuses, Pageable pageable);
 }

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -1,6 +1,7 @@
 package com.example.mate.domain.mate.service;
 
 import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
@@ -64,6 +65,10 @@ public class MateService {
     }
 
     public List<MatePostSummaryResponse> getMatePostMain(Long teamId) {
+        if (teamId != null && !TeamInfo.existById(teamId)) {
+            throw new CustomException(ErrorCode.TEAM_NOT_FOUND);
+        }
+
         LocalDateTime now = LocalDateTime.now();
         List<Status> validStatuses = List.of(Status.OPEN, Status.CLOSED);
 

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -6,6 +6,7 @@ import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
 import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
 import com.example.mate.domain.mate.dto.response.MatePostResponse;
+import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
 import com.example.mate.domain.mate.entity.MatePost;
 import com.example.mate.domain.mate.entity.Status;
 import com.example.mate.domain.mate.repository.MateRepository;
@@ -13,8 +14,13 @@ import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.example.mate.common.error.ErrorCode.*;
 
@@ -54,9 +60,21 @@ public class MateService {
                 .build();
         MatePost savedPost = mateRepository.save(matePost);
 
-        return MatePostResponse.builder()
-                .id(savedPost.getId())
-                .status(savedPost.getStatus())
-                .build();
+        return MatePostResponse.from(savedPost);
+    }
+
+    public List<MatePostSummaryResponse> getMatePostMain(Long teamId) {
+        LocalDateTime now = LocalDateTime.now();
+        List<Status> validStatuses = List.of(Status.OPEN, Status.CLOSED);
+
+        List<MatePost> mainPagePosts = mateRepository.findMainPagePosts(
+                teamId,
+                now,
+                validStatuses,
+                PageRequest.of(0, 3));
+
+        return mainPagePosts.stream()
+                .map(MatePostSummaryResponse::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
+++ b/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
@@ -3,12 +3,14 @@ package com.example.mate.domain.mate.controller;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
 import com.example.mate.domain.mate.dto.response.MatePostResponse;
+import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
 import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.mate.entity.Status;
 import com.example.mate.domain.mate.entity.TransportType;
 import com.example.mate.domain.mate.service.MateService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -19,8 +21,13 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -40,88 +47,161 @@ class MateControllerTest {
     @MockBean
     private MateService mateService;
 
-    private MatePostCreateRequest createMatePostRequest() {
-        return MatePostCreateRequest.builder()
-                .memberId(1L)
-                .teamId(1L)
-                .matchId(1L)
-                .title("테스트 제목")
-                .content("테스트 내용")
-                .age(Age.TWENTIES)
-                .maxParticipants(4)
-                .gender(Gender.FEMALE)
-                .transportType(TransportType.PUBLIC)
-                .build();
+    @Nested
+    @DisplayName("메이트 게시글 작성 테스트")
+    class CreateMatePost {
+
+        private MatePostCreateRequest createMatePostRequest() {
+            return MatePostCreateRequest.builder()
+                    .memberId(1L)
+                    .teamId(1L)
+                    .matchId(1L)
+                    .title("테스트 제목")
+                    .content("테스트 내용")
+                    .age(Age.TWENTIES)
+                    .maxParticipants(4)
+                    .gender(Gender.FEMALE)
+                    .transportType(TransportType.PUBLIC)
+                    .build();
+        }
+
+        private MatePostResponse createMatePostResponse() {
+            return MatePostResponse.builder()
+                    .id(1L)
+                    .status(Status.OPEN)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 작성 성공")
+        void createMatePost_success() throws Exception {
+            // given
+            MatePostCreateRequest request = createMatePostRequest();
+            MatePostResponse response = createMatePostResponse();
+
+            MockMultipartFile data = new MockMultipartFile(
+                    "data",
+                    "",
+                    MediaType.APPLICATION_JSON_VALUE,
+                    objectMapper.writeValueAsBytes(request)
+            );
+
+            MockMultipartFile file = new MockMultipartFile(
+                    "file",
+                    "test.jpg",
+                    MediaType.IMAGE_JPEG_VALUE,
+                    "test image content".getBytes()
+            );
+
+            given(mateService.createMatePost(any(MatePostCreateRequest.class), any()))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(multipart("/api/mates")
+                            .file(file)
+                            .file(data))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andExpect(jsonPath("$.data.status").value("OPEN"))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 작성 성공 - 이미지 없음")
+        void createMatePost_successWithoutImage() throws Exception {
+            // given
+            MatePostCreateRequest request = createMatePostRequest();
+            MatePostResponse response = createMatePostResponse();
+
+            MockMultipartFile data = new MockMultipartFile(
+                    "data",
+                    "",
+                    MediaType.APPLICATION_JSON_VALUE,
+                    objectMapper.writeValueAsBytes(request)
+            );
+
+            given(mateService.createMatePost(any(MatePostCreateRequest.class), any()))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(multipart("/api/mates")
+                            .file(data))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andExpect(jsonPath("$.data.status").value("OPEN"))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
     }
 
-    private MatePostResponse createMatePostResponse() {
-        return MatePostResponse.builder()
-                .id(1L)
-                .status(Status.OPEN)
-                .build();
-    }
+    @Nested
+    @DisplayName("메이트 게시글 조회 테스트")
+    class GetMatePosts {
+        private MatePostSummaryResponse createMatePostSummaryResponse() {
+            return MatePostSummaryResponse.builder()
+                    .imageUrl("test-image.jpg")
+                    .title("테스트 제목")
+                    .status(Status.OPEN)
+                    .rivalTeamName("두산")
+                    .rivalMatchTime(LocalDateTime.now().plusDays(1))
+                    .location("잠실야구장")
+                    .maxParticipants(4)
+                    .age(Age.TWENTIES)
+                    .gender(Gender.FEMALE)
+                    .transportType(TransportType.PUBLIC)
+                    .build();
+        }
 
-    @Test
-    @DisplayName("메이트 게시글 작성 성공")
-    void createMatePost_success() throws Exception {
-        // given
-        MatePostCreateRequest request = createMatePostRequest();
-        MatePostResponse response = createMatePostResponse();
+        @Test
+        @DisplayName("메인 페이지 메이트 게시글 목록 조회 성공 - 팀 ID 있음")
+        void getMatePostsMain_successWithTeamId() throws Exception {
+            // given
+            Long teamId = 1L;
+            List<MatePostSummaryResponse> responses = List.of(
+                    createMatePostSummaryResponse(),
+                    createMatePostSummaryResponse()
+            );
 
-        MockMultipartFile data = new MockMultipartFile(
-                "data",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsBytes(request)
-        );
+            given(mateService.getMatePostMain(eq(teamId)))
+                    .willReturn(responses);
 
-        MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "test.jpg",
-                MediaType.IMAGE_JPEG_VALUE,
-                "test image content".getBytes()
-        );
+            // when & then
+            mockMvc.perform(get("/api/mates/main")
+                            .param("teamId", String.valueOf(teamId))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
 
-        given(mateService.createMatePost(any(MatePostCreateRequest.class), any()))
-                .willReturn(response);
+        @Test
+        @DisplayName("메인 페이지 메이트 게시글 목록 조회 성공 - 팀 ID 없음")
+        void getMatePostsMain_successWithoutTeamId() throws Exception {
+            // given
+            List<MatePostSummaryResponse> responses = List.of(
+                    createMatePostSummaryResponse(),
+                    createMatePostSummaryResponse(),
+                    createMatePostSummaryResponse()
+            );
 
-        // when & then
-        mockMvc.perform(multipart("/api/mates")
-                        .file(file)
-                        .file(data))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.id").value(1L))
-                .andExpect(jsonPath("$.data.status").value("OPEN"))
-                .andExpect(jsonPath("$.code").value(200));
-    }
+            given(mateService.getMatePostMain(any()))
+                    .willReturn(responses);
 
-    @Test
-    @DisplayName("메이트 게시글 작성 성공 - 이미지 없음")
-    void createMatePost_successWithoutImage() throws Exception {
-        // given
-        MatePostCreateRequest request = createMatePostRequest();
-        MatePostResponse response = createMatePostResponse();
-
-        MockMultipartFile data = new MockMultipartFile(
-                "data",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsBytes(request)
-        );
-
-        given(mateService.createMatePost(any(MatePostCreateRequest.class), any()))
-                .willReturn(response);
-
-        // when & then
-        mockMvc.perform(multipart("/api/mates")
-                        .file(data))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.id").value(1L))
-                .andExpect(jsonPath("$.data.status").value("OPEN"))
-                .andExpect(jsonPath("$.code").value(200));
+            // when & then
+            mockMvc.perform(get("/api/mates/main")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(3))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
     }
 }

--- a/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
@@ -1,12 +1,5 @@
 package com.example.mate.domain.mate.integration;
 
-import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
@@ -19,18 +12,29 @@ import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -52,16 +56,37 @@ public class MateIntegrationTest {
     @Autowired
     private MateRepository mateRepository;
 
+    // 테스트에서 공통으로 사용할 객체들
     private Member testMember;
-    private Match testMatch;
+    private Match futureMatch;
+    private Match pastMatch;
+    private MatePost openPost;
+    private MatePost closedPost;
+    private MatePost completedPost;
 
     @BeforeEach
     void setUp() {
+        // 기존 데이터 정리
         mateRepository.deleteAll();
         matchRepository.deleteAll();
         memberRepository.deleteAll();
 
-        testMember = memberRepository.save(Member.builder()
+        // 테스트 멤버 생성
+        testMember = createTestMember();
+
+        // 테스트 매치 생성
+        futureMatch = createMatch(LocalDateTime.now().plusDays(2));
+        pastMatch = createMatch(LocalDateTime.now().minusDays(1));
+
+        // 테스트 게시글 생성
+        openPost = createMatePost(futureMatch, 1L, Status.OPEN);
+        closedPost = createMatePost(futureMatch, 1L, Status.CLOSED);
+        completedPost = createMatePost(pastMatch, 2L, Status.COMPLETE);
+    }
+
+    // 테스트 데이터 생성 헬퍼 메소드들
+    private Member createTestMember() {
+        return memberRepository.save(Member.builder()
                 .name("테스트유저")
                 .email("test@test.com")
                 .nickname("테스트계정")
@@ -70,20 +95,37 @@ public class MateIntegrationTest {
                 .age(25)
                 .manner(0.3f)
                 .build());
+    }
 
-        testMatch = matchRepository.save(Match.builder()
+    private Match createMatch(LocalDateTime matchTime) {
+        return matchRepository.save(Match.builder()
                 .homeTeamId(1L)
                 .awayTeamId(2L)
                 .stadiumId(1L)
                 .status(SCHEDULED)
-                .matchTime(LocalDateTime.now().plusDays(1))
+                .matchTime(matchTime)
+                .build());
+    }
+
+    private MatePost createMatePost(Match match, Long teamId, Status status) {
+        return mateRepository.save(MatePost.builder()
+                .author(testMember)
+                .teamId(teamId)
+                .match(match)
+                .title("테스트 제목")
+                .content("테스트 내용")
+                .status(status)
+                .maxParticipants(4)
+                .age(Age.TWENTIES)
+                .gender(Gender.FEMALE)
+                .transport(TransportType.PUBLIC)
                 .build());
     }
 
     private void assertMatePostEquals(MatePost actual, MatePostCreateRequest expected) {
         assertThat(actual.getAuthor()).isEqualTo(testMember);
         assertThat(actual.getTeamId()).isEqualTo(expected.getTeamId());
-        assertThat(actual.getMatch()).isEqualTo(testMatch);
+        assertThat(actual.getMatch().getId()).isEqualTo(expected.getMatchId());
         assertThat(actual.getTitle()).isEqualTo(expected.getTitle());
         assertThat(actual.getContent()).isEqualTo(expected.getContent());
         assertThat(actual.getStatus()).isEqualTo(Status.OPEN);
@@ -94,6 +136,8 @@ public class MateIntegrationTest {
     }
 
     private void performErrorTest(MockMultipartFile data, String errorCode, int expectedStatus) throws Exception {
+        mateRepository.deleteAll();
+
         mockMvc.perform(multipart("/api/mates")
                         .file(data))
                 .andExpect(status().is(expectedStatus))
@@ -105,123 +149,218 @@ public class MateIntegrationTest {
         assertThat(mateRepository.findAll()).isEmpty();
     }
 
-    @Test
-    @DisplayName("메이트 게시글 작성 성공")
-    void createMatePost_Success() throws Exception {
-        // given
-        MatePostCreateRequest request = MatePostCreateRequest.builder()
-                .memberId(testMember.getId())
-                .teamId(1L)
-                .matchId(testMatch.getId())
-                .title("통합 테스트 제목")
-                .content("통합 테스트 내용")
-                .age(Age.TWENTIES)
-                .maxParticipants(4)
-                .gender(Gender.FEMALE)
-                .transportType(TransportType.PUBLIC)
-                .build();
+    @Nested
+    @DisplayName("메이트 게시글 작성 테스트")
+    class CreateMatePost {
 
-        MockMultipartFile data = new MockMultipartFile(
-                "data",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsBytes(request)
-        );
+        @Test
+        @DisplayName("메이트 게시글 작성 성공")
+        void createMatePost_Success() throws Exception {
+            // given
+            MatePostCreateRequest request = MatePostCreateRequest.builder()
+                    .memberId(testMember.getId())
+                    .teamId(1L)
+                    .matchId(futureMatch.getId())
+                    .title("통합 테스트 제목")
+                    .content("통합 테스트 내용")
+                    .age(Age.TWENTIES)
+                    .maxParticipants(4)
+                    .gender(Gender.FEMALE)
+                    .transportType(TransportType.PUBLIC)
+                    .build();
 
-        // when & then
-        mockMvc.perform(multipart("/api/mates")
-                        .file(data))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.status").value("OPEN"))
-                .andExpect(jsonPath("$.code").value(200))
-                .andDo(print());
+            MockMultipartFile data = new MockMultipartFile(
+                    "data",
+                    "",
+                    MediaType.APPLICATION_JSON_VALUE,
+                    objectMapper.writeValueAsBytes(request)
+            );
 
-        // DB 검증
-        List<MatePost> savedPosts = mateRepository.findAll();
-        assertThat(savedPosts).hasSize(1);
-        assertMatePostEquals(savedPosts.get(0), request);
+            // when & then
+            mockMvc.perform(multipart("/api/mates")
+                            .file(data))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.status").value("OPEN"))
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andDo(print());
+
+            List<MatePost> savedPosts = mateRepository.findAll();
+            assertThat(savedPosts).hasSize(4); // 기존 3개 + 새로 생성된 1개
+            assertMatePostEquals(savedPosts.get(savedPosts.size() - 1), request);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원으로 메이트 게시글 작성 시 실패")
+        void createMatePost_WithInvalidMember() throws Exception {
+            MatePostCreateRequest request = MatePostCreateRequest.builder()
+                    .memberId(999L)
+                    .teamId(1L)
+                    .matchId(futureMatch.getId())
+                    .title("통합 테스트 제목")
+                    .content("통합 테스트 내용")
+                    .age(Age.TWENTIES)
+                    .maxParticipants(4)
+                    .gender(Gender.FEMALE)
+                    .transportType(TransportType.PUBLIC)
+                    .build();
+
+            MockMultipartFile data = new MockMultipartFile(
+                    "data",
+                    "",
+                    MediaType.APPLICATION_JSON_VALUE,
+                    objectMapper.writeValueAsBytes(request)
+            );
+
+            performErrorTest(data, "MEMBER_NOT_FOUND_BY_ID", 404);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 경기로 메이트 게시글 작성 시 실패")
+        void createMatePost_WithInvalidMatch() throws Exception {
+            MatePostCreateRequest request = MatePostCreateRequest.builder()
+                    .memberId(testMember.getId())
+                    .teamId(1L)
+                    .matchId(999L)
+                    .title("통합 테스트 제목")
+                    .content("통합 테스트 내용")
+                    .age(Age.TWENTIES)
+                    .maxParticipants(4)
+                    .gender(Gender.FEMALE)
+                    .transportType(TransportType.PUBLIC)
+                    .build();
+
+            MockMultipartFile data = new MockMultipartFile(
+                    "data",
+                    "",
+                    MediaType.APPLICATION_JSON_VALUE,
+                    objectMapper.writeValueAsBytes(request)
+            );
+
+            performErrorTest(data, "MATCH_NOT_FOUND_BY_ID", 404);
+        }
+
+        @Test
+        @DisplayName("잘못된 요청 데이터로 메이트 게시글 작성 시 실패")
+        void createMatePost_WithInvalidRequest() throws Exception {
+            MatePostCreateRequest request = MatePostCreateRequest.builder()
+                    .memberId(testMember.getId())
+                    .teamId(1L)
+                    .matchId(futureMatch.getId())
+                    .title("")
+                    .content("통합 테스트 내용")
+                    .age(Age.TWENTIES)
+                    .maxParticipants(11)
+                    .gender(null)
+                    .transportType(TransportType.PUBLIC)
+                    .build();
+
+            MockMultipartFile data = new MockMultipartFile(
+                    "data",
+                    "",
+                    MediaType.APPLICATION_JSON_VALUE,
+                    objectMapper.writeValueAsBytes(request)
+            );
+
+            performErrorTest(data, "INVALID_REQUEST", 400);
+        }
     }
 
+    @Nested
+    @DisplayName("메이트 게시글 조회 테스트")
+    class GetMatePosts {
 
-    @Test
-    @DisplayName("존재하지 않는 회원으로 메이트 게시글 작성 시 실패")
-    void createMatePost_WithInvalidMember() throws Exception {
-        // given
-        MatePostCreateRequest request = MatePostCreateRequest.builder()
-                .memberId(999L) // 존재하지 않는 회원 ID
-                .teamId(1L)
-                .matchId(testMatch.getId())
-                .title("통합 테스트 제목")
-                .content("통합 테스트 내용")
-                .age(Age.TWENTIES)
-                .maxParticipants(4)
-                .gender(Gender.FEMALE)
-                .transportType(TransportType.PUBLIC)
-                .build();
+        @Test
+        @DisplayName("메인 페이지 메이트 게시글 목록 조회 성공 - 팀 ID 있음")
+        void getMatePostsMain_WithTeamId_Success() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/mates/main")
+                            .param("teamId", "1")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    // 첫 번째 게시글 (OPEN) 검증
+                    .andExpect(jsonPath("$.data[0].title").value("테스트 제목"))
+                    .andExpect(jsonPath("$.data[0].status").value("OPEN"))
+                    .andExpect(jsonPath("$.data[0].maxParticipants").value(4))
+                    .andExpect(jsonPath("$.data[0].age").value("20대"))
+                    .andExpect(jsonPath("$.data[0].gender").value("여자만"))
+                    .andExpect(jsonPath("$.data[0].transportType").value("대중교통"))
+                    .andExpect(jsonPath("$.data[0].rivalTeamName").value("LG"))
+                    .andExpect(jsonPath("$.data[0].location").value("광주-기아 챔피언스 필드"))
+                    // 두 번째 게시글 (CLOSED) 검증
+                    .andExpect(jsonPath("$.data[1].title").value("테스트 제목"))
+                    .andExpect(jsonPath("$.data[1].status").value("CLOSED"))
+                    .andExpect(jsonPath("$.data[1].maxParticipants").value(4))
+                    .andExpect(jsonPath("$.data[1].age").value("20대"))
+                    .andExpect(jsonPath("$.data[1].gender").value("여자만"))
+                    .andExpect(jsonPath("$.data[1].transportType").value("대중교통"))
+                    .andExpect(jsonPath("$.data[1].rivalTeamName").value("LG"))
+                    .andExpect(jsonPath("$.data[1].location").value("광주-기아 챔피언스 필드"))
+                    .andDo(print());
+        }
 
-        MockMultipartFile data = new MockMultipartFile(
-                "data",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsBytes(request)
-        );
+        @Test
+        @DisplayName("메인 페이지 메이트 게시글 목록 조회 성공 - 팀 ID 없음")
+        void getMatePostsMain_WithoutTeamId_Success() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/mates/main")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    // 첫 번째 게시글 (OPEN) 검증
+                    .andExpect(jsonPath("$.data[0].title").value("테스트 제목"))
+                    .andExpect(jsonPath("$.data[0].status").value("OPEN"))
+                    .andExpect(jsonPath("$.data[0].maxParticipants").value(4))
+                    .andExpect(jsonPath("$.data[0].age").value("20대"))
+                    .andExpect(jsonPath("$.data[0].gender").value("여자만"))
+                    .andExpect(jsonPath("$.data[0].transportType").value("대중교통"))
+                    .andExpect(jsonPath("$.data[0].rivalTeamName").value("LG"))
+                    .andExpect(jsonPath("$.data[0].location").value("광주-기아 챔피언스 필드"))
+                    // 두 번째 게시글 (CLOSED) 검증
+                    .andExpect(jsonPath("$.data[1].title").value("테스트 제목"))
+                    .andExpect(jsonPath("$.data[1].status").value("CLOSED"))
+                    .andExpect(jsonPath("$.data[1].maxParticipants").value(4))
+                    .andExpect(jsonPath("$.data[1].age").value("20대"))
+                    .andExpect(jsonPath("$.data[1].gender").value("여자만"))
+                    .andExpect(jsonPath("$.data[1].transportType").value("대중교통"))
+                    .andExpect(jsonPath("$.data[1].rivalTeamName").value("LG"))
+                    .andExpect(jsonPath("$.data[1].location").value("광주-기아 챔피언스 필드"))
+                    .andDo(print());
+        }
 
-        // when & then
-        performErrorTest(data, "MEMBER_NOT_FOUND_BY_ID", 404);
-    }
+        @Test
+        @DisplayName("과거 경기 또는 완료된 게시글은 조회되지 않음")
+        void getMatePostsMain_ExcludePastAndCompleted() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/mates/main")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].status").value("OPEN"))
+                    .andExpect(jsonPath("$.data[1].status").value("CLOSED"))
+                    .andDo(print());
 
-    @Test
-    @DisplayName("존재하지 않는 경기로 메이트 게시글 작성 시 실패")
-    void createMatePost_WithInvalidMatch() throws Exception {
-        // given
-        MatePostCreateRequest request = MatePostCreateRequest.builder()
-                .memberId(testMember.getId())
-                .teamId(1L)
-                .matchId(999L) // 존재하지 않는 경기 ID
-                .title("통합 테스트 제목")
-                .content("통합 테스트 내용")
-                .age(Age.TWENTIES)
-                .maxParticipants(4)
-                .gender(Gender.FEMALE)
-                .transportType(TransportType.PUBLIC)
-                .build();
+            // DB 검증
+            List<MatePost> posts = mateRepository.findMainPagePosts(
+                    null,
+                    LocalDateTime.now(),
+                    List.of(Status.OPEN, Status.CLOSED),
+                    PageRequest.of(0, 3)
+            );
 
-        MockMultipartFile data = new MockMultipartFile(
-                "data",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsBytes(request)
-        );
-
-        // when & then
-        performErrorTest(data, "MATCH_NOT_FOUND_BY_ID", 404);
-    }
-
-    @Test
-    @DisplayName("잘못된 요청 데이터로 메이트 게시글 작성 시 실패")
-    void createMatePost_WithInvalidRequest() throws Exception {
-        // given
-        MatePostCreateRequest request = MatePostCreateRequest.builder()
-                .memberId(testMember.getId())
-                .teamId(1L)
-                .matchId(testMatch.getId())
-                .title("") // 빈 제목
-                .content("통합 테스트 내용")
-                .age(Age.TWENTIES)
-                .maxParticipants(11) // 최대 인원 초과
-                .gender(null)
-                .transportType(TransportType.PUBLIC)
-                .build();
-
-        MockMultipartFile data = new MockMultipartFile(
-                "data",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsBytes(request)
-        );
-
-        // when & then
-        performErrorTest(data, "INVALID_REQUEST", 400);
+            assertThat(posts).hasSize(2)
+                    .doesNotContain(completedPost)
+                    .extracting(MatePost::getMatch)
+                    .doesNotContain(pastMatch);
+        }
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: "jdbc:h2:mem:test-mate;MODE=MySQL;"
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+
+    hibernate.ddl-auto: create
+
+    properties.hibernate:
+      format_sql: true
+      highlight_sql: true
+      use_sql_comments: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,20 +1,5 @@
 spring:
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: "jdbc:h2:mem:test-mate;MODE=MySQL;"
-    username: sa
-    password:
-
-  jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-
-    hibernate.ddl-auto: create
-
-    properties.hibernate:
-      format_sql: true
-      highlight_sql: true
-      use_sql_comments: true
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+  profiles:
+    group:
+      test: test, common
+    active: test


### PR DESCRIPTION
## 💡 작업 내용
- [x] 메인페이지에서의 메이트 게시글 조회 API 구현
- [x] 팀 필터링 기능 구현 (특정 팀 또는 전체 KBO 팀)
- [x] 미래 경기 및 유효한 모집 상태 필터링 구현
- [x] 경기 시간 기준 가장 가까운 3개 게시글 조회 기능 구현
- [x]  테스트 환경 설정 파일 구조 개선

## 💡 자세한 설명
### API 구현 내용
1. 메이트 게시글 조회 엔드포인트 구현
   - GET `/api/mates/main`
   - Optional QueryParam: `teamId`

2. 비즈니스 로직 구현
   - 팀 존재 여부 검증
   - 현재 시점 이후 경기만 필터링
   - 모집중/모집완료 상태의 게시글만 조회
   - 경기 시간 기준 정렬 및 최대 3개 제한

3. 응답 데이터 구조화
   - 게시글 요약 정보 (MatePostSummaryResponse)
   - 경기 관련 정보 (상대팀, 시간, 장소)
   - 모집 조건 정보 (인원, 연령대, 성별, 교통수단)

### 테스트 환경 설정 개선
1. 테스트 설정 파일 구조 변경
   - test/resources/application.yml
     ```yaml
     spring:
       profiles:
         group:
           test: test, common
         active: test
     ```
   - test/resources/application-test.yml
     ```yaml
     spring:
       datasource:
         driver-class-name: org.h2.Driver
         url: "jdbc:h2:mem:test-mate;MODE=MySQL;"
         username: sa
         password:
       # ... [나머지 설정]
     ```

2. 개선 사항
   - 프로파일 그룹화를 통해 test와 common 프로파일을 함께 활성화
   - application-common.yml의 공통 설정(JWT 시크릿키, 공공 API 키 등)을 테스트 환경에서도 재사용 가능
   - 테스트 환경별 설정과 공통 설정의 명확한 분리

### 설정 변경 배경
- JWT 시크릿키, 공공 API 키 등 공통 설정의 재사용성 확보
- 테스트 환경에서도 실제 환경과 동일한 설정 구조 유지
- 환경별 설정의 명확한 분리를 통한 유지보수성 향상


## 📗 참고 자료

## 📢 리뷰 요구 사항

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
