### PR TITLE
MATE-33 : [FEAT] 회원 언팔로우 기능 구현

### DIFF
--- a/http/Member.http
+++ b/http/Member.http
@@ -3,9 +3,14 @@
 
 ### 다른 회원 프로필 조회
 ## TODO : 리뷰 기능 구현 시 리뷰 기록 추가
-GET http://localhost:5173/api/members/1
+GET http://localhost:8080/api/members/1
 
 
 ### 회원 팔로우
 ## TODO : JWT 구현 시 쿼리스트링 삭제
-POST http://localhost:5173/api/profile/follow/1?followerId=3
+POST http://localhost:8080/api/profile/follow/1?followerId=3
+
+
+### 회원 언팔로우
+## TODO : JWT 구현 시 쿼리스트링 삭제
+DELETE http://localhost:8080/api/profile/follow/1?unfollowerId=3

--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
     ALREADY_UNFOLLOWED_MEMBER(HttpStatus.BAD_REQUEST, "F002", "이미 언팔로우한 회원입니다."),
     FOLLOWER_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "F003", "해당 ID의 팔로워 회원을 찾을 수 없습니다."),
     FOLLOWING_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "F004", "해당 ID의 팔로잉 회원을 찾을 수 없습니다."),
+    UNFOLLOWER_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "F005", "해당 ID의 언팔로워 회원을 찾을 수 없습니다."),
+    UNFOLLOWING_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "F006", "해당 ID의 언팔로잉 회원을 찾을 수 없습니다."),
 
     // Mate Post
     INVALID_MATE_POST_PARTICIPANTS(HttpStatus.BAD_REQUEST, "MP001", "모집 인원은 2명에서 10명 사이여야 합니다."),

--- a/src/main/java/com/example/mate/domain/member/controller/FollowController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/FollowController.java
@@ -42,14 +42,15 @@ public class FollowController {
     }
 
     /*
-    TODO : 2024/11/23 - 회원 언팔로우 기능
-    1. JwtToken 을 통해 사용자 정보 조회
-    2. 팔로우 여부 확인
-    3. memberId 회원 유효성 검사
-    4. 언팔로우 처리
+    TODO : 2024/11/29 - 회원 언팔로우 기능
+    1. JwtToken 을 통해 사용자 정보 조회 - 현재는 임시로 @RequestParam 사용
     */
+    @Operation(summary = "회원 언팔로우 기능")
     @DeleteMapping("/follow/{memberId}")
