### PR TITLE
MATE-56 : [FEAT] 팀별 주차별 일정 조회 기능 구현

### DIFF
--- a/http/Match.http
+++ b/http/Match.http
@@ -1,8 +1,8 @@
 ### [Match API] ###
 ####################
 
-### 1. 전체 경기 조회 ###
-### 메인 배너용 경기 조회 (5개) (상단 배너)
+### 전체 경기 조회 ###
+### 메인 배너용 경기 조회(5개) (상단 배너)
 GET http://localhost:8000/api/matches/main
 Content-Type: application/json
 
@@ -14,6 +14,14 @@ Content-Type: application/json
 ### KIA 팀 완료된 경기 전적 조회
 GET http://localhost:8000/api/matches/team/1/completed
 Content-Type: application/json
+
+### 팀별 주차별 경기 일정 조회 (KIA) - 날짜 지정
+GET http://localhost:8000/api/matches/team/1/weekly?startDate=2024-11-15
+Accept: application/json
+
+### 팀별 주차별 경기 일정 조회 (KIA) - 오늘 날짜 기준
+GET http://localhost:8000/api/matches/team/1/weekly
+Accept: application/json
 
 ### [Team API] ###
 #################

--- a/src/main/java/com/example/mate/domain/match/controller/MatchController.java
+++ b/src/main/java/com/example/mate/domain/match/controller/MatchController.java
@@ -2,6 +2,7 @@ package com.example.mate.domain.match.controller;
 
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.domain.match.dto.response.MatchResponse;
+import com.example.mate.domain.match.dto.response.WeeklyMatchesResponse;
 import com.example.mate.domain.match.entity.MatchStatus;
 import com.example.mate.domain.match.service.MatchService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,13 +10,13 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @RestController
@@ -46,5 +47,21 @@ public class MatchController {
     public ResponseEntity<ApiResponse<List<MatchResponse>>> getTeamCompletedMatches(
             @Parameter(description = "팀 ID") @PathVariable Long teamId) {
         return ResponseEntity.ok(ApiResponse.success(matchService.getTeamCompletedMatches(teamId)));
+    }
+
+    @Operation(summary = "팀별 주차별 경기 일정 조회")
+    @GetMapping("/team/{teamId}/weekly")
+    public ResponseEntity<ApiResponse<List<WeeklyMatchesResponse>>> getTeamWeeklyMatches(
+            @Parameter(description = "팀 ID")
+            @PathVariable Long teamId,
+            @Parameter(description = "조회 시작일 (yyyy-MM-dd), 입력하지 않으면 현재 날짜")
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate startDate
+    ) {
+        LocalDate queryDate = Optional.ofNullable(startDate).orElse(LocalDate.now());
+        return ResponseEntity.ok(ApiResponse.success(
+                matchService.getTeamWeeklyMatches(teamId, queryDate)
+        ));
     }
 }

