### PR TITLE
MATE-26 : [FEAT] 메이트 페이지 게시글 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,12 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.assertj:assertj-core:3.24.2'
+
+    // querydsl for spring boot 3.x
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/mate/common/config/QueryDslConfig.java
+++ b/src/main/java/com/example/mate/common/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.example.mate.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -56,7 +56,10 @@ public enum ErrorCode {
     INVALID_GENDER_VALUE(HttpStatus.BAD_REQUEST, "GENDER001", "유효하지 않은 성별 값입니다."),
 
     // TransportType
-    INVALID_TRANSPORT_TYPE_VALUE(HttpStatus.BAD_REQUEST, "TRANSPORT001", "유효하지 않은 교통 수단 값입니다.");
+    INVALID_TRANSPORT_TYPE_VALUE(HttpStatus.BAD_REQUEST, "TRANSPORT001", "유효하지 않은 교통 수단 값입니다."),
+
+    // SortType
+    INVALID_SORT_TYPE_VALUE(HttpStatus.BAD_REQUEST, "ST001", "유효하지 않은 정렬 기준 값입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/mate/domain/constant/Gender.java
+++ b/src/main/java/com/example/mate/domain/constant/Gender.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 @Getter
 public enum Gender {
     ANY("상관없음"),
-    MALE("남자만"),
-    FEMALE("여자만");
+    MALE("남자"),
+    FEMALE("여자");
 
     @JsonValue
     private final String value;

--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -9,6 +9,7 @@ import com.example.mate.domain.mate.dto.response.MatePostResponse;
 import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
 import com.example.mate.domain.mate.dto.response.MateReviewCreateResponse;
 import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.domain.mate.entity.SortType;
 import com.example.mate.domain.mate.entity.Status;
 import com.example.mate.domain.mate.entity.TransportType;
 import com.example.mate.domain.mate.service.MateService;
@@ -44,41 +45,31 @@ public class MateController {
 
     // 메이트 게시글 목록 조회(메인 페이지)
     @GetMapping(value = "/main", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ApiResponse<List<MatePostSummaryResponse>>> getMatePostsMain(@RequestParam(required = false) Long teamId) {
-        List<MatePostSummaryResponse> matePostMain = mateService.getMatePostMain(teamId);
+    public ResponseEntity<ApiResponse<List<MatePostSummaryResponse>>> getMainPagePosts(@RequestParam(required = false) Long teamId) {
+        List<MatePostSummaryResponse> matePostMain = mateService.getMainPagePosts(teamId);
         return ResponseEntity.ok(ApiResponse.success(matePostMain));
     }
 
     // 메이트 게시글 목록 조회(메이트 페이지)
-    // 필터링 검색을 위한 동적 쿼리 적용 필요
-    @GetMapping
-    public ResponseEntity<PageResponse<MatePostSummaryResponse>> getMatePosts(@RequestParam Long teamId,
-                                                                              @PageableDefault(size = 10) Pageable pageable,
-                                                                              @ModelAttribute MatePostSearchRequest searchRequest) {
-        List<MatePostSummaryResponse> posts = List.of(
-                MatePostSummaryResponse.builder()
-                        .imageUrl("imageUrl")
-                        .title("12월 경기 메이트 찾아요")
-                        .status(Status.OPEN)
-                        .rivalTeamName("삼성")
-                        .rivalMatchTime(LocalDateTime.now())
-                        .maxParticipants(10)
-                        .age(Age.TWENTIES)
-                        .gender(Gender.MALE)
-                        .transportType(TransportType.PUBLIC)
-                        .build()
-        );
-
-        PageResponse<MatePostSummaryResponse> pageResponse = PageResponse.<MatePostSummaryResponse>builder()
-                .content(posts)
-                .totalPages(5)          // 총 페이지 수
-                .totalElements(42L)     // 총 게시글 수
-                .hasNext(true)          // 다음 페이지 존재 여부
-                .pageNumber(0)          // 현재 페이지 번호 (0부터 시작)
-                .pageSize(10)           // 페이지 크기
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<PageResponse<MatePostSummaryResponse>>> getMatePagePosts(@RequestParam(required = false) Long teamId,
+                                                                                               @RequestParam(required = false) String sortType,
+                                                                                               @RequestParam(required = false) String age,
+                                                                                               @RequestParam(required = false) String gender,
+                                                                                               @RequestParam(required = false) Integer maxParticipants,
+                                                                                               @RequestParam(required = false) String transportType,
+                                                                                               @PageableDefault(size = 10) Pageable pageable) {
+        MatePostSearchRequest request = MatePostSearchRequest.builder()
+                .teamId(teamId)
+                .sortType(sortType != null ? SortType.from(sortType) : null)
+                .age(age != null ? Age.from(age) : null)
+                .gender(gender != null ? Gender.from(gender) : null)
+                .maxParticipants(maxParticipants)
+                .transportType(transportType != null ? TransportType.from(transportType) : null)
                 .build();
 
-        return ResponseEntity.ok(pageResponse);
+        PageResponse<MatePostSummaryResponse> response = mateService.getMatePagePosts(request, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 메이트 게시글 상세 조회

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MatePostSearchRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MatePostSearchRequest.java
@@ -1,14 +1,40 @@
 package com.example.mate.domain.mate.dto.request;
 
-import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.common.utils.validator.ValidEnum;
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.domain.mate.entity.SortType;
 import com.example.mate.domain.mate.entity.TransportType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MatePostSearchRequest {
+
+    @Min(value = 0, message = "팀 ID는 0 이상이어야 합니다.")
+    @Max(value = 10, message = "팀 ID는 10 이하이어야 합니다.")
+    private Long teamId;
+
+    @ValidEnum(message = "정렬 기준 입력 값이 잘못되었습니다.", enumClass = SortType.class)
+    private SortType sortType;
+
+    @ValidEnum(message = "연령대의 입력 값이 잘못되었습니다.", enumClass = Age.class)
     private Age age;
+
+    @ValidEnum(message = "성별의 입력 값이 잘못되었습니다.", enumClass = Gender.class)
     private Gender gender;
+
+    @Min(value = 2, message = "최대 참여 인원은 2명 이상이어야 합니다.")
+    @Max(value = 10, message = "최대 참여 인원은 10명 이하여야 합니다.")
     private Integer maxParticipants;
+
+    @ValidEnum(message = "이동수단의 입력 값이 잘못되었습니다.", enumClass = TransportType.class)
     private TransportType transportType;
 }

--- a/src/main/java/com/example/mate/domain/mate/entity/SortType.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/SortType.java
@@ -1,0 +1,28 @@
+package com.example.mate.domain.mate.entity;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+@Getter
+public enum SortType {
+    LATEST("최근 작성일 순"),
+    MATCH_TIME("가까운 경기 순"),
+    MANNER("매너타율 순");
+
+    @JsonValue
+    private final String value;
+
+    SortType(String value) {this.value = value;}
+
+    @JsonCreator
+    public static SortType from(String value) {
+        for (SortType type : SortType.values()) {
+            if (type.value.equals(value))
+                return type;
+        }
+        throw new CustomException(ErrorCode.INVALID_SORT_TYPE_VALUE);
+    }
+}

--- a/src/main/java/com/example/mate/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateRepository.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
-public interface MateRepository extends JpaRepository<MatePost, Long> {
+public interface MateRepository extends JpaRepository<MatePost, Long>, MateRepositoryCustom {
     @Query("""
             SELECT mp FROM MatePost mp JOIN FETCH mp.match mt
             WHERE (:teamId IS NULL OR mp.teamId = :teamId)

--- a/src/main/java/com/example/mate/domain/mate/repository/MateRepositoryCustom.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.mate.domain.mate.repository;
+
+import com.example.mate.domain.mate.dto.request.MatePostSearchRequest;
+import com.example.mate.domain.mate.entity.MatePost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MateRepositoryCustom {
+    Page<MatePost> findMatePostsByFilter(MatePostSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/example/mate/domain/mate/repository/MateRepositoryImpl.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateRepositoryImpl.java
@@ -1,0 +1,97 @@
+package com.example.mate.domain.mate.repository;
+
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.match.entity.QMatch;
+import com.example.mate.domain.mate.dto.request.MatePostSearchRequest;
+import com.example.mate.domain.mate.entity.*;
+import com.example.mate.domain.member.entity.QMember;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MateRepositoryImpl implements MateRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MatePost> findMatePostsByFilter(MatePostSearchRequest request, Pageable pageable) {
+        QMatePost matePost = QMatePost.matePost;
+        QMatch match = QMatch.match;
+        QMember author = QMember.member;
+
+        // 기본 조건 설정 (미래 경기, 모집 상태)
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(match.matchTime.after(LocalDateTime.now()));
+        builder.and(matePost.status.in(Status.OPEN, Status.CLOSED));
+
+        // 동적 필터 조건 추가
+        if (request.getTeamId() != null) {
+            builder.and(matePost.teamId.eq(request.getTeamId()));
+        }
+
+        if (request.getAge() != null && request.getAge() != Age.ALL) {
+            builder.and(matePost.age.eq(request.getAge()));
+        }
+
+        if (request.getGender() != null && request.getGender() != Gender.ANY) {
+            builder.and(matePost.gender.eq(request.getGender()));
+        }
+
+        if (request.getMaxParticipants() != null) {
+                builder.and(matePost.maxParticipants.eq(request.getMaxParticipants()));
+        }
+
+        if (request.getTransportType() != null && request.getTransportType() != TransportType.ANY) {
+            builder.and(matePost.transport.eq(request.getTransportType()));
+        }
+
+        // 정렬 조건 설정
+        OrderSpecifier<?> orderSpecifier = createOrderSpecifier(request.getSortType(), matePost, match, author);
+
+        // 쿼리 실행
+        List<MatePost> content = queryFactory
+                .selectFrom(matePost)
+                .join(matePost.match, match).fetchJoin()
+                .join(matePost.author, author).fetchJoin()
+                .where(builder)
+                .orderBy(orderSpecifier)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 개수 조회
+        long total = queryFactory
+                .selectFrom(matePost)
+                .join(matePost.match, match)
+                .join(matePost.author, author)
+                .where(builder)
+                .fetch()
+                .size();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private OrderSpecifier<?> createOrderSpecifier(SortType sortType,
+                                                   QMatePost matePost,
+                                                   QMatch match,
+                                                   QMember author) {
+        if (sortType == null) {
+            return new OrderSpecifier<>(Order.DESC, matePost.id); // 기본 정렬
+        }
+
+        return switch (sortType) {
+            case LATEST -> new OrderSpecifier<>(Order.DESC, matePost.id);
+            case MATCH_TIME -> new OrderSpecifier<>(Order.ASC, match.matchTime);
+            case MANNER -> new OrderSpecifier<>(Order.DESC, author.manner);
+            default -> new OrderSpecifier<>(Order.DESC, matePost.id);
+        };
+    }
+}

--- a/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
@@ -139,7 +139,7 @@ public class MateIntegrationTest {
     }
 
     @Nested
-    @DisplayName("메이트 게시글 작성 테스트")
+    @DisplayName("메이트 게시글 작성")
     class CreateMatePost {
 
         @Test
@@ -243,8 +243,8 @@ public class MateIntegrationTest {
     }
 
     @Nested
-    @DisplayName("메이트 게시글 조회 테스트")
-    class GetMatePosts {
+    @DisplayName("메인 페이지 메이트 게시글 조회")
+    class GetMainPageMatePosts {
 
         @Test
         @DisplayName("메인 페이지 메이트 게시글 목록 조회 성공 - 팀 ID 있음")
@@ -263,7 +263,7 @@ public class MateIntegrationTest {
                     .andExpect(jsonPath("$.data[0].status").value("OPEN"))
                     .andExpect(jsonPath("$.data[0].maxParticipants").value(4))
                     .andExpect(jsonPath("$.data[0].age").value("20대"))
-                    .andExpect(jsonPath("$.data[0].gender").value("여자만"))
+                    .andExpect(jsonPath("$.data[0].gender").value("여자"))
                     .andExpect(jsonPath("$.data[0].transportType").value("대중교통"))
                     .andExpect(jsonPath("$.data[0].rivalTeamName").value("LG"))
                     .andExpect(jsonPath("$.data[0].location").value("광주-기아 챔피언스 필드"))
@@ -272,7 +272,7 @@ public class MateIntegrationTest {
                     .andExpect(jsonPath("$.data[1].status").value("CLOSED"))
                     .andExpect(jsonPath("$.data[1].maxParticipants").value(4))
                     .andExpect(jsonPath("$.data[1].age").value("20대"))
-                    .andExpect(jsonPath("$.data[1].gender").value("여자만"))
+                    .andExpect(jsonPath("$.data[1].gender").value("여자"))
                     .andExpect(jsonPath("$.data[1].transportType").value("대중교통"))
                     .andExpect(jsonPath("$.data[1].rivalTeamName").value("LG"))
                     .andExpect(jsonPath("$.data[1].location").value("광주-기아 챔피언스 필드"))
@@ -295,7 +295,7 @@ public class MateIntegrationTest {
                     .andExpect(jsonPath("$.data[0].status").value("OPEN"))
                     .andExpect(jsonPath("$.data[0].maxParticipants").value(4))
                     .andExpect(jsonPath("$.data[0].age").value("20대"))
-                    .andExpect(jsonPath("$.data[0].gender").value("여자만"))
+                    .andExpect(jsonPath("$.data[0].gender").value("여자"))
                     .andExpect(jsonPath("$.data[0].transportType").value("대중교통"))
                     .andExpect(jsonPath("$.data[0].rivalTeamName").value("LG"))
                     .andExpect(jsonPath("$.data[0].location").value("광주-기아 챔피언스 필드"))
@@ -304,7 +304,7 @@ public class MateIntegrationTest {
                     .andExpect(jsonPath("$.data[1].status").value("CLOSED"))
                     .andExpect(jsonPath("$.data[1].maxParticipants").value(4))
                     .andExpect(jsonPath("$.data[1].age").value("20대"))
-                    .andExpect(jsonPath("$.data[1].gender").value("여자만"))
+                    .andExpect(jsonPath("$.data[1].gender").value("여자"))
                     .andExpect(jsonPath("$.data[1].transportType").value("대중교통"))
                     .andExpect(jsonPath("$.data[1].rivalTeamName").value("LG"))
                     .andExpect(jsonPath("$.data[1].location").value("광주-기아 챔피언스 필드"))
@@ -337,6 +337,134 @@ public class MateIntegrationTest {
                     .doesNotContain(completedPost)
                     .extracting(MatePost::getMatch)
                     .doesNotContain(pastMatch);
+        }
+    }
+
+
+    @Nested
+    @DisplayName("메이트 페이지 게시글 조회")
+    class GetMatePagePosts {
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 성공 - 필터 없음")
+        void getMatePagePosts_NoFilter_Success() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/mates")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(2))
+                    .andExpect(jsonPath("$.data.totalElements").value(2))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 성공 - 팀 필터")
+        void getMatePagePosts_TeamFilter_Success() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/mates")
+                            .param("teamId", "1")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(2))
+                    .andExpect(jsonPath("$.data.content[0].rivalTeamName").value("LG"))
+                    .andExpect(jsonPath("$.data.content[1].rivalTeamName").value("LG"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 성공 - 연령대 필터")
+        void getMatePagePosts_AgeFilter_Success() throws Exception {
+            // given
+            MatePost thirtyPost = createMatePost(futureMatch, 1L, Status.OPEN);
+            thirtyPost.updatePost(1L, futureMatch, null, "30대 게시글", "내용", 4,
+                    Age.THIRTIES, Gender.FEMALE, TransportType.PUBLIC);
+            mateRepository.save(thirtyPost);
+
+            // when & then
+            mockMvc.perform(get("/api/mates")
+                            .param("age", "30대")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(1))
+                    .andExpect(jsonPath("$.data.content[0].age").value("30대"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 성공 - 성별 필터")
+        void getMatePagePosts_GenderFilter_Success() throws Exception {
+            // given
+            MatePost malePost = createMatePost(futureMatch, 1L, Status.OPEN);
+            malePost.updatePost(1L, futureMatch, null, "남자 게시글", "내용", 4,
+                    Age.TWENTIES, Gender.MALE, TransportType.PUBLIC);
+            mateRepository.save(malePost);
+
+            // when & then
+            mockMvc.perform(get("/api/mates")
+                            .param("gender", "남자")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(1))
+                    .andExpect(jsonPath("$.data.content[0].gender").value("남자"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 성공 - 인원 수 필터")
+        void getMatePagePosts_MaxParticipantsFilter_Success() throws Exception {
+            // given
+            MatePost largeGroupPost = createMatePost(futureMatch, 1L, Status.OPEN);
+            largeGroupPost.updatePost(1L, futureMatch, null, "대규모 모집", "내용", 10,
+                    Age.TWENTIES, Gender.FEMALE, TransportType.PUBLIC);
+            mateRepository.save(largeGroupPost);
+
+            // when & then
+            mockMvc.perform(get("/api/mates")
+                            .param("maxParticipants", "10")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(1))
+                    .andExpect(jsonPath("$.data.content[0].maxParticipants").value(10))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 성공 - 이동수단 필터")
+        void getMatePagePosts_TransportFilter_Success() throws Exception {
+            // given
+            MatePost carPost = createMatePost(futureMatch, 1L, Status.OPEN);
+            carPost.updatePost(1L, futureMatch, null, "자차 이동", "내용", 4,
+                    Age.TWENTIES, Gender.FEMALE, TransportType.CAR);
+            mateRepository.save(carPost);
+
+            // when & then
+            mockMvc.perform(get("/api/mates")
+                            .param("transportType", "자차")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(1))
+                    .andExpect(jsonPath("$.data.content[0].transportType").value("자차"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 실패 - 존재하지 않는 팀")
+        void getMatePagePosts_InvalidTeamId_Failure() throws Exception {
+            mockMvc.perform(get("/api/mates")
+                            .param("teamId", "999")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.TEAM_NOT_FOUND.getMessage()))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andDo(print());
         }
     }
 }

--- a/src/test/java/com/example/mate/domain/mate/service/MateServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateServiceTest.java
@@ -1,16 +1,16 @@
 package com.example.mate.domain.mate.service;
 
 import com.example.mate.common.error.CustomException;
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.constant.StadiumInfo;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
 import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
+import com.example.mate.domain.mate.dto.request.MatePostSearchRequest;
 import com.example.mate.domain.mate.dto.response.MatePostResponse;
 import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
-import com.example.mate.domain.mate.entity.Age;
-import com.example.mate.domain.mate.entity.MatePost;
-import com.example.mate.domain.mate.entity.Status;
-import com.example.mate.domain.mate.entity.TransportType;
+import com.example.mate.domain.mate.entity.*;
 import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
@@ -29,7 +32,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.example.mate.common.error.ErrorCode.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -69,36 +73,6 @@ class MateServiceTest {
                 .build();
     }
 
-    private MatePostCreateRequest createTestRequest() {
-        return MatePostCreateRequest.builder()
-                .memberId(TEST_MEMBER_ID)
-                .teamId(TEST_MATCH_ID)
-                .matchId(1L)
-                .title("테스트 제목")
-                .content("테스트 내용")
-                .age(Age.TWENTIES)
-                .maxParticipants(4)
-                .gender(Gender.FEMALE)
-                .transportType(TransportType.PUBLIC)
-                .build();
-    }
-
-    private MatePost createTestMatePost(Member author, Match match) {
-        return MatePost.builder()
-                .id(1L)
-                .author(author)
-                .teamId(1L)
-                .match(match)
-                .title("테스트 제목")
-                .content("테스트 내용")
-                .status(Status.OPEN)
-                .maxParticipants(4)
-                .age(Age.TWENTIES)
-                .gender(Gender.FEMALE)
-                .transport(TransportType.PUBLIC)
-                .build();
-    }
-
     @Nested
     @DisplayName("메이트 게시글 작성")
     class CreateMatePost {
@@ -109,8 +83,32 @@ class MateServiceTest {
             // given
             Member testMember = createTestMember();
             Match testMatch = createTestMatch();
-            MatePostCreateRequest request = createTestRequest();
-            MatePost matePost = createTestMatePost(testMember, testMatch);
+
+            MatePostCreateRequest request = MatePostCreateRequest.builder()
+                    .memberId(TEST_MEMBER_ID)
+                    .teamId(TEST_MATCH_ID)
+                    .matchId(1L)
+                    .title("테스트 제목")
+                    .content("테스트 내용")
+                    .age(Age.TWENTIES)
+                    .maxParticipants(4)
+                    .gender(Gender.FEMALE)
+                    .transportType(TransportType.PUBLIC)
+                    .build();
+
+            MatePost matePost = MatePost.builder()
+                    .id(1L)
+                    .author(testMember)
+                    .teamId(1L)
+                    .match(testMatch)
+                    .title("테스트 제목")
+                    .content("테스트 내용")
+                    .status(Status.OPEN)
+                    .maxParticipants(4)
+                    .age(Age.TWENTIES)
+                    .gender(Gender.FEMALE)
+                    .transport(TransportType.PUBLIC)
+                    .build();
 
             given(memberRepository.findById(request.getMemberId()))
                     .willReturn(Optional.of(testMember));
@@ -124,7 +122,6 @@ class MateServiceTest {
 
             // then
             assertThat(response.getStatus()).isEqualTo(Status.OPEN);
-
             verify(memberRepository).findById(TEST_MEMBER_ID);
             verify(matchRepository).findById(TEST_MATCH_ID);
             verify(mateRepository).save(any(MatePost.class));
@@ -134,7 +131,18 @@ class MateServiceTest {
         @DisplayName("메이트 게시글 작성 실패 - 존재하지 않는 회원")
         void createMatePost_FailWithInvalidMember() {
             // given
-            MatePostCreateRequest request = createTestRequest();
+            MatePostCreateRequest request = MatePostCreateRequest.builder()
+                    .memberId(TEST_MEMBER_ID)
+                    .teamId(TEST_MATCH_ID)
+                    .matchId(1L)
+                    .title("테스트 제목")
+                    .content("테스트 내용")
+                    .age(Age.TWENTIES)
+                    .maxParticipants(4)
+                    .gender(Gender.FEMALE)
+                    .transportType(TransportType.PUBLIC)
+                    .build();
+
             given(memberRepository.findById(request.getMemberId()))
                     .willReturn(Optional.empty());
 
@@ -153,7 +161,17 @@ class MateServiceTest {
         void createMatePost_FailWithInvalidMatch() {
             // given
             Member testMember = createTestMember();
-            MatePostCreateRequest request = createTestRequest();
+            MatePostCreateRequest request = MatePostCreateRequest.builder()
+                    .memberId(TEST_MEMBER_ID)
+                    .teamId(TEST_MATCH_ID)
+                    .matchId(1L)
+                    .title("테스트 제목")
+                    .content("테스트 내용")
+                    .age(Age.TWENTIES)
+                    .maxParticipants(4)
+                    .gender(Gender.FEMALE)
+                    .transportType(TransportType.PUBLIC)
+                    .build();
 
             given(memberRepository.findById(request.getMemberId()))
                     .willReturn(Optional.of(testMember));
@@ -172,7 +190,7 @@ class MateServiceTest {
     }
 
     @Nested
-    @DisplayName("메이트 게시글 조회")
+    @DisplayName("메인 페이지 메이트 게시글 조회")
     class GetMatePosts {
 
         private List<MatePost> createTestMatePostList() {
@@ -222,7 +240,7 @@ class MateServiceTest {
                     .willReturn(testPosts);
 
             // when
-            List<MatePostSummaryResponse> result = mateService.getMatePostMain(null);
+            List<MatePostSummaryResponse> result = mateService.getMainPagePosts(null);
 
             // then
             assertThat(result.size()).isEqualTo(2);
@@ -250,7 +268,7 @@ class MateServiceTest {
                     .willReturn(testPosts);
 
             // when
-            List<MatePostSummaryResponse> result = mateService.getMatePostMain(teamId);
+            List<MatePostSummaryResponse> result = mateService.getMainPagePosts(teamId);
 
             // then
             assertThat(result).hasSize(2);
@@ -278,7 +296,7 @@ class MateServiceTest {
                     .willReturn(Collections.emptyList());
 
             // when
-            List<MatePostSummaryResponse> result = mateService.getMatePostMain(1L);
+            List<MatePostSummaryResponse> result = mateService.getMainPagePosts(1L);
 
             // then
             assertThat(result).isEmpty();
@@ -297,7 +315,7 @@ class MateServiceTest {
             Long invalidTeamId = 999L;
 
             // when & then
-            assertThatThrownBy(() -> mateService.getMatePostMain(invalidTeamId))
+            assertThatThrownBy(() -> mateService.getMainPagePosts(invalidTeamId))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", TEAM_NOT_FOUND);
 
@@ -307,6 +325,162 @@ class MateServiceTest {
                     any(),
                     any(Pageable.class));
         }
+    }
 
+    @Nested
+    @DisplayName("메이트 페이지 게시글 조회")
+    class GetMatePagePosts {
+
+        private List<MatePost> createFilteredTestMatePostList() {
+            Member testMember = createTestMember();
+            Match testMatch = Match.builder()
+                    .homeTeamId(1L)
+                    .awayTeamId(2L)
+                    .stadiumId(StadiumInfo.JAMSIL.id)
+                    .matchTime(LocalDateTime.now().plusDays(1))
+                    .build();
+
+            return List.of(
+                    MatePost.builder()
+                            .author(testMember)
+                            .teamId(1L)
+                            .match(testMatch)
+                            .title("테스트 제목1")
+                            .content("테스트 내용1")
+                            .status(Status.OPEN)
+                            .maxParticipants(4)
+                            .age(Age.TWENTIES)
+                            .gender(Gender.ANY)
+                            .transport(TransportType.PUBLIC)
+                            .build(),
+                    MatePost.builder()
+                            .author(testMember)
+                            .teamId(1L)
+                            .match(testMatch)
+                            .title("테스트 제목2")
+                            .content("테스트 내용2")
+                            .status(Status.OPEN)
+                            .maxParticipants(3)
+                            .age(Age.THIRTIES)
+                            .gender(Gender.ANY)
+                            .transport(TransportType.CAR)
+                            .build()
+            );
+        }
+
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 성공 - 필터 없음")
+        void getMatePagePosts_SuccessWithoutFilters() {
+            // given
+            List<MatePost> testPosts = createFilteredTestMatePostList();
+            Page<MatePost> testPage = new PageImpl<>(testPosts);
+            Pageable pageable = PageRequest.of(0, 10);
+            MatePostSearchRequest request = MatePostSearchRequest.builder().build();
+
+            given(mateRepository.findMatePostsByFilter(request, pageable))
+                    .willReturn(testPage);
+
+            // when
+            PageResponse<MatePostSummaryResponse> result = mateService.getMatePagePosts(request, pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getContent().get(0).getTitle()).isEqualTo("테스트 제목1");
+            assertThat(result.getContent().get(1).getTitle()).isEqualTo("테스트 제목2");
+            assertThat(result.getTotalElements()).isEqualTo(2);
+            assertThat(result.getPageNumber()).isZero();
+
+            verify(mateRepository).findMatePostsByFilter(request, pageable);
+        }
+
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 성공 - 모든 필터 적용")
+        void getMatePagePosts_SuccessWithAllFilters() {
+            // given
+            Member testMember = createTestMember();
+            Match testMatch = Match.builder()
+                    .homeTeamId(1L)
+                    .awayTeamId(2L)
+                    .stadiumId(StadiumInfo.JAMSIL.id)
+                    .matchTime(LocalDateTime.now().plusDays(1))
+                    .build();
+
+            MatePost filteredPost = MatePost.builder()
+                    .author(testMember)
+                    .teamId(1L)
+                    .match(testMatch)
+                    .title("테스트 제목1")
+                    .content("테스트 내용1")
+                    .status(Status.OPEN)
+                    .maxParticipants(4)
+                    .age(Age.TWENTIES)
+                    .gender(Gender.ANY)
+                    .transport(TransportType.PUBLIC)
+                    .build();
+
+            Page<MatePost> testPage = new PageImpl<>(List.of(filteredPost));
+            Pageable pageable = PageRequest.of(0, 10);
+
+            MatePostSearchRequest request = MatePostSearchRequest.builder()
+                    .teamId(1L)
+                    .sortType(SortType.LATEST)
+                    .age(Age.TWENTIES)
+                    .gender(Gender.ANY)
+                    .maxParticipants(4)
+                    .transportType(TransportType.PUBLIC)
+                    .build();
+
+            given(mateRepository.findMatePostsByFilter(request, pageable))
+                    .willReturn(testPage);
+
+            // when
+            PageResponse<MatePostSummaryResponse> result = mateService.getMatePagePosts(request, pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getPageNumber()).isZero();
+            assertThat(result.getContent().get(0).getTransportType()).isEqualTo(TransportType.PUBLIC);
+
+            verify(mateRepository).findMatePostsByFilter(request, pageable);
+        }
+
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 - 결과 없음")
+        void getMatePagePosts_EmptyResult() {
+            // given
+            Page<MatePost> emptyPage = new PageImpl<>(Collections.emptyList());
+            Pageable pageable = PageRequest.of(0, 10);
+            MatePostSearchRequest request = MatePostSearchRequest.builder().build();
+
+            given(mateRepository.findMatePostsByFilter(request, pageable))
+                    .willReturn(emptyPage);
+
+            // when
+            PageResponse<MatePostSummaryResponse> result = mateService.getMatePagePosts(request, pageable);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getTotalElements()).isZero();
+
+            verify(mateRepository).findMatePostsByFilter(request, pageable);
+        }
+
+        @Test
+        @DisplayName("메이트 페이지 게시글 목록 조회 실패 - 존재하지 않는 팀")
+        void getMatePagePosts_FailWithInvalidTeamId() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            MatePostSearchRequest request = MatePostSearchRequest.builder()
+                    .teamId(999L)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> mateService.getMatePagePosts(request, pageable))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", TEAM_NOT_FOUND);
+
+            verify(mateRepository, never()).findMatePostsByFilter(any(), any());
+        }
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 메이트 페이지 게시글 목록 조회 API 개발
- [x] `SortType` enum 추가 (최신순, 경기시간순, 매너타율순)
- [x] QueryDSL을 활용한 동적 필터링 기능 구현

## 💡 자세한 설명
### API 개발 내용
1. 메이트 페이지 게시글 목록 조회 API 구현
   - 경로: `GET /api/mates`
   - 페이징 처리 (기본값: 10개)
   - 다양한 필터링 옵션 지원
     - 팀 ID
     - 연령대
     - 성별
     - 최대 참여 인원
     - 이동수단 종류

2. 정렬 기능
   - `SortType` enum을 통한 정렬 기준 정의
     - 최근 작성일순 (기본값)
     - 가까운 경기순
     - 매너타율순

3. 응답 데이터
   - 게시글 기본 정보 (제목, 상태, 이미지 등)
   - 경기 관련 정보 (상대팀명, 경기시간, 경기장)
   - 모집 조건 (최대인원, 연령대, 성별, 이동수단)

### 기술적 구현
1. QueryDSL 활용
   - 동적 쿼리 생성으로 유연한 필터링 구현
   - N+1 문제 해결을 위한 fetch join 적용
   - 안전한 정렬 처리를 위한 `OrderSpecifier` 사용

2. 코드 구조
   - Controller: 요청 파라미터 검증 및 DTO 변환
   - Service: 비즈니스 로직 처리 (팀 존재 여부 확인 등)
   - Repository: QueryDSL을 활용한 동적 쿼리 구현

## 📗 참고 자료
-  [[김영한님의 QueryDSL 강의](https://www.inflearn.com/course/querydsl-%EC%8B%A4%EC%A0%84)]
- [[QueryDsl 환경설정](https://velog.io/@weonest/QueryDSL-%EC%82%AC%EC%9A%A9)]

## 📢 리뷰 요구 사항
- QueryDSL 동적 쿼리 구현 부분 중점적으로 봐주시면 감사하겠습니다.
- 정렬 로직의 적절성 검토 부탁드립니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?