-    public ResponseEntity<Void> unfollowMember(@PathVariable Long memberId) {
+    public ResponseEntity<Void> unfollowMember(
+            @Parameter(description = "언팔로우할 회원 ID") @PathVariable Long memberId,
+            @Parameter(description = "언팔로우하는 회원 ID") @RequestParam Long unfollowerId) {
+        followService.unfollow(unfollowerId, memberId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
+++ b/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
@@ -18,4 +18,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     // 특정 회원에 대한 팔로잉 여부 판단
     boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
+
+    void deleteByFollower_IdAndFollowing_Id(Long followerId, Long followingId);
 }

--- a/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
+++ b/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
@@ -19,5 +19,5 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     // 특정 회원에 대한 팔로잉 여부 판단
     boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
 
-    void deleteByFollower_IdAndFollowing_Id(Long followerId, Long followingId);
+    void deleteByFollowerIdAndFollowingId(Long followerId, Long followingId);
 }

--- a/src/main/java/com/example/mate/domain/member/service/FollowService.java
+++ b/src/main/java/com/example/mate/domain/member/service/FollowService.java
@@ -6,11 +6,13 @@ import com.example.mate.domain.member.entity.Follow;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.FollowRepository;
 import com.example.mate.domain.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class FollowService {
 
@@ -19,7 +21,7 @@ public class FollowService {
 
     // 특정 회원 팔로우 - 해당 회원 팔로우 되어있는지 확인한 뒤 팔로우
     public void follow(Long followerId, Long followingId) {
-        Map<String, Member> members = isValidMember(followerId, followingId);
+        Map<String, Member> members = isValidMemberFollow(followerId, followingId);
         if (!followRepository.existsByFollowerIdAndFollowingId(followerId, followingId)) {
             followRepository.save(createFollow(members.get("follower"), members.get("following")));
         } else {
@@ -27,13 +29,32 @@ public class FollowService {
         }
     }
 
-    private Map<String, Member> isValidMember(Long followerId, Long followingId) {
+    // 특정 회원 언팔로우 - 해당 회원 팔로우 되어있는지 확인한 뒤 언팔로우
+    public void unfollow(Long unfollowerId, Long unfollowingId) {
+        Map<String, Member> members = isValidMemberUnfollow(unfollowerId, unfollowingId);
+        if (followRepository.existsByFollowerIdAndFollowingId(unfollowerId, unfollowingId)) {
+            followRepository.deleteByFollower_IdAndFollowing_Id(unfollowerId, unfollowingId);
+        } else {
+            throw new CustomException(ErrorCode.ALREADY_UNFOLLOWED_MEMBER);
+        }
+    }
+
+    private Map<String, Member> isValidMemberFollow(Long followerId, Long followingId) {
         Member follower = memberRepository.findById(followerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.FOLLOWER_NOT_FOUND_BY_ID));
         Member following = memberRepository.findById(followingId)
                 .orElseThrow(() -> new CustomException(ErrorCode.FOLLOWING_NOT_FOUND_BY_ID));
         return Map.of("follower", follower, "following", following);
     }
+
+    private Map<String, Member> isValidMemberUnfollow(Long unfollowerId, Long unfollowingId) {
+        Member follower = memberRepository.findById(unfollowerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.UNFOLLOWER_NOT_FOUND_BY_ID));
+        Member following = memberRepository.findById(unfollowingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.UNFOLLOWING_NOT_FOUND_BY_ID));
+        return Map.of("unfollower", follower, "unfollowing", following);
+    }
+
 
     private Follow createFollow(Member follower, Member following) {
         return Follow.builder().follower(follower).following(following).build();
@@ -53,6 +74,4 @@ public class FollowService {
     public int getFollowerCount(Long memberId) {
         return followRepository.countByFollowingId(memberId);
     }
-
-
 }

--- a/src/main/java/com/example/mate/domain/member/service/FollowService.java
+++ b/src/main/java/com/example/mate/domain/member/service/FollowService.java
@@ -33,7 +33,7 @@ public class FollowService {
     public void unfollow(Long unfollowerId, Long unfollowingId) {
         Map<String, Member> members = isValidMemberUnfollow(unfollowerId, unfollowingId);
         if (followRepository.existsByFollowerIdAndFollowingId(unfollowerId, unfollowingId)) {
-            followRepository.deleteByFollower_IdAndFollowing_Id(unfollowerId, unfollowingId);
+            followRepository.deleteByFollowerIdAndFollowingId(unfollowerId, unfollowingId);
         } else {
             throw new CustomException(ErrorCode.ALREADY_UNFOLLOWED_MEMBER);
         }

--- a/src/test/java/com/example/mate/domain/member/service/FollowServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/FollowServiceTest.java
@@ -166,7 +166,7 @@ class FollowServiceTest {
         verify(memberRepository, times(1)).findById(unfollowerId);
         verify(memberRepository, times(1)).findById(unfollowingId);
         verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(unfollowerId, unfollowingId);
-        verify(followRepository, times(1)).deleteByFollower_IdAndFollowing_Id(unfollowerId, unfollowingId);
+        verify(followRepository, times(1)).deleteByFollowerIdAndFollowingId(unfollowerId, unfollowingId);
     }
 
     @Test
@@ -190,7 +190,7 @@ class FollowServiceTest {
 
         verify(memberRepository, times(1)).findById(unfollowerId);
         verify(memberRepository, times(1)).findById(unfollowingId);
-        verify(followRepository, never()).deleteByFollower_IdAndFollowing_Id(any(), any());
+        verify(followRepository, never()).deleteByFollowerIdAndFollowingId(any(), any());
     }
 
     @Test
@@ -213,6 +213,6 @@ class FollowServiceTest {
         verify(memberRepository, times(1)).findById(unfollowerId);
         verify(memberRepository, never()).findById(unfollowingId);
         verify(followRepository, never()).existsByFollowerIdAndFollowingId(any(), any());
-        verify(followRepository, never()).deleteByFollower_IdAndFollowing_Id(any(), any());
+        verify(followRepository, never()).deleteByFollowerIdAndFollowingId(any(), any());
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 다른 회원 언팔로우 기능 추가
- [x] 언팔로우 테스트 코드

## 💡 자세한 설명

#### `DELETE /api/profile/follow/{memberId}?unfollowerId={unfollowerId}`

- 다른 회원 언팔로우 기능 구현
- 쿼리스트링의 unfollowerId는 현재 사용자 정보를 받아올 수 없어 임시구현. 
    - 시큐리티 적용 시 교체 `DELETE /api/profile/follow/{memberId}`

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?