### PR TITLE
MATE-32 : [FEAT] 회원 팔로우 기능 구현

### DIFF
--- a/http/Member.http
+++ b/http/Member.http
@@ -4,3 +4,8 @@
 ### 다른 회원 프로필 조회
 ## TODO : 리뷰 기능 구현 시 리뷰 기록 추가
 GET http://localhost:5173/api/members/1
+
+
+### 회원 팔로우
+## TODO : JWT 구현 시 쿼리스트링 삭제
+POST http://localhost:5173/api/profile/follow/1?followerId=3

--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -28,13 +28,19 @@ public enum ErrorCode {
     // Member
     MEMBER_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "M001", "해당 ID의 회원 정보를 찾을 수 없습니다"),
 
+    // Follow
+    ALREADY_FOLLOWED_MEMBER(HttpStatus.BAD_REQUEST, "F001", "이미 팔로우한 회원입니다."),
+    ALREADY_UNFOLLOWED_MEMBER(HttpStatus.BAD_REQUEST, "F002", "이미 언팔로우한 회원입니다."),
+    FOLLOWER_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "F003", "해당 ID의 팔로워 회원을 찾을 수 없습니다."),
+    FOLLOWING_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "F004", "해당 ID의 팔로잉 회원을 찾을 수 없습니다."),
+
     // Mate Post
     INVALID_MATE_POST_PARTICIPANTS(HttpStatus.BAD_REQUEST, "MP001", "모집 인원은 2명에서 10명 사이여야 합니다."),
     INVALID_MATE_POST_STATUS_CHANGE(HttpStatus.BAD_REQUEST, "MP002", "직관 완료된 게시글은 상태를 변경할 수 없습니다."),
     INVALID_MATE_POST_COMPLETION(HttpStatus.BAD_REQUEST, "MP003", "모집완료 상태에서만 직관 완료가 가능합니다."),
     MATE_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "MP004", "해당 ID의 메이트 게시글을 찾을 수 없습니다."),
     UNAUTHORIZED_MATE_POST_ACCESS(HttpStatus.FORBIDDEN, "MP005", "해당 메이트 게시글에 대한 권한이 없습니다."),
-  
+
     // Goods
     GOODS_IMAGES_ARE_EMPTY(HttpStatus.BAD_REQUEST, "G001", "굿즈 이미지는 최소 1개 이상을 업로드 할 수 있습니다."),
     GOODS_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "G002", "해당 ID의 굿즈 판매글 정보를 찾을 수 없습니다"),

--- a/src/main/java/com/example/mate/domain/member/controller/FollowController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/FollowController.java
@@ -1,8 +1,13 @@
 package com.example.mate.domain.member.controller;
 
+import com.example.mate.common.response.ApiResponse;
 import com.example.mate.domain.member.dto.response.MemberSummaryResponse;