--- a/src/main/java/com/example/mate/domain/match/dto/response/WeeklyMatchesResponse.java
+++ b/src/main/java/com/example/mate/domain/match/dto/response/WeeklyMatchesResponse.java
@@ -1,0 +1,45 @@
+package com.example.mate.domain.match.dto.response;
+
+import com.example.mate.domain.match.util.WeekCalculator;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WeeklyMatchesResponse {
+    private int weekNumber;
+    private String weekLabel;
+    private LocalDate weekStartDate;
+    private LocalDate weekEndDate;
+    private List<MatchResponse> matches;
+
+    @Builder
+    public WeeklyMatchesResponse(int weekNumber, String weekLabel,
+                                 LocalDate weekStartDate, LocalDate weekEndDate,
+                                 List<MatchResponse> matches) {
+        this.weekNumber = weekNumber;
+        this.weekLabel = weekLabel;
+        this.weekStartDate = weekStartDate;
+        this.weekEndDate = weekEndDate;
+        this.matches = matches;
+    }
+
+    public static WeeklyMatchesResponse of(
+            int weekNumber,
+            LocalDate weekStart,
+            List<MatchResponse> matches
+    ) {
+        return WeeklyMatchesResponse.builder()
+                .weekNumber(weekNumber)
+                .weekLabel(WeekCalculator.generateWeekLabel(weekStart))
+                .weekStartDate(weekStart)
+                .weekEndDate(weekStart.plusDays(6))
+                .matches(matches)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
@@ -3,8 +3,11 @@ package com.example.mate.domain.match.repository;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.entity.MatchStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -14,5 +17,15 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
     List<Match> findByStatusAndHomeTeamIdOrStatusAndAwayTeamIdOrderByMatchTimeDesc(
             MatchStatus status1, Long homeTeamId,
             MatchStatus status2, Long awayTeamId
+    );
+    @Query("SELECT m FROM Match m WHERE (m.homeTeamId = :teamId OR m.awayTeamId = :teamId) " +
+            "AND m.matchTime BETWEEN :startDate AND :endDate " +
+            "AND m.status = 'SCHEDULED' " +
+            "AND m.isCanceled = false " +
+            "ORDER BY m.matchTime ASC")
+    List<Match> findTeamMatchesInPeriod(
+            @Param("teamId") Long teamId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
     );
 }

--- a/src/main/java/com/example/mate/domain/match/service/MatchService.java
+++ b/src/main/java/com/example/mate/domain/match/service/MatchService.java
@@ -2,13 +2,21 @@ package com.example.mate.domain.match.service;
 
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.match.dto.response.MatchResponse;
+import com.example.mate.domain.match.dto.response.WeeklyMatchesResponse;
 import com.example.mate.domain.match.entity.MatchStatus;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
+import com.example.mate.domain.match.util.WeekCalculator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,6 +25,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class MatchService {
     private final MatchRepository matchRepository;
+
+    private static final int WEEKS_TO_FETCH = 4;
 
     public List<MatchResponse> getMainBannerMatches() {
         return matchRepository.findTop5ByOrderByMatchTimeDesc().stream()
@@ -44,6 +54,90 @@ public class MatchService {
                 .stream()
                 .map(match -> MatchResponse.from(match, teamId))
                 .collect(Collectors.toList());
+    }
+
+    // 특정 팀의 주차별 경기 일정 조회
+    public List<WeeklyMatchesResponse> getTeamWeeklyMatches(Long teamId, LocalDate queryDate) {
+        TeamInfo.getById(teamId);
+
+        // 현재 주의 월요일과 4주 후의 날짜 계산
+        LocalDate currentWeekStart = WeekCalculator.getWeekStart(queryDate);
+        LocalDate endDate = WeekCalculator.calculateEndDate(currentWeekStart, WEEKS_TO_FETCH);
+
+        // 경기 조회 및 주차별 그룹화
+        List<Match> matches = fetchMatchesForPeriod(teamId, queryDate, endDate);
+        return createWeeklyResponses(matches, queryDate, currentWeekStart, teamId);
+    }
+
+    // 특정 기간 동안의 팀 경기를 조회
+    private List<Match> fetchMatchesForPeriod(Long teamId, LocalDate queryDate, LocalDate endDate) {
+        return matchRepository.findTeamMatchesInPeriod(
+                teamId,
+                queryDate.atStartOfDay(),
+                endDate.atTime(LocalTime.MAX)
+        );
+    }
+
+    // 조회된 경기들을 주차별로 그룹화
+    private List<WeeklyMatchesResponse> createWeeklyResponses(
+            List<Match> matches,
+            LocalDate queryDate,
+            LocalDate weekStart,
+            Long teamId
+    ) {
+        List<WeeklyMatchesResponse> responses = new ArrayList<>();
+
+        for (int weekIndex = 0; weekIndex < WEEKS_TO_FETCH; weekIndex++) {
+            LocalDate currentWeekStart = weekStart.plusWeeks(weekIndex);
+            // 해당 주차의 경기 필터링
+            List<MatchResponse> weekMatches = filterMatchesForWeek(
+                    matches, currentWeekStart, queryDate, weekIndex, teamId);
+
+            // 주차별 응답 객체 생성
+            responses.add(WeeklyMatchesResponse.of(
+                    weekIndex + 1,
+                    currentWeekStart,
+                    weekMatches
+            ));
+        }
+
+        return responses;
+    }
+
+    // 특정 주차에 해당하는 경기만 필터링
+    private List<MatchResponse> filterMatchesForWeek(
+            List<Match> matches,
+            LocalDate weekStart,
+            LocalDate queryDate,
+            int weekIndex,
+            Long teamId
+    ) {
+        LocalDate weekEnd = weekStart.plusDays(6);
+
+        return matches.stream()
+                .filter(match -> isMatchInWeekPeriod(match, weekStart, weekEnd, queryDate, weekIndex))
+                .sorted(Comparator.comparing(Match::getMatchTime))
+                .map(match -> MatchResponse.from(match, teamId))
+                .collect(Collectors.toList());
+    }
+
+    // 경기가 해당 주차에 속하는지 판단
+    private boolean isMatchInWeekPeriod(
+            Match match,
+            LocalDate weekStart,
+            LocalDate weekEnd,
+            LocalDate queryDate,
+            int weekIndex
+    ) {
+        LocalDate matchDate = match.getMatchTime().toLocalDate();
+
+        // 조회 시작일부터 해당 주의 일요일까지의 경기
+        if (weekIndex == 0) {
+            return !matchDate.isBefore(queryDate) && !matchDate.isAfter(weekEnd);
+        }
+
+        // 2주차 ~ 4주차
+        return !matchDate.isBefore(weekStart) && !matchDate.isAfter(weekEnd);
     }
 }
 

--- a/src/main/java/com/example/mate/domain/match/util/WeekCalculator.java
+++ b/src/main/java/com/example/mate/domain/match/util/WeekCalculator.java
@@ -1,0 +1,35 @@
+package com.example.mate.domain.match.util;
+
+import lombok.experimental.UtilityClass;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+
+@UtilityClass
+public class WeekCalculator {
+    private static final WeekFields WEEK_FIELDS = WeekFields.of(DayOfWeek.MONDAY, 4);
+
+    // 주의 시작일(월요일) 계산
+    public LocalDate getWeekStart(LocalDate date) {
+        return date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+    }
+
+    // "n월 m주차" 형식의 라벨 생성
+    public String generateWeekLabel(LocalDate date) {
+        // 현재 주의 월요일 날짜를 구함
+        LocalDate mondayOfWeek = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
+        // 월요일이 속한 달과 주차로 표시
+        int month = mondayOfWeek.getMonthValue();
+        int weekOfMonth = mondayOfWeek.get(WEEK_FIELDS.weekOfMonth());
+
+        return String.format("%d월 %d주차", month, weekOfMonth);
+    }
+
+    // 시작일로부터 n주 후의 날짜 계산
+    public LocalDate calculateEndDate(LocalDate startDate, int weekCount) {
+        return startDate.plusWeeks(weekCount);
+    }
+}

--- a/src/test/java/com/example/mate/domain/match/integration/MatchIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/match/integration/MatchIntegrationTest.java
@@ -1,11 +1,14 @@
 package com.example.mate.domain.match.integration;
 
+import com.example.mate.common.response.ApiResponse;
 import com.example.mate.domain.constant.StadiumInfo;
 import com.example.mate.domain.constant.TeamInfo;
-import com.example.mate.domain.match.dto.request.MatchRequest;
+import com.example.mate.domain.match.dto.response.WeeklyMatchesResponse;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.entity.MatchStatus;
 import com.example.mate.domain.match.repository.MatchRepository;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,14 +18,24 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
-
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @SpringBootTest
@@ -33,10 +46,20 @@ class MatchIntegrationTest {
     private MockMvc mockMvc;
 
     @Autowired
+    private WebApplicationContext ctx;
+
+    @Autowired
     private MatchRepository matchRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+
         matchRepository.deleteAll();
     }
 
@@ -55,16 +78,16 @@ class MatchIntegrationTest {
         matchRepository.saveAll(Arrays.asList(pastMatch, futureMatch1, futureMatch2));
 
         // when
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/api/matches/main")
+        ResultActions result = mockMvc.perform(get("/api/matches/main")
                 .accept(MediaType.APPLICATION_JSON));
 
         // then
-        result.andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("SUCCESS"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].homeTeam.id").value(TeamInfo.SSG.id))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].homeTeam.id").value(TeamInfo.LG.id));
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].homeTeam.id").value(TeamInfo.SSG.id))
+                .andExpect(jsonPath("$.data[1].homeTeam.id").value(TeamInfo.LG.id));
     }
 
     @Test
