### PR TITLE
MATE-48 : [FEAT] 굿즈거래 판매글 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
+++ b/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
@@ -78,8 +78,9 @@ public class GoodsController {
 
     // 굿즈 거래하기 상세 페이지 : 굿즈 거래글 단건 조회
     @GetMapping("/{goodsPostId}")
-    public ResponseEntity<GoodsPostResponse> getGoodsPost(@PathVariable Long goodsPostId) {
-        return ResponseEntity.ok(goodsService.getGoodsPost(goodsPostId));
+    public ResponseEntity<ApiResponse<GoodsPostResponse>> getGoodsPost(@PathVariable Long goodsPostId) {
+        GoodsPostResponse response = goodsService.getGoodsPost(goodsPostId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /*

--- a/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
+++ b/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
@@ -76,6 +76,12 @@ public class GoodsController {
         return ResponseEntity.noContent().build();
     }
 
+    // 굿즈 거래하기 상세 페이지 : 굿즈 거래글 단건 조회
+    @GetMapping("/{goodsPostId}")
+    public ResponseEntity<GoodsPostResponse> getGoodsPost(@PathVariable Long goodsPostId) {
+        return ResponseEntity.ok(goodsService.getGoodsPost(goodsPostId));
+    }
+
     /*
     메인 페이지 : 굿즈 거래글 요약 4개 리스트 조회
     테스트 용도로, 가상의 동일한 거래글 데이터 4개를 생성
@@ -115,12 +121,6 @@ public class GoodsController {
                 .build();
 
         return ResponseEntity.ok(pageResponse);
-    }
-
-    // 굿즈 거래하기 상세 페이지 : 굿즈 거래글 단건 조회
-    @GetMapping("/{goodsPostId}")
-    public ResponseEntity<GoodsPostResponse> getGoodsPost(@PathVariable Long goodsPostId) {
-        return ResponseEntity.ok(GoodsPostResponse.createResponse(goodsPostId));
     }
 
     // 굿즈 채팅창 - 알럿창 : 굿즈 거래 완료

--- a/src/main/java/com/example/mate/domain/goods/dto/response/GoodsPostResponse.java
+++ b/src/main/java/com/example/mate/domain/goods/dto/response/GoodsPostResponse.java
@@ -3,17 +3,13 @@ package com.example.mate.domain.goods.dto.response;
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.goods.dto.LocationInfo;
 import com.example.mate.domain.goods.dto.MemberInfo;
-import com.example.mate.domain.goods.dto.request.GoodsPostRequest;
-import com.example.mate.domain.goods.entity.Category;
 import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.GoodsPostImage;
 import com.example.mate.domain.goods.entity.Role;
-import com.example.mate.domain.goods.entity.Status;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Builder
@@ -45,64 +41,5 @@ public class GoodsPostResponse {
                 .imageUrls(goodsPost.getGoodsPostImages().stream().map(GoodsPostImage::getImageUrl).toList())
                 .status(goodsPost.getStatus().getValue())
                 .build();
-    }
-
-    /*
-    굿즈 거래글 단건 조회 요청을 GoodsPostResponse로 반환
-    거래글 id를 제외한 모든 값 하드코딩
-     */
-    public static GoodsPostResponse createResponse(Long id) {
-        return GoodsPostResponse.builder()
-                .id(id)
-                .seller(MemberInfo.builder()
-                        .memberId(1L)
-                        .nickname("tester")
-                        .manner(0.3F)
-                        .role(Role.SELLER)
-                        .build())
-                .teamName(TeamInfo.NC.shortName)
-                .title("NC 다이노스 배틀크러쉬 모자")
-                .category(Category.CLOTHING.getValue())
-                .price(40000)
-                .content("플레이스 홀더")
-                .location(LocationInfo.builder()
-                        .placeName("장소명")
-                        .longitude("123.123")
-                        .latitude("123.123")
-                        .build())
-                .imageUrls(List.of("upload/image1.png", "upload/image2.png", "upload/image3.png"))
-                .status(Status.OPEN.getValue())
-                .build();
-    }
-
-    /*
-    굿즈 거래글 수정 요청을 GoodsPostResponse로 반환
-    회원정보 MemberInfo는 하드코딩
-    id와 request 값에 따른 반환 값 확인
-     */
-    public static GoodsPostResponse updateResponse(Long id, GoodsPostRequest request, MultipartFile[] files) {
-        return GoodsPostResponse.builder()
-                .id(id)
-                .seller(MemberInfo.builder()
-                        .memberId(1L)
-                        .nickname("tester")
-                        .manner(0.3F)
-                        .role(Role.SELLER)
-                        .build())
-                .teamName(getTeamName(request.getTeamId()))
-                .title(request.getTitle())
-                .category(request.getCategory().getValue())
-                .price(request.getPrice())
-                .content(request.getContent())
-                .location(request.getLocation())
-//                .imageUrls(upload(files))
-                .status(Status.OPEN.getValue())
-                .build();
-    }
-
-    // 요청 받은 teamId를 통해 해당 팀명 반환
-    private static String getTeamName(Long teamId) {
-        TeamInfo.Team team = TeamInfo.getById(teamId);
-        return team.shortName;
     }
 }

--- a/src/main/java/com/example/mate/domain/goods/entity/GoodsPost.java
+++ b/src/main/java/com/example/mate/domain/goods/entity/GoodsPost.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +52,7 @@ public class GoodsPost {
     private Long teamId;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("id ASC")
     @Builder.Default
     private List<GoodsPostImage> goodsPostImages = new ArrayList<>();
 

--- a/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
@@ -108,7 +108,7 @@ public class GoodsService {
         List<String> imageUrls = imageRepository.getImageUrlsByPostId(goodsPostId);
         imageUrls.forEach(url -> {
             if (!FileUploader.deleteFile(url)) {
-                throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+                throw new CustomException(ErrorCode.FILE_DELETE_ERROR);
             }
         });
         imageRepository.deleteAllByPostId(goodsPostId);
@@ -123,10 +123,8 @@ public class GoodsService {
                     .imageUrl(uploadUrl)
                     .post(savedPost)
                     .build();
-            GoodsPostImage savedImage = imageRepository.save(image);
-            images.add(savedImage);
+            images.add(image);
         }
-
         return images;
     }
 }

--- a/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
@@ -75,6 +75,14 @@ public class GoodsService {
         goodsPostRepository.delete(goodsPost);
     }
 
+    @Transactional(readOnly = true)
+    public GoodsPostResponse getGoodsPost(Long goodsPostId) {
+        GoodsPost goodsPost = goodsPostRepository.findById(goodsPostId).orElseThrow(()
+                -> new CustomException(ErrorCode.GOODS_NOT_FOUND_BY_ID));
+
+        return GoodsPostResponse.of(goodsPost);
+    }
+
     private Member getSellerAndValidate(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(()
                 -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));

--- a/src/test/java/com/example/mate/domain/goods/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goods/controller/GoodsControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -163,5 +164,24 @@ class GoodsControllerTest {
 
 
         verify(goodsService).deleteGoodsPost(memberId, goodsPostId);
+    }
+
+    @Test
+    @DisplayName("굿즈 판매글 상세 조회 - API 테스트")
+    void get_goods_post_success() throws Exception {
+        // given
+        Long goodsPostId = 1L;
+        GoodsPostResponse response = createGoodsPostResponse();
+
+        given(goodsService.getGoodsPost(goodsPostId)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/goods/{goodsPostId}", goodsPostId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(response.getId()))
+                .andExpect(jsonPath("$.data.status").value(response.getStatus()));
+
+        verify(goodsService).getGoodsPost(goodsPostId);
     }
 }

--- a/src/test/java/com/example/mate/domain/goods/service/GoodsServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goods/service/GoodsServiceTest.java
@@ -118,11 +118,9 @@ class GoodsServiceTest {
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
 
             GoodsPost post = GoodsPostRequest.toEntity(member, request);
-            GoodsPostImage image = goodsPostImage;
 
             given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
             given(goodsPostRepository.save(any(GoodsPost.class))).willReturn(post);
-            given(imageRepository.save(any(GoodsPostImage.class))).willReturn(image);
 
             // when
             GoodsPostResponse response = goodsService.registerGoodsPost(member.getId(), request, files);
@@ -133,7 +131,6 @@ class GoodsServiceTest {
 
             verify(memberRepository).findById(member.getId());
             verify(goodsPostRepository).save(any(GoodsPost.class));
-            verify(imageRepository).save(any(GoodsPostImage.class));
         }
 
         @Test
@@ -185,12 +182,10 @@ class GoodsServiceTest {
             Long goodsPostId = 1L;
             GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....", createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
-            GoodsPostImage updatedGoodsImage = goodsPostImage;
 
             given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
             given(goodsPostRepository.findById(goodsPostId)).willReturn(Optional.of(goodsPost));
             given(imageRepository.getImageUrlsByPostId(goodsPostId)).willReturn(List.of());
-            given(imageRepository.save(any(GoodsPostImage.class))).willReturn(updatedGoodsImage);
 
             // when
             GoodsPostResponse actual = goodsService.updateGoodsPost(member.getId(), goodsPostId, request, files);
@@ -205,7 +200,6 @@ class GoodsServiceTest {
             verify(memberRepository).findById(member.getId());
             verify(imageRepository).getImageUrlsByPostId(goodsPostId);
             verify(imageRepository).deleteAllByPostId(goodsPostId);
-            verify(imageRepository).save(any(GoodsPostImage.class));
         }
 
         @Test

--- a/src/test/java/com/example/mate/domain/goods/service/GoodsServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goods/service/GoodsServiceTest.java
@@ -327,4 +327,46 @@ class GoodsServiceTest {
             verify(goodsPostRepository, never()).delete(any(GoodsPost.class));
         }
     }
+
+    @Nested
+    @DisplayName("굿즈거래 판매글 상세 조회 테스트")
+    class GoodsServiceSearchTest {
+
+        @Test
+        @DisplayName("굿즈거래 판매글 상세 조회 성공")
+        void get_goods_post_success() {
+            // given
+            Long goodsPostId = 1L;
+            given(goodsPostRepository.findById(goodsPostId)).willReturn(Optional.of(goodsPost));
+
+            // when
+            GoodsPostResponse response = goodsService.getGoodsPost(goodsPostId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTitle()).isEqualTo(goodsPost.getTitle());
+            assertThat(response.getContent()).isEqualTo(goodsPost.getContent());
+            assertThat(response.getCategory()).isEqualTo(goodsPost.getCategory().getValue());
+            assertThat(response.getPrice()).isEqualTo(goodsPost.getPrice());
+            assertThat(response.getLocation().getPlaceName()).isEqualTo(goodsPost.getLocation().getPlaceName());
+
+            verify(goodsPostRepository).findById(goodsPostId);
+        }
+
+        @Test
+        @DisplayName("굿즈거래 판매글 상세 조회 실패 - 유효하지 않은 판매글")
+        void get_goods_post_failed_with_invalid_post() {
+            // given
+            Long goodsPostId = 1L;
+
+            given(goodsPostRepository.findById(goodsPostId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> goodsService.getGoodsPost(goodsPostId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.GOODS_NOT_FOUND_BY_ID.getMessage());
+
+            verify(goodsPostRepository).findById(goodsPostId);
+        }
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 판매글 상세 조회 기능 구현
- [x] 굿즈거래 판매글 상세 조회 테스트 코드 작성

## 💡 자세한 설명
#### `GET /api/goods/{goodsPostId}`
- 판매자(본인) 과 구매자가 조회할 때, 데이터가 동일하기 때문에 공통 조회 기능으로 만들었습니다.
- 굿즈거래 판매글 이미지들의 순서를 보장하기 위해 `@OrderBy` 어노테이션으로 `id` 값을 통해 이미지를 정렬했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?