+import com.example.mate.domain.member.service.FollowService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.Collections;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -13,22 +18,27 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/profile")
 public class FollowController {
 
+    private final FollowService followService;
+
     /*
-    TODO : 2024/11/23 - 회원 팔로우 기능
-    1. JwtToken 을 통해 사용자 정보 조회
-    2. 팔로우 여부 확인
-    3. memberId 회원 유효성 검사
-    4. 팔로우 처리
+    TODO : 2024/11/29 - 회원 팔로우 기능
+    1. JwtToken 을 통해 사용자 정보 조회 - 현재는 임시로 @RequestParam 사용
     */
+    @Operation(summary = "회원 팔로우 기능")
     @PostMapping("/follow/{memberId}")
-    public ResponseEntity<Void> followMember(@PathVariable Long memberId) {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<ApiResponse<Void>> followMember(
+            @Parameter(description = "팔로우할 회원 ID") @PathVariable Long memberId,
+            @Parameter(description = "팔로우하는 회원 ID") @RequestParam Long followerId) {
+        followService.follow(followerId, memberId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /*

--- a/src/main/java/com/example/mate/domain/member/service/FollowService.java
+++ b/src/main/java/com/example/mate/domain/member/service/FollowService.java
@@ -1,6 +1,12 @@
 package com.example.mate.domain.member.service;
 
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.domain.member.entity.Follow;
+import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.FollowRepository;
+import com.example.mate.domain.member.repository.MemberRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,6 +15,34 @@ import org.springframework.stereotype.Service;
 public class FollowService {
 
     private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+
+    // 특정 회원 팔로우 - 해당 회원 팔로우 되어있는지 확인한 뒤 팔로우
+    public void follow(Long followerId, Long followingId) {
+        Map<String, Member> members = isValidMember(followerId, followingId);
+        if (!followRepository.existsByFollowerIdAndFollowingId(followerId, followingId)) {
+            followRepository.save(createFollow(members.get("follower"), members.get("following")));
+        } else {
+            throw new CustomException(ErrorCode.ALREADY_FOLLOWED_MEMBER);
+        }
+    }
+
+    private Map<String, Member> isValidMember(Long followerId, Long followingId) {
+        Member follower = memberRepository.findById(followerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FOLLOWER_NOT_FOUND_BY_ID));
+        Member following = memberRepository.findById(followingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FOLLOWING_NOT_FOUND_BY_ID));
+        return Map.of("follower", follower, "following", following);
+    }
+
+    private Follow createFollow(Member follower, Member following) {
+        return Follow.builder().follower(follower).following(following).build();
+    }
+
+    private Member findByMemberId(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
+    }
 
     // 특정 회원의 팔로잉 수 카운트
     public int getFollowCount(Long memberId) {
@@ -19,4 +53,6 @@ public class FollowService {
     public int getFollowerCount(Long memberId) {
         return followRepository.countByFollowingId(memberId);
     }
+
+
 }

--- a/src/test/java/com/example/mate/domain/member/controller/FollowControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/FollowControllerTest.java
@@ -1,0 +1,124 @@
+package com.example.mate.domain.member.controller;
+
+
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.member.entity.Follow;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.service.FollowService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(FollowController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc(addFilters = false)
+class FollowControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private FollowService followService;
+
+    @Nested
+    @DisplayName("회원 팔로우 테스트")
+    class FollowMember {
+
+        private Member createMember(Long id) {
+            return Member.builder()
+                    .id(id)
+                    .name("홍길동" + id)
+                    .nickname("tester" + id)
+                    .email("tester" + id + "example.com")
+                    .imageUrl("image" + id + ".png")
+                    .age((int) (20 + id))
+                    .gender(Gender.MALE)
+                    .teamId(1L)
+                    .manner(0.300F)
+                    .aboutMe("this is tester")
+                    .build();
+        }
+
+        private Follow createFollow(Member follower, Member following) {
+            return Follow.builder().id(1L).follower(follower).following(following).build();
+        }
+
+        @Test
+        @DisplayName("다른 회원 팔로우 성공")
+        void follow_member_success() throws Exception {
+            // given
+            Long followerId = 1L;
+            Long followingId = 2L;
+
+            willDoNothing().given(followService).follow(followerId, followingId);
+
+            // when & then
+            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId)
+                            .param("followerId", String.valueOf(followerId)))
+                    .andExpect(status().isOk())
+                    .andDo(print());
+
+            verify(followService, times(1)).follow(followerId, followingId);
+        }
+
+        @Test
+        @DisplayName("이미 팔로우한 회원을 다시 팔로우하려는 경우 예외 발생")
+        void follow_member_already_followed() throws Exception {
+            // given
+            Long followerId = 1L;
+            Long followingId = 2L;
+
+            // 팔로우가 이미 되어 있다고 설정
+            willThrow(new CustomException(ErrorCode.ALREADY_FOLLOWED_MEMBER))
+                    .given(followService).follow(followerId, followingId);
+
+            // when & then
+            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId)
+                            .param("followerId", String.valueOf(followerId)))
+                    .andExpect(status().isBadRequest())  // 400 Bad Request
+                    .andDo(print());
+
+            verify(followService, times(1)).follow(followerId, followingId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 팔로워 또는 팔로잉을 팔로우하려는 경우 예외 발생")
+        void follow_member_not_found() throws Exception {
+            // given
+            Long followerId = 1L;
+            Long followingId = 999L; // 존재하지 않는 팔로잉 ID
+
+            // 존재하지 않는 팔로워 또는 팔로잉에 대한 예외 설정
+            willThrow(new CustomException(ErrorCode.FOLLOWER_NOT_FOUND_BY_ID))
+                    .given(followService).follow(followerId, followingId);
+
+            // when & then
+            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId)
+                            .param("followerId", String.valueOf(followerId)))
+                    .andExpect(status().isNotFound())  // 404 Not Found
+                    .andDo(print());
+
+            verify(followService, times(1)).follow(followerId, followingId);
+        }
+    }
+}

--- a/src/test/java/com/example/mate/domain/member/integration/FollowIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/FollowIntegrationTest.java
@@ -1,0 +1,155 @@
+package com.example.mate.domain.member.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.member.entity.Follow;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.FollowRepository;
+import com.example.mate.domain.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class FollowIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private FollowRepository followRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member1;
+    private Member member2;
+    private Follow follow;
+
+    @BeforeEach
+    void setUp() {
+        followRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        createMember();
+        createFollow(member1, member2);  // member1만 member2 팔로우한 상황 설정
+    }
+
+    private void createMember() {
+        member1 = Member.builder()
+                .name("홍길동")
+                .nickname("tester1")
+                .email("tester1@example.com")
+                .imageUrl("image.png")
+                .age(20)
+                .gender(Gender.MALE)
+                .teamId(1L)
+                .manner(0.300F)
+                .aboutMe("this is tester")
+                .build();
+        memberRepository.save(member1);
+        member2 = Member.builder()
+                .name("김영희")
+                .nickname("tester2")
+                .email("tester2@example.com")
+                .imageUrl("image.png")
+                .age(20)
+                .gender(Gender.FEMALE)
+                .teamId(1L)
+                .manner(0.300F)
+                .aboutMe("this is tester")
+                .build();
+        memberRepository.save(member2);
+    }
+
+    private void createFollow(Member follower, Member following) {
+        follow = Follow.builder().follower(follower).following(following).build();
+        followRepository.save(follow);
+    }
+
+    @Nested
+    @DisplayName("회원 팔로우 테스트")
+    class FollowMember {
+
+        @Test
+        @DisplayName("다른 회원 팔로우 성공")
+        void follow_member_success() throws Exception {
+            // given
+            Long followerId = member2.getId();
+            Long followingId = member1.getId();
+
+            // when & then
+            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId)
+                            .param("followerId", String.valueOf(followerId)))
+                    .andExpect(status().isOk())
+                    .andDo(print());
+
+            List<Follow> savedFollows = followRepository.findAll();
+            assertThat(savedFollows).size().isEqualTo(2); // 기존 1개 + 새로 1개 추가
+            assertThat(savedFollows.get(savedFollows.size() - 1)
+                    .getFollower().getId()).isEqualTo(followerId);
+            assertThat(savedFollows.get(savedFollows.size() - 1)
+                    .getFollowing().getId()).isEqualTo(followingId);
+        }
+
+        @Test
+        @DisplayName("이미 팔로우한 회원을 다시 팔로우하려는 경우 예외 발생")
+        void follow_member_already_followed() throws Exception {
+            // given - 이미 팔로우 되어 있는 상태인 member1가 member2 팔로우 상황 가정
+            Long followerId = member1.getId();
+            Long followingId = member2.getId();
+
+            // when & then
+            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId)
+                            .param("followerId", String.valueOf(followerId)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value("이미 팔로우한 회원입니다."))
+                    .andDo(print());
+
+            List<Follow> savedFollows = followRepository.findAll();
+            assertThat(savedFollows).size().isEqualTo(1);
+            assertThat(savedFollows.get(savedFollows.size() - 1)
+                    .getFollower().getId()).isEqualTo(member1.getId());
+            assertThat(savedFollows.get(savedFollows.size() - 1)
+                    .getFollowing().getId()).isEqualTo(member2.getId());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 팔로워 또는 팔로잉을 팔로우하려는 경우 예외 발생")
+        void follow_member_not_found() throws Exception {
+            // given
+            Long followerId = member1.getId() + 999L;
+            Long followingId = member1.getId();
+
+            // when & then
+            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId)
+                            .param("followerId", String.valueOf(followerId)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value("해당 ID의 팔로워 회원을 찾을 수 없습니다."))
+                    .andDo(print());
+
+            List<Follow> savedFollows = followRepository.findAll();
+            assertThat(savedFollows).size().isEqualTo(1);
+            assertThat(savedFollows.get(savedFollows.size() - 1)
+                    .getFollower().getId()).isEqualTo(member1.getId());
+            assertThat(savedFollows.get(savedFollows.size() - 1)
+                    .getFollowing().getId()).isEqualTo(member2.getId());
+        }
+    }
+}

--- a/src/test/java/com/example/mate/domain/member/service/FollowServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/FollowServiceTest.java
@@ -1,0 +1,145 @@
+package com.example.mate.domain.member.service;
+
+import static com.example.mate.common.error.ErrorCode.ALREADY_FOLLOWED_MEMBER;
+import static com.example.mate.common.error.ErrorCode.FOLLOWER_NOT_FOUND_BY_ID;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.domain.member.entity.Follow;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.FollowRepository;
+import com.example.mate.domain.member.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FollowServiceTest {
+
+    @InjectMocks
+    private FollowService followService;
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private Member follower;
+    private Member following;
+
+    @BeforeEach
+    void setUp() {
+        createTestMember();
+    }
+
+    private void createTestMember() {
+        follower = Member.builder()
+                .id(1L)
+                .name("홍길동")
+                .teamId(1L)
+                .email("tester1@example.com")
+                .nickname("tester1")
+                .build();
+        following = Member.builder()
+                .id(2L)
+                .name("김영희")
+                .teamId(2L)
+                .email("tester2@example.com")
+                .nickname("tester2")
+                .build();
+    }
+
+    private Follow createTestFollow() {
+        return Follow.builder()
+                .id(1L)
+                .follower(follower)
+                .following(following).build();
+    }
+
+    @Test
+    @DisplayName("다른 회원 팔로우 성공")
+    void follow_member_success() {
+        // given
+        Long followerId = 1L;
+        Long followingId = 2L;
+        Follow follow = createTestFollow();
+
+        given(memberRepository.findById(followerId))
+                .willReturn(Optional.of(follower));
+        given(memberRepository.findById(followingId))
+                .willReturn(Optional.of(following));
+        given(followRepository.existsByFollowerIdAndFollowingId(followerId, followingId))
+                .willReturn(false);
+        given(followRepository.save(any(Follow.class)))
+                .willReturn(follow);
+
+        // when
+        followService.follow(followerId, followingId);
+
+        // then
+        verify(memberRepository, times(1)).findById(followerId);
+        verify(memberRepository, times(1)).findById(followingId);
+        verify(followRepository).existsByFollowerIdAndFollowingId(followerId, followingId);
+        verify(followRepository).save(any(Follow.class));
+    }
+
+    @Test
+    @DisplayName("이미 팔로우한 회원을 다시 팔로우하려는 경우 예외 발생")
+    void follow_member_already_followed() {
+        // given
+        Long followerId = 1L;
+        Long followingId = 2L;
+
+        given(memberRepository.findById(followerId))
+                .willReturn(Optional.of(follower));
+        given(memberRepository.findById(followingId))
+                .willReturn(Optional.of(following));
+        given(followRepository.existsByFollowerIdAndFollowingId(followerId, followingId))
+                .willReturn(true); // 이미 팔로우한 상태
+
+        // when & then
+        assertThatThrownBy(() -> followService.follow(followerId, followingId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ALREADY_FOLLOWED_MEMBER);
+
+        verify(memberRepository, times(1)).findById(followerId);
+        verify(memberRepository, times(1)).findById(followingId);
+        verify(followRepository, never()).save(any());
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 팔로워 또는 팔로잉을 팔로우하려는 경우 예외 발생")
+    void follow_member_not_found() {
+        // given
+        Long followerId = 1L;
+        Long followingId = 2L;
+
+        // 팔로워가 존재하지 않는 경우
+        given(memberRepository.findById(followerId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> followService.follow(followerId, followingId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", FOLLOWER_NOT_FOUND_BY_ID);
+
+        // 팔로워 조회는 한 번 호출되었고, 팔로잉은 조회되지 않음
+        verify(memberRepository, times(1)).findById(followerId);
+        verify(memberRepository, never()).findById(followingId);
+        verify(followRepository, never()).existsByFollowerIdAndFollowingId(any(), any());
+        verify(followRepository, never()).save(any());
+    }
+
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 다른 회원 팔로우 기능 추가
- [x] 팔로우 테스트 코드

## 💡 자세한 설명

#### `POST /api/profile/follow/{memberId}?followerId={followerId}`

- 다른 회원 팔로우 기능 구현
- 쿼리스트링의 followerId는 현재 사용자 정보를 받아올 수 없어 임시구현. 
    - 시큐리티 적용 시 교체 `POST /api/profile/follow/{memberId}`

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?