@@ -82,30 +105,30 @@ class MatchIntegrationTest {
         matchRepository.saveAll(Arrays.asList(pastMatch, futureMatch1, futureMatch2));
 
         // when
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/api/matches/team/{teamId}", TeamInfo.LG.id)
+        ResultActions result = mockMvc.perform(get("/api/matches/team/{teamId}", TeamInfo.LG.id)
                 .accept(MediaType.APPLICATION_JSON));
 
         // then
-        result.andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("SUCCESS"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].awayTeam.id").value(TeamInfo.NC.id))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].awayTeam.id").value(TeamInfo.KT.id));
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].awayTeam.id").value(TeamInfo.NC.id))
+                .andExpect(jsonPath("$.data[1].awayTeam.id").value(TeamInfo.KT.id));
     }
 
     @Test
     @DisplayName("팀별 경기 조회 - 실패 (존재하지 않는 팀)")
     void getTeamMatches_Fail_TeamNotFound() throws Exception {
         // when
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/api/matches/team/{teamId}", 999L)
+        ResultActions result = mockMvc.perform(get("/api/matches/team/{teamId}", 999L)
                 .accept(MediaType.APPLICATION_JSON));
 
         // then
-        result.andExpect(MockMvcResultMatchers.status().isNotFound())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("ERROR"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("팀을 찾을 수 없습니다"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(404));
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("ERROR"))
+                .andExpect(jsonPath("$.message").value("팀을 찾을 수 없습니다"))
+                .andExpect(jsonPath("$.code").value(404));
     }
 
     @Test
