### PR TITLE
MATE-20 : [FEAT] 다른 회원 프로필 조회 기능 구현

### DIFF
--- a/http/Member.http
+++ b/http/Member.http
@@ -1,0 +1,6 @@
+## [Member API]
+
+
+### 다른 회원 프로필 조회
+## TODO : 리뷰 기능 구현 시 리뷰 기록 추가
+GET http://localhost:5173/api/members/1

--- a/src/main/java/com/example/mate/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/mate/domain/auth/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.example.mate.domain.auth.controller;
 import com.example.mate.common.jwt.JwtToken;
 import com.example.mate.domain.auth.dto.response.LoginResponse;
 import com.example.mate.domain.auth.service.NaverAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -18,6 +20,7 @@ import org.springframework.web.servlet.view.RedirectView;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@Tag(name = "Auth Controller", description = "소셜 로그인 관련 API")
 public class AuthController {
 
     private final NaverAuthService naverAuthService;
@@ -25,6 +28,7 @@ public class AuthController {
     /**
      * 네이버 소셜 로그인 연결 : 네이버 인증 페이지로의 리다이렉트
      */
+    @Operation(summary = "네이버 소셜 인증 페이지 리다이렉트")
     @GetMapping("/connect/naver")
     public RedirectView connectNaver() {
         return new RedirectView(naverAuthService.getAuthUrl());
@@ -33,6 +37,7 @@ public class AuthController {
     /**
      * 네이버 소셜 로그인 콜백 : 인증 페이지에서 로그인한 뒤, 네이버 사용자 정보와 로그인 토큰을 함께 반환
      */
+    @Operation(summary = "네이버 소셜 로그인 콜백")
     @GetMapping("/login/naver")
     public ResponseEntity<LoginResponse> loginByNaver(@RequestParam @NotEmpty String code,
                                                       @RequestParam String state) {

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
@@ -1,7 +1,12 @@
 package com.example.mate.domain.goods.repository;
 
 import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long> {
+
+    @Query("SELECT COUNT(gp) FROM GoodsPost gp WHERE gp.seller.id = :memberId AND gp.status = :status")
+    int countGoodsPostsBySellerIdAndStatus(Long memberId, Status status);
 }

--- a/src/main/java/com/example/mate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/MemberController.java
@@ -1,10 +1,15 @@
 package com.example.mate.domain.member.controller;
 
+import com.example.mate.common.response.ApiResponse;
 import com.example.mate.domain.member.dto.request.JoinRequest;
 import com.example.mate.domain.member.dto.request.MemberInfoUpdateRequest;
 import com.example.mate.domain.member.dto.response.JoinResponse;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
 import com.example.mate.domain.member.dto.response.MyProfileResponse;
+import com.example.mate.domain.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,14 +23,17 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/members")
 public class MemberController {
 
+    private final MemberService memberService;
+
     /*
-    TODO : 2024/11/23 - 소셜 회원가입 후, 자체 회원가입 기능
-    1. JwtToken 을 통해 사용자 정보 조회
-    2. nickname, myTeam 정보 저장
-    */
+        TODO : 2024/11/23 - 소셜 회원가입 후, 자체 회원가입 기능
+        1. JwtToken 을 통해 사용자 정보 조회
+        2. nickname, myTeam 정보 저장
+        */
     @PostMapping("/join")
     public ResponseEntity<JoinResponse> join(
             @RequestBody JoinRequest joinRequest
@@ -65,25 +73,11 @@ public class MemberController {
         return ResponseEntity.ok(myProfileResponse);
     }
 
-    /*
-    TODO : 2024/11/25 - 다른 회원 프로필 조회
-    1. memberId 을 통해 사용자 정보 조회
-    */
+    @Operation(summary = "다른 회원 프로필 조회")
     @GetMapping("/{memberId}")
-    public ResponseEntity<MemberProfileResponse> findMemberInfo(@PathVariable Long memberId) {
-        MemberProfileResponse memberProfileResponse = MemberProfileResponse.builder()
-                .nickname("삼성빠돌이")
-                .imageUrl("default.jpg")
-                .teamName("삼성")
-                .manner(0.3f)
-                .aboutMe("삼성을 사랑하는 삼성빠돌이입니다!")
-                .followingCount(10)
-                .followerCount(20)
-                .reviewsCount(10)
-                .goodsSoldCount(20)
-                .build();
-
-        return ResponseEntity.ok(memberProfileResponse);
+    public ResponseEntity<ApiResponse<MemberProfileResponse>> findMemberInfo(
+            @Parameter(description = "회원 ID") @PathVariable Long memberId) {
+        return ResponseEntity.ok(ApiResponse.success(memberService.getMemberProfile(memberId)));
     }
 
     /*

--- a/src/main/java/com/example/mate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.example.mate.domain.member.dto.response.MyProfileResponse;
 import com.example.mate.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
+@Tag(name = "Member Controller", description = "회원 관련 API")
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/example/mate/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MemberProfileResponse.java
@@ -1,5 +1,7 @@
 package com.example.mate.domain.member.dto.response;
 
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,4 +22,18 @@ public class MemberProfileResponse {
     private Integer followerCount;
     private Integer reviewsCount;
     private Integer goodsSoldCount;
+
+    // TODO : rewviewsCount, goodsSoldCount 추가
+    public static MemberProfileResponse of(Member member, int followingCount, int followerCount, int goodsSoldCount) {
+        return MemberProfileResponse.builder()
+                .nickname(member.getNickname())
+                .imageUrl(member.getImageUrl())
+                .teamName(TeamInfo.getById(member.getTeamId()).shortName)
+                .manner(member.getManner())
+                .aboutMe(member.getAboutMe())
+                .followingCount(followingCount)
+                .followerCount(followerCount)
+                .goodsSoldCount(goodsSoldCount)
+                .build();
+    }
 }

--- a/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
+++ b/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
@@ -1,0 +1,21 @@
+package com.example.mate.domain.member.repository;
+
+
+import com.example.mate.domain.member.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    // 특정 회원의 팔로잉 수 카운트
+    @Query("SELECT COUNT(f) FROM Follow f WHERE f.follower.id = :followerId")
+    int countByFollowerId(@Param("followerId") Long followerId);
+
+    // 특정 회원의 팔로워 수 카운트
+    @Query("SELECT COUNT(f) FROM Follow f WHERE f.following.id = :followingId")
+    int countByFollowingId(@Param("followingId") Long followingId);
+
+    // 특정 회원에 대한 팔로잉 여부 판단
+    boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
+}

--- a/src/main/java/com/example/mate/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/mate/domain/member/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.example.mate.domain.member.repository;
 
 import com.example.mate.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/src/main/java/com/example/mate/domain/member/service/FollowService.java
+++ b/src/main/java/com/example/mate/domain/member/service/FollowService.java
@@ -1,0 +1,22 @@
+package com.example.mate.domain.member.service;
+
+import com.example.mate.domain.member.repository.FollowRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final FollowRepository followRepository;
+
+    // 특정 회원의 팔로잉 수 카운트
+    public int getFollowCount(Long memberId) {
+        return followRepository.countByFollowerId(memberId);
+    }
+
+    // 특정 회원의 팔로워 수 카운트
+    public int getFollowerCount(Long memberId) {
+        return followRepository.countByFollowingId(memberId);
+    }
+}

--- a/src/main/java/com/example/mate/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/mate/domain/member/service/MemberService.java
@@ -1,0 +1,34 @@
+package com.example.mate.domain.member.service;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.domain.goods.entity.Status;
+import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.member.dto.response.MemberProfileResponse;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final FollowService followService;
+    private final GoodsPostRepository goodsPostRepository;
+
+    // 다른 회원 프로필 조회
+    public MemberProfileResponse getMemberProfile(Long memberId) {
+        Member member = findByMemberId(memberId);
+        int followCount = followService.getFollowCount(memberId);
+        int followerCount = followService.getFollowerCount(memberId);
+        int goodsSoldCount = goodsPostRepository.countGoodsPostsBySellerIdAndStatus(memberId, Status.CLOSED);
+        return MemberProfileResponse.of(member, followCount, followerCount, goodsSoldCount);
+    }
+
+    private Member findByMemberId(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
+    }
+}

--- a/src/main/java/com/example/mate/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/mate/domain/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
 import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.FollowRepository;
 import com.example.mate.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,14 +16,14 @@ import org.springframework.stereotype.Service;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final FollowService followService;
+    private final FollowRepository followRepository;
     private final GoodsPostRepository goodsPostRepository;
 
     // 다른 회원 프로필 조회
     public MemberProfileResponse getMemberProfile(Long memberId) {
         Member member = findByMemberId(memberId);
-        int followCount = followService.getFollowCount(memberId);
-        int followerCount = followService.getFollowerCount(memberId);
+        int followCount = followRepository.countByFollowerId(memberId);
+        int followerCount = followRepository.countByFollowingId(memberId);
         int goodsSoldCount = goodsPostRepository.countGoodsPostsBySellerIdAndStatus(memberId, Status.CLOSED);
         return MemberProfileResponse.of(member, followCount, followerCount, goodsSoldCount);
     }

--- a/src/test/java/com/example/mate/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,73 @@
+package com.example.mate.domain.member.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.mate.domain.member.dto.response.MemberProfileResponse;
+import com.example.mate.domain.member.service.MemberService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MemberController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberService memberService;
+
+    private MemberProfileResponse createMemberProfileResponse() {
+        return MemberProfileResponse.builder()
+                .nickname("tester")
+                .imageUrl("default.jpg")
+                .teamName("KIA")
+                .manner(4.5f)
+                .aboutMe("테스터입니다.")
+                .followingCount(10)
+                .followerCount(20)
+                .reviewsCount(5)
+                .goodsSoldCount(15)
+                .build();
+    }
+
+    @Test
+    @DisplayName("다른 회원 프로필 조회")
+    void find_member_info_success() throws Exception {
+        // given
+        Long memberId = 1L;
+        MemberProfileResponse response = createMemberProfileResponse();
+
+        given(memberService.getMemberProfile(memberId)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/members/{memberId}", memberId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.nickname").value("tester"))
+                .andExpect(jsonPath("$.data.imageUrl").value("default.jpg"))
+                .andExpect(jsonPath("$.data.teamName").value("KIA"))
+                .andExpect(jsonPath("$.data.manner").value(4.5))
+                .andExpect(jsonPath("$.data.aboutMe").value("테스터입니다."))
+                .andExpect(jsonPath("$.data.followingCount").value(10))
+                .andExpect(jsonPath("$.data.followerCount").value(20))
+                .andExpect(jsonPath("$.data.reviewsCount").value(5))
+                .andExpect(jsonPath("$.data.goodsSoldCount").value(15));
+    }
+}

--- a/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.example.mate.domain.member.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import com.example.mate.domain.member.service.MemberService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class MemberIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(MemberIntegrationTest.class);
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MemberService memberService;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAll();
+
+        // 데이터베이스에 테스트 회원을 삽입
+        member = Member.builder()
+                .name("홍길동")
+                .nickname("tester")
+                .email("tester@example.com")
+                .imageUrl("default.jpg")
+                .age(20)
+                .gender(Gender.MALE)
+                .teamId(1L)
+                .manner(0.300F)
+                .aboutMe("tester입니다.")
+                .build();
+        memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("다른 회원 프로필 조회 - 성공")
+    void find_member_info_success() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/members/" + member.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.nickname").value("tester"))
+                .andExpect(jsonPath("$.data.imageUrl").value("default.jpg"))
+                .andExpect(jsonPath("$.data.teamName").value("KIA"))
+                .andExpect(jsonPath("$.data.aboutMe").value("tester입니다."))
+                .andExpect(jsonPath("$.data.manner").value(0.300F))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("다른 회원 프로필 조회 - 실패 (해당 회원 없음)")
+    void find_member_info_fail_member_not_found() throws Exception {
+        // given
+        long invalidMemberId = member.getId() + 999L;
+
+        // when & then
+        mockMvc.perform(get("/api/members/" + invalidMemberId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("ERROR"))
+                .andExpect(jsonPath("$.message").value("해당 ID의 회원 정보를 찾을 수 없습니다"))
+                .andExpect(jsonPath("$.code").value(404))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
@@ -11,6 +11,7 @@ import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
 import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.FollowRepository;
 import com.example.mate.domain.member.repository.MemberRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +35,7 @@ class MemberServiceTest {
     private GoodsPostRepository goodsPostRepository;
 
     @Mock
-    private FollowService followService;
+    private FollowRepository followRepository;
 
     private Member member;
     private GoodsPost goodsPost;
@@ -73,8 +74,8 @@ class MemberServiceTest {
         int goodsSoldCount = 1;
 
         given(memberRepository.findById(memberId)).willReturn(java.util.Optional.of(member));
-        given(followService.getFollowCount(memberId)).willReturn(followCount);
-        given(followService.getFollowerCount(memberId)).willReturn(followerCount);
+        given(followRepository.countByFollowerId(memberId)).willReturn(followCount);
+        given(followRepository.countByFollowingId(memberId)).willReturn(followerCount);
         given(goodsPostRepository.countGoodsPostsBySellerIdAndStatus(memberId, Status.CLOSED)).
                 willReturn(goodsSoldCount);
 

--- a/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,105 @@
+package com.example.mate.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.Status;
+import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.member.dto.response.MemberProfileResponse;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private GoodsPostRepository goodsPostRepository;
+
+    @Mock
+    private FollowService followService;
+
+    private Member member;
+    private GoodsPost goodsPost;
+
+    @BeforeEach
+    void setUp() {
+        createTestMember();
+        createTestGoodsPost();
+    }
+
+    private void createTestMember() {
+        member = Member.builder()
+                .id(1L)
+                .name("홍길동")
+                .teamId(1L)
+                .email("test@example.com")
+                .nickname("tester")
+                .build();
+    }
+
+    private void createTestGoodsPost() {
+        goodsPost = GoodsPost.builder()
+                .id(1L)
+                .seller(member)
+                .status(Status.CLOSED)
+                .build();
+    }
+
+    @Test
+    @DisplayName("다른 회원 프로필 조회 - 성공")
+    void get_member_profile_success() {
+        // given
+        Long memberId = 1L;
+        int followCount = 10;
+        int followerCount = 20;
+        int goodsSoldCount = 1;
+
+        given(memberRepository.findById(memberId)).willReturn(java.util.Optional.of(member));
+        given(followService.getFollowCount(memberId)).willReturn(followCount);
+        given(followService.getFollowerCount(memberId)).willReturn(followerCount);
+        given(goodsPostRepository.countGoodsPostsBySellerIdAndStatus(memberId, Status.CLOSED)).
+                willReturn(goodsSoldCount);
+
+        // when
+        MemberProfileResponse result = memberService.getMemberProfile(memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getNickname()).isEqualTo(member.getNickname());
+        assertThat(result.getFollowingCount()).isEqualTo(followCount);
+        assertThat(result.getFollowerCount()).isEqualTo(followerCount);
+        assertThat(result.getGoodsSoldCount()).isEqualTo(goodsSoldCount);
+    }
+
+    @Test
+    @DisplayName("회원 프로필 조회 - 실패 (해당 회원 없음)")
+    void get_member_profile_fail_member_id_not_found() {
+        // given
+        Long memberId = 1L;
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.getMemberProfile(memberId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage());
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 다른 회원 프로필 조회 기능 구현
- [x] 테스트 코드 작성

## 💡 자세한 설명

#### `GET /api/members/{memberId}`

- 다른 회원 프로필 화면에 노출되는 닉네임, 사진, 팀 이름, 매너, 소개글, 팔로우 수, 팔로워 수, 굿즈판매 수 표기
- 굿즈거래 리뷰, 메이트 리뷰 수는 리뷰 기능 완료 시 추가

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?