### PR TITLE
MATE-46 : [FEAT] 굿즈거래 판매글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
+++ b/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
@@ -66,6 +66,17 @@ public class GoodsController {
     }
 
     /*
+    굿즈 거래하기 상세 페이지 : 굿즈 거래글 삭제
+    TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
+    "/api/goods/{goodsPostId}" 로 변경 예정
+     */
+    @DeleteMapping("/{memberId}/post/{goodsPostId}")
+    public ResponseEntity<Void> deleteGoodsPost(@PathVariable Long memberId, @PathVariable Long goodsPostId) {
+        goodsService.deleteGoodsPost(memberId, goodsPostId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /*
     메인 페이지 : 굿즈 거래글 요약 4개 리스트 조회
     테스트 용도로, 가상의 동일한 거래글 데이터 4개를 생성
      */
@@ -110,12 +121,6 @@ public class GoodsController {
     @GetMapping("/{goodsPostId}")
     public ResponseEntity<GoodsPostResponse> getGoodsPost(@PathVariable Long goodsPostId) {
         return ResponseEntity.ok(GoodsPostResponse.createResponse(goodsPostId));
-    }
-
-    // 굿즈 거래하기 상세 페이지 : 굿즈 거래글 삭제
-    @DeleteMapping("/{goodsPostId}")
-    public ResponseEntity<Void> deleteGoodsPost(@PathVariable Long goodsPostId) {
-        return ResponseEntity.noContent().build();
     }
 
     // 굿즈 채팅창 - 알럿창 : 굿즈 거래 완료

--- a/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
@@ -65,6 +65,16 @@ public class GoodsService {
         return GoodsPostResponse.of(goodsPost);
     }
 
+    public void deleteGoodsPost(Long memberId, Long goodsPostId) {
+        // 사용자, 판매글 정보 유효성 검증
+        Member seller = getSellerAndValidate(memberId);
+        GoodsPost goodsPost = getGoodsPostAndValidate(seller, goodsPostId);
+
+        // 업로된 이미지 파일 삭제
+        deleteExistingImages(goodsPostId);
+        goodsPostRepository.delete(goodsPost);
+    }
+
     private Member getSellerAndValidate(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(()
                 -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));

--- a/src/test/java/com/example/mate/domain/goods/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goods/controller/GoodsControllerTest.java
@@ -4,7 +4,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -143,5 +145,23 @@ class GoodsControllerTest {
                 .andExpect(jsonPath("$.code").value(200));
 
         verify(goodsService).updateGoodsPost(eq(memberId), eq(goodsPostId), any(GoodsPostRequest.class), anyList());
+    }
+
+    @Test
+    @DisplayName("굿즈 판매글 삭제 - API 테스트")
+    void delete_goods_post_success() throws Exception {
+        // given
+        Long memberId = 1L;
+        Long goodsPostId = 1L;
+
+        willDoNothing().given(goodsService).deleteGoodsPost(memberId, goodsPostId);
+
+        // when & then
+        mockMvc.perform(delete("/api/goods/{memberId}/post/{goodsPostId}", memberId, goodsPostId))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+
+
+        verify(goodsService).deleteGoodsPost(memberId, goodsPostId);
     }
 }

--- a/src/test/java/com/example/mate/domain/goods/integration/GoodsIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/goods/integration/GoodsIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.example.mate.domain.goods.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -15,12 +16,14 @@ import com.example.mate.domain.goods.entity.Category;
 import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.GoodsPostImage;
 import com.example.mate.domain.goods.entity.Status;
+import com.example.mate.domain.goods.repository.GoodsPostImageRepository;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,8 +44,9 @@ public class GoodsIntegrationTest {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private MemberRepository memberRepository;
-    @Autowired private GoodsPostRepository goodsPostRepository;@Autowired
-    private ObjectMapper objectMapper;
+    @Autowired private GoodsPostRepository goodsPostRepository;
+    @Autowired private GoodsPostImageRepository imageRepository;
+    @Autowired private ObjectMapper objectMapper;
 
     private Member member;
 
@@ -123,6 +127,26 @@ public class GoodsIntegrationTest {
         // then
         assertApiResponse(apiResponse, goodsPostRequest, files);
         assertActualData(apiResponse.getData().getId(), goodsPostRequest, files);
+    }
+
+    @Test
+    @DisplayName("굿즈거래 판매글 삭제 통합 테스트")
+    void delete_goods_post_integration_test() throws Exception {
+        // given
+        Long memberId = member.getId();
+        Long goodsPostId = goodsPost.getId();
+
+        // when
+        mockMvc.perform(delete("/api/goods/{memberId}/post/{goodsPostId}", memberId, goodsPostId))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+
+        // then
+        Optional<GoodsPost> goodsPost = goodsPostRepository.findById(goodsPostId);
+        assertThat(goodsPost).isEmpty();
+
+        List<String> imageUrls = imageRepository.getImageUrlsByPostId(goodsPostId);
+        assertThat(imageUrls).isEmpty();
     }
 
     // ApiResponse 검증


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 판매글 삭제 기능 구현
- [x] 테스트 코드 작성

## 💡 자세한 설명

#### `DELETE /api/goods/{memberId}/post/{postId}`

- `GoodsPost` 객체를 먼저 삭제하여 영속성 전이를 활용해 `GoodsPostImage`도 함께 삭제하려 했으나, 이미지 한 개당 추가적인 쿼리가 발생하는 문제를 확인
-   따라서 `deleteAllByPostId`메서드를 사용해 이미지 삭제를 별도로 처리하였습니다.
- `ApiResponse<T>` 클래스를 통해  `204 noContent` 를 반환하기 어려워 삭제 반환은 `ResponseEntity.noContent().build();` 를 사용하여 처리함

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
삭제 기능이라서 중요한 기능은 없으니 편하게 봐주세요!

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?