@@ -122,19 +145,19 @@ class MatchIntegrationTest {
         matchRepository.saveAll(Arrays.asList(completedMatch1, completedMatch2, scheduledMatch));
 
         // when
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/api/matches/team/{teamId}/completed", TeamInfo.LG.id)
+        ResultActions result = mockMvc.perform(get("/api/matches/team/{teamId}/completed", TeamInfo.LG.id)
                 .accept(MediaType.APPLICATION_JSON));
 
         // then
-        result.andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("SUCCESS"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data").isArray())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].status").value("COMPLETED"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].homeTeam.id").value(TeamInfo.LG.id))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].homeScore").value(5))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].awayTeam.id").value(TeamInfo.LG.id))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].awayScore").value(7));
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].status").value("COMPLETED"))
+                .andExpect(jsonPath("$.data[0].homeTeam.id").value(TeamInfo.LG.id))
+                .andExpect(jsonPath("$.data[0].homeScore").value(5))
+                .andExpect(jsonPath("$.data[1].awayTeam.id").value(TeamInfo.LG.id))
+                .andExpect(jsonPath("$.data[1].awayScore").value(7));
     }
 
     private Match createCompletedMatch(Long homeTeamId, Long awayTeamId, Long stadiumId,
@@ -162,5 +185,128 @@ class MatchIntegrationTest {
                 .homeScore(null)
                 .awayScore(null)
                 .build();
+    }
+
+    @Test
+    @DisplayName("팀별 주차별 경기 일정 조회 - 정상 케이스")
+    void getTeamWeeklyMatches_Success() throws Exception {
+        // Given
+        LocalDate startDate = LocalDate.of(2024, 3, 25); // 월요일
+        Long teamId = TeamInfo.LG.id;
+
+        saveTestMatches(teamId, startDate);
+
+        // When
+        ApiResponse<List<WeeklyMatchesResponse>> response =
+                performWeeklyMatchesRequest(teamId, startDate);
+
+        // Then
+        assertWeeklyMatchesResponse(response, teamId, startDate);
+    }
+
+    @Test
+    @DisplayName("팀별 주차별 경기 일정 조회 - 존재하지 않는 팀")
+    void getTeamWeeklyMatches_TeamNotFound() throws Exception {
+        // Given
+        Long invalidTeamId = 999L;
+        LocalDate startDate = LocalDate.now();
+
+        // When & Then
+        mockMvc.perform(get("/api/matches/team/{teamId}/weekly", invalidTeamId)
+                        .param("startDate", startDate.toString())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("팀을 찾을 수 없습니다"));
+    }
+
+    @Test
+    @DisplayName("팀별 주차별 경기 일정 조회 - 날짜 미입력시 현재 날짜 기준 조회")
+    void getTeamWeeklyMatches_WithoutDate() throws Exception {
+        // Given
+        Long teamId = TeamInfo.LG.id;
+
+        // When & Then
+        mockMvc.perform(get("/api/matches/team/{teamId}/weekly", teamId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    private void saveTestMatches(Long teamId, LocalDate startDate) {
+        List<Match> matches = Arrays.asList(
+                createWeeklyMatch(teamId, TeamInfo.KT.id, startDate.plusDays(1)),  // 화요일
+                createWeeklyMatch(teamId, TeamInfo.NC.id, startDate.plusDays(2)),  // 수요일
+                createWeeklyMatch(teamId, TeamInfo.KIA.id, startDate.plusDays(8))  // 다음주 화요일
+        );
+        matchRepository.saveAll(matches);
+    }
+
+    private Match createWeeklyMatch(Long homeTeamId, Long awayTeamId, LocalDate matchDate) {
+        return Match.builder()
+                .homeTeamId(homeTeamId)
+                .awayTeamId(awayTeamId)
+                .stadiumId(StadiumInfo.JAMSIL.id)
+                .matchTime(matchDate.atTime(18, 30))
+                .isCanceled(false)
+                .status(MatchStatus.SCHEDULED)
+                .build();
+    }
+
+    private ApiResponse<List<WeeklyMatchesResponse>> performWeeklyMatchesRequest(
+            Long teamId, LocalDate startDate) throws Exception {
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/matches/team/{teamId}/weekly", teamId)
+                                .param("startDate", startDate.toString())
+                                .accept(MediaType.APPLICATION_JSON)
+                                .characterEncoding("UTF-8"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readValue(
+                mvcResult.getResponse().getContentAsString(),
+                new TypeReference<ApiResponse<List<WeeklyMatchesResponse>>>() {}
+        );
+    }
+
+    private void assertWeeklyMatchesResponse(
+            ApiResponse<List<WeeklyMatchesResponse>> response,
+            Long teamId,
+            LocalDate startDate
+    ) {
+        List<WeeklyMatchesResponse> weeklyResponses = response.getData();
+        assertThat(weeklyResponses).hasSize(4);
+
+        // 첫 주차 검증
+        assertFirstWeek(weeklyResponses.get(0), teamId, startDate);
+        // 두번째 주차 검증
+        assertSecondWeek(weeklyResponses.get(1));
+        // 나머지 주차 검증
+        assertThat(weeklyResponses.get(2).getMatches()).isEmpty();
+        assertThat(weeklyResponses.get(3).getMatches()).isEmpty();
+    }
+
+    private void assertFirstWeek(WeeklyMatchesResponse firstWeek, Long teamId, LocalDate startDate) {
+        assertThat(firstWeek)
+                .satisfies(week -> {
+                    assertThat(week.getWeekNumber()).isEqualTo(1);
+                    assertThat(week.getWeekLabel()).isEqualTo("3월 4주차");
+                    assertThat(week.getMatches()).hasSize(2)
+                            .extracting(
+                                    match -> match.getMatchTime().toLocalDate(),
+                                    match -> match.getHomeTeam().getId()
+                            )
+                            .containsExactly(
+                                    tuple(startDate.plusDays(1), teamId),
+                                    tuple(startDate.plusDays(2), teamId)
+                            );
+                });
+    }
+
+    private void assertSecondWeek(WeeklyMatchesResponse secondWeek) {
+        assertThat(secondWeek.getMatches()).hasSize(1);
+    }
+
+    private void assertEmptyWeeks(List<WeeklyMatchesResponse> emptyWeeks) {
+        emptyWeeks.forEach(week ->
+                assertThat(week.getMatches()).isEmpty());
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 팀별 주차별 일정 조회 전용 ResponseDTO 생성
> WeeklyMatchesResponse

- [x] 날짜 계산 @UtilityClass 생성
> WeekCalculator

- [x] MatchRepository, MatchService, MatchController 내에서 작업

- [x] 컨트롤러 테스트, 서비스 테스트, 통합 테스트 작성

## 💡 자세한 설명
**1. WeekCalculator를 유틸리티 클래스로 생성한 이유**
> 일반 클래스와 비교하여 객체 생성 없이 바로 사용 가능

MatchService 내 getTeamWeeklyMatches
![image](https://github.com/user-attachments/assets/869f2a8c-4574-4fd6-be1b-c3e63c94fc8a)

**2. MatchRepository 내 사용한 메서드**
![image](https://github.com/user-attachments/assets/efcbb0d0-42d6-4509-a870-bd9bbe104979)

> 홈팀 또는 원정팀으로 참여하는 경기만 조회 / 예정된(SCHEDULED) 상태이며 취소되지 않은 경기만 조회 / 경기 시간 순으로 정렬

**3. MatchService 내 흐름**
> getTeamWeeklyMatches 호출
> fetchMatchesForPeriod 호출하여 DB 데이터 조회
> createWeeklyResponses 호출하여 주차별 데이터 생성
> filterMatchesForWeek 호출하여 각 주차의 경기 필터링
팀 존재 여부 확인 / 주차 시작일 계산 / Repository를 통해 경기 데이터 조회 / 주차별로 데이터 그룹화 / 응답 데이터 생성
-> 팀 ID와 조회 시작일을 받아서 4주치 경기 일정을 조회
-> 조회 시작일이 속한 주의 월요일부터 4주간의 데이터 조회
-> 경기들을 주차별로 그룹화하여 응답

**4. MatchController**
![스크린샷 2024-11-29 오후 3 38 37](https://github.com/user-attachments/assets/5834f40f-42cc-4c2e-9c50-522257810f40)

> NullPointerException 방지하기 위해 Optional을 사용한 null 처리

**트러블 슈팅 기록**
MatchIntegrationTest 중
```
org.assertj.core.error.AssertJMultipleFailuresError: 
Multiple Failures (1 failure)
-- failure 1 --
Multiple Failures (1 failure)
-- failure 1 --
expected: "3월 4주차"
 but was: "3ì 4ì£¼ì°¨"
```
-> 테스트에서 한글 인코딩 문제로 보이는 것을 발견
MockMVC 설정에 CharacterEncodingFilter 추가하는 방법으로 해결
![image](https://github.com/user-attachments/assets/171d7677-7555-4af7-8c32-1df9fd56d4d6)
참고자료 : https://github.com/HomoEfficio/dev-tips/blob/master/Spring%20Test%20MockMvc%EC%9D%98%20%ED%95%9C%EA%B8%80%20%EA%B9%A8%EC%A7%90%20%EC%B2%98%EB%A6%AC.md


## 📗 참고 자료 (선택)
**WeekCalculator 관련 참고자료**
https://hojun-dev.tistory.com/entry/JAVA-LocalDate-%ED%95%9C%EA%B5%AD%EC%8B%9D-%EC%9B%94-%EC%A3%BC%EC%B0%A8-%EA%B5%AC%ED%95%98%EA%B8%B0

**주차 개념 혼동 방지를 위한 참고**
1주차: 3월 4주차 (3/25 ~ 3/31)
2주차: 4월 1주차 (4/1 ~ 4/7)
3주차: 4월 2주차 (4/8 ~ 4/14)
4주차: 4월 3주차 (4/15 ~ 4/21)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?