### PR TITLE
MATE-27 : [FEAT] 메이트 게시글 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -24,7 +24,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -46,6 +45,7 @@ public class MateController {
     // 메이트 게시글 목록 조회(메인 페이지)
     @GetMapping(value = "/main", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<List<MatePostSummaryResponse>>> getMainPagePosts(@RequestParam(required = false) Long teamId) {
+
         List<MatePostSummaryResponse> matePostMain = mateService.getMainPagePosts(teamId);
         return ResponseEntity.ok(ApiResponse.success(matePostMain));
     }
@@ -59,6 +59,7 @@ public class MateController {
                                                                                                @RequestParam(required = false) Integer maxParticipants,
                                                                                                @RequestParam(required = false) String transportType,
                                                                                                @PageableDefault(size = 10) Pageable pageable) {
+
         MatePostSearchRequest request = MatePostSearchRequest.builder()
                 .teamId(teamId)
                 .sortType(sortType != null ? SortType.from(sortType) : null)
@@ -74,23 +75,10 @@ public class MateController {
 
     // 메이트 게시글 상세 조회
     @GetMapping("/{postId}")
-    public ResponseEntity<MatePostDetailResponse> getMatePostDetail(@PathVariable Long postId) {
-        return ResponseEntity.ok(MatePostDetailResponse.builder()
-                        .postImageUrl("imageUrl")
-                        .title("12월 경기 메이트 찾아요")
-                        .status(Status.OPEN)
-                        .rivalTeamName("삼성")
-                        .rivalMatchTime(LocalDateTime.now())
-                        .location("문학")
-                        .age(Age.TWENTIES)
-                        .gender(Gender.MALE)
-                        .transportType(TransportType.PUBLIC)
-                        .maxParticipants(10)
-                        .userImageUrl("imageUrl")
-                        .nickname("빌터")
-                        .manner(0.300F)
-                        .description("같이 갈 사람 구합니다.")
-                .build());
+    public ResponseEntity<ApiResponse<MatePostDetailResponse>> getMatePostDetail(@PathVariable Long postId) {
+
+        MatePostDetailResponse response = mateService.getMatePostDetail(postId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 메이트 게시글 상태 변경

--- a/src/main/java/com/example/mate/domain/mate/dto/response/MatePostDetailResponse.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/response/MatePostDetailResponse.java
@@ -1,7 +1,10 @@
 package com.example.mate.domain.mate.dto.response;
 
-import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.domain.mate.entity.MatePost;
 import com.example.mate.domain.mate.entity.Status;
 import com.example.mate.domain.mate.entity.TransportType;
 import lombok.Builder;
@@ -25,6 +28,40 @@ public class MatePostDetailResponse {
     private String userImageUrl;
     private String nickname;
     private Float manner;
-    private String description;
+    private String content;
     private Long postId;
+
+    public static MatePostDetailResponse from(MatePost post) {
+        return MatePostDetailResponse.builder()
+                .postImageUrl(post.getImageUrl())
+                .title(post.getTitle())
+                .status(post.getStatus())
+                .rivalTeamName(getRivalTeamName(post))
+                .rivalMatchTime(post.getMatch().getMatchTime())
+                .location(post.getMatch().getStadium().name)
+                .age(post.getAge())
+                .gender(post.getGender())
+                .transportType(post.getTransport())
+                .maxParticipants(post.getMaxParticipants())
+                .userImageUrl(post.getAuthor().getImageUrl())
+                .nickname(post.getAuthor().getNickname())
+                .manner(post.getAuthor().getManner())
+                .content(post.getContent())
+                .postId(post.getId())
+                .build();
+    }
+
+    private static String getRivalTeamName(MatePost post) {
+        Match match = post.getMatch();
+        Long postTeamId = post.getTeamId(); // 게시글 작성자가 선택한 팀
+
+        // 게시글 작성자가 선택한 팀이 홈팀인 경우 원정팀이 상대팀
+        if (postTeamId.equals(match.getHomeTeamId())) {
+            return TeamInfo.getById(match.getAwayTeamId()).shortName;
+        }
+        // 게시글 작성자가 선택한 팀이 원정팀인 경우 홈팀이 상대팀
+        else {
+            return TeamInfo.getById(match.getHomeTeamId()).shortName;
+        }
+    }
 }

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -26,7 +26,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.example.mate.common.error.ErrorCode.*;

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -8,6 +8,7 @@ import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
 import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
 import com.example.mate.domain.mate.dto.request.MatePostSearchRequest;
+import com.example.mate.domain.mate.dto.response.MatePostDetailResponse;
 import com.example.mate.domain.mate.dto.response.MatePostResponse;
 import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
 import com.example.mate.domain.mate.entity.MatePost;
@@ -25,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.example.mate.common.error.ErrorCode.*;
@@ -106,5 +108,12 @@ public class MateService {
                 .pageNumber(matePostPage.getNumber())
                 .pageSize(matePostPage.getSize())
                 .build();
+    }
+
+    public MatePostDetailResponse getMatePostDetail(Long postId) {
+        MatePost matePost = mateRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND));
+
+        return MatePostDetailResponse.from(matePost);
     }
 }

--- a/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
+++ b/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
@@ -5,6 +5,7 @@ import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
+import com.example.mate.domain.mate.dto.response.MatePostDetailResponse;
 import com.example.mate.domain.mate.dto.response.MatePostResponse;
 import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
 import com.example.mate.domain.mate.entity.Age;
@@ -344,6 +345,79 @@ class MateControllerTest {
                     .andExpect(jsonPath("$.data.totalElements").value(50))
                     .andExpect(jsonPath("$.data.hasNext").value(true))
                     .andExpect(jsonPath("$.code").value(200));
+        }
+    }
+
+    @Nested
+    @DisplayName("메이트 게시글 상세 조회")
+    class GetMatePostDetail {
+
+        private MatePostDetailResponse createMatePostDetailResponse() {
+            return MatePostDetailResponse.builder()
+                    .postImageUrl("test-image.jpg")
+                    .title("테스트 제목")
+                    .status(Status.OPEN)
+                    .rivalTeamName("두산")
+                    .rivalMatchTime(LocalDateTime.now().plusDays(1))
+                    .location("잠실야구장")
+                    .age(Age.TWENTIES)
+                    .gender(Gender.FEMALE)
+                    .transportType(TransportType.PUBLIC)
+                    .maxParticipants(4)
+                    .userImageUrl("user-image.jpg")
+                    .nickname("테스트닉네임")
+                    .manner(36.5f)
+                    .content("테스트 내용입니다.")
+                    .postId(1L)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상세 조회 성공")
+        void getMatePostDetail_success() throws Exception {
+            // given
+            Long postId = 1L;
+            MatePostDetailResponse response = createMatePostDetailResponse();
+
+            given(mateService.getMatePostDetail(postId))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/mates/{postId}", postId)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.postId").value(postId))
+                    .andExpect(jsonPath("$.data.title").value(response.getTitle()))
+                    .andExpect(jsonPath("$.data.status").value(response.getStatus().toString()))
+                    .andExpect(jsonPath("$.data.rivalTeamName").value(response.getRivalTeamName()))
+                    .andExpect(jsonPath("$.data.location").value(response.getLocation()))
+                    .andExpect(jsonPath("$.data.age").value(response.getAge().getValue()))
+                    .andExpect(jsonPath("$.data.gender").value(response.getGender().getValue()))
+                    .andExpect(jsonPath("$.data.transportType").value(response.getTransportType().getValue()))
+                    .andExpect(jsonPath("$.data.maxParticipants").value(response.getMaxParticipants()))
+                    .andExpect(jsonPath("$.data.nickname").value(response.getNickname()))
+                    .andExpect(jsonPath("$.data.manner").value(response.getManner()))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상세 조회 실패 - 존재하지 않는 게시글")
+        void getMatePostDetail_failPostNotFound() throws Exception {
+            // given
+            Long nonExistentPostId = 999L;
+            given(mateService.getMatePostDetail(nonExistentPostId))
+                    .willThrow(new CustomException(ErrorCode.MATE_POST_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(get("/api/mates/{postId}", nonExistentPostId)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.code").value(404));
         }
     }
 }

--- a/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
@@ -467,4 +467,69 @@ public class MateIntegrationTest {
                     .andDo(print());
         }
     }
+
+    @Nested
+    @DisplayName("메이트 게시글 상세 조회")
+    class GetMatePostDetail {
+
+        @Test
+        @DisplayName("메이트 게시글 상세 조회 성공")
+        void getMatePostDetail_Success() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/mates/" + openPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.data.postId").value(openPost.getId()))
+                    .andExpect(jsonPath("$.data.title").value("테스트 제목"))
+                    .andExpect(jsonPath("$.data.content").value("테스트 내용"))
+                    .andExpect(jsonPath("$.data.status").value("OPEN"))
+                    .andExpect(jsonPath("$.data.maxParticipants").value(4))
+                    .andExpect(jsonPath("$.data.age").value("20대"))
+                    .andExpect(jsonPath("$.data.gender").value("여자"))
+                    .andExpect(jsonPath("$.data.transportType").value("대중교통"))
+                    .andExpect(jsonPath("$.data.rivalTeamName").value("LG"))
+                    .andExpect(jsonPath("$.data.location").value("광주-기아 챔피언스 필드"))
+                    .andExpect(jsonPath("$.data.userImageUrl").value("test.jpg"))
+                    .andExpect(jsonPath("$.data.nickname").value("테스트계정"))
+                    .andExpect(jsonPath("$.data.manner").value(0.3))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상세 조회 실패 - 존재하지 않는 게시글")
+        void getMatePostDetail_NotFound() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/mates/999")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MATE_POST_NOT_FOUND.getMessage()))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상세 조회 - 모든 상태의 게시글 조회 가능")
+        void getMatePostDetail_AllStatusAccessible() throws Exception {
+            // Test OPEN status
+            mockMvc.perform(get("/api/mates/" + openPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.status").value("OPEN"));
+
+            // Test CLOSED status
+            mockMvc.perform(get("/api/mates/" + closedPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.status").value("CLOSED"));
+
+            // Test COMPLETE status
+            mockMvc.perform(get("/api/mates/" + completedPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.status").value("COMPLETE"));
+        }
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 메이트 게시글 상세 조회 API (`GET /mate-posts/{postId}`) 구현

## 💡 자세한 설명
메이트 게시글의 상세 정보를 조회할 수 있는 API를 구현했습니다. 
해당 API는 게시글 ID를 경로 변수로 받아, 데이터베이스에서 해당 게시글을 조회하고, 게시글의 상세 정보를 포함한 응답을 반환합니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?