### PR TITLE
MATE-29 : [FEAT] 메이트 게시글 삭제 기능 구현 및 테스트 커버리지 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.5'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'com.example'
@@ -68,4 +69,18 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport  // 테스트 후 리포트 생성
+}
+
+jacocoTestReport {
+
+    // test 태스크가 실행된 후에 리포트를 생성하도록 지정
+    dependsOn test
+
+    // 리포트 출력 형식 설정
+    reports {
+        xml.required = false
+        csv.required = false
+        html.required = true
+    }
 }

--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -32,9 +32,11 @@ public enum ErrorCode {
     INVALID_MATE_POST_PARTICIPANTS(HttpStatus.BAD_REQUEST, "MP001", "모집 인원은 2명에서 10명 사이여야 합니다."),
     INVALID_MATE_POST_STATUS_CHANGE(HttpStatus.BAD_REQUEST, "MP002", "직관 완료된 게시글은 상태를 변경할 수 없습니다."),
     INVALID_MATE_POST_COMPLETION(HttpStatus.BAD_REQUEST, "MP003", "모집완료 상태에서만 직관 완료가 가능합니다."),
-    MATE_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "MP004", "해당 ID의 메이트 게시글을 찾을 수 없습니다."),
+    MATE_POST_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "MP004", "해당 ID의 메이트 게시글을 찾을 수 없습니다."),
     UNAUTHORIZED_MATE_POST_ACCESS(HttpStatus.FORBIDDEN, "MP005", "해당 메이트 게시글에 대한 권한이 없습니다."),
-  
+    MATE_POST_DELETE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MP006", "메이트 게시글의 작성자가 아니라면, 게시글을 수정할 수 없습니다"),
+
+
     // Goods
     GOODS_IMAGES_ARE_EMPTY(HttpStatus.BAD_REQUEST, "G001", "굿즈 이미지는 최소 1개 이상을 업로드 할 수 있습니다."),
     GOODS_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "G002", "해당 ID의 굿즈 판매글 정보를 찾을 수 없습니다"),

--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -81,7 +81,7 @@ public class MateController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // 메이트 게시글 상태 변경
+    // 메이트 게시글 모집 상태 변경(모집중, 모집완료)
     @PatchMapping("/{postId}/status")
     public ResponseEntity<MatePostResponse> updateMatePostStatus(
             @PathVariable Long postId,
@@ -90,9 +90,11 @@ public class MateController {
         return ResponseEntity.ok(MatePostResponse.builder().id(1L).status(Status.CLOSED).build());
     }
 
+    // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
     // 메이트 게시글 삭제
-    @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deleteMatePost(@PathVariable Long postId) {
+    @DeleteMapping("/{memberId}/{postId}")
+    public ResponseEntity<Void> deleteMatePost(@PathVariable Long memberId, @PathVariable Long postId) {
+        mateService.deleteMatePost(memberId, postId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/example/mate/domain/mate/entity/MatePost.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/MatePost.java
@@ -64,7 +64,7 @@ public class MatePost {
     @Column(name = "transport", nullable = false)
     private TransportType transport;
 
-    @OneToOne(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "post")
     private Visit visit;
 
     // Team 정보 조회
@@ -115,11 +115,9 @@ public class MatePost {
             throw new IllegalStateException("모집완료 상태에서만 직관 완료가 가능합니다.");
         }
 
-        if (this.visit == null) {
-            this.visit = Visit.builder()
-                    .post(this)
-                    .build();
-        }
+        this.visit = Visit.builder()
+                .post(this)
+                .build();
 
         this.status = Status.COMPLETE;
         return this.visit;

--- a/src/main/java/com/example/mate/domain/mate/entity/Visit.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/Visit.java
@@ -20,7 +20,7 @@ public class Visit {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id", nullable = false)
+    @JoinColumn(name = "post_id")
     private MatePost post;
 
     @OneToMany(mappedBy = "visit")
@@ -31,7 +31,10 @@ public class Visit {
     @Builder.Default
     private List<MateReview> reviews = new ArrayList<>();
 
-    // 참여자 추가
+    public void detachPost() {
+        this.post = null;
+    }
+
     public void addParticipants(List<Member> members) {
         members.forEach(member -> {
             VisitPart visitPart = VisitPart.builder()

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -111,8 +111,23 @@ public class MateService {
 
     public MatePostDetailResponse getMatePostDetail(Long postId) {
         MatePost matePost = mateRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND_BY_ID));
 
         return MatePostDetailResponse.from(matePost);
+    }
+
+    public void deleteMatePost(Long memberId, Long postId) {
+        MatePost matePost = mateRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND_BY_ID));
+
+        if (!matePost.getAuthor().getId().equals(memberId)) {
+            throw new CustomException(MATE_POST_DELETE_NOT_ALLOWED);
+        }
+
+        if (matePost.getStatus() == Status.COMPLETE) {
+            matePost.getVisit().detachPost();
+        }
+
+        mateRepository.delete(matePost);
     }
 }

--- a/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
@@ -5,10 +5,7 @@ import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
 import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
-import com.example.mate.domain.mate.entity.Age;
-import com.example.mate.domain.mate.entity.MatePost;
-import com.example.mate.domain.mate.entity.Status;
-import com.example.mate.domain.mate.entity.TransportType;
+import com.example.mate.domain.mate.entity.*;
 import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
@@ -31,8 +28,7 @@ import java.util.List;
 
 import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -505,7 +501,7 @@ public class MateIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.status").value("ERROR"))
-                    .andExpect(jsonPath("$.message").value(ErrorCode.MATE_POST_NOT_FOUND.getMessage()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MATE_POST_NOT_FOUND_BY_ID.getMessage()))
                     .andExpect(jsonPath("$.code").value(404))
                     .andDo(print());
         }
@@ -530,6 +526,86 @@ public class MateIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.status").value("COMPLETE"));
+        }
+    }
+
+    @Nested
+    @DisplayName("메이트 게시글 삭제")
+    class DeleteMatePost {
+
+        @Test
+        @DisplayName("메이트 게시글 삭제 성공")
+        void deleteMatePost_Success() throws Exception {
+            // when & then
+            mockMvc.perform(delete("/api/mates/{memberId}/{postId}", testMember.getId(), openPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNoContent())
+                    .andDo(print());
+
+            // DB 검증
+            assertThat(mateRepository.findById(openPost.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 삭제 실패 - 존재하지 않는 게시글")
+        void deleteMatePost_NotFound() throws Exception {
+            // when & then
+            mockMvc.perform(delete("/api/mates/{memberId}/{postId}", testMember.getId(), 999L)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MATE_POST_NOT_FOUND_BY_ID.getMessage()))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andDo(print());
+
+            // DB 검증 - 기존 게시글들은 여전히 존재
+            assertThat(mateRepository.findAll()).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 삭제 실패 - 권한 없음")
+        void deleteMatePost_NotAllowed() throws Exception {
+            // given
+            Member otherMember = memberRepository.save(Member.builder()
+                    .name("다른유저")
+                    .email("other@test.com")
+                    .nickname("다른계정")
+                    .imageUrl("other.jpg")
+                    .gender(Gender.MALE)
+                    .age(30)
+                    .manner(0.3f)
+                    .build());
+
+            // when & then
+            mockMvc.perform(delete("/api/mates/{memberId}/{postId}", otherMember.getId(), openPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MATE_POST_DELETE_NOT_ALLOWED.getMessage()))
+                    .andExpect(jsonPath("$.code").value(403))
+                    .andDo(print());
+
+            // DB 검증 - 게시글이 삭제되지 않음
+            assertThat(mateRepository.findById(openPost.getId())).isPresent();
+        }
+
+        @Test
+        @DisplayName("직관 완료된 게시글 삭제 시 Visit 엔티티와 연관관계 제거")
+        void deleteMatePost_WithCompletedStatus() throws Exception {
+            // given
+            MatePost post = createMatePost(futureMatch, 1L, Status.CLOSED); // CLOSED 상태로 생성
+            post.completeVisit(List.of(testMember.getId())); // completeVisit 호출하여 COMPLETE로 변경
+            Visit visit = post.getVisit();
+
+            // when
+            mockMvc.perform(delete("/api/mates/{memberId}/{postId}", testMember.getId(), post.getId())
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNoContent())
+                    .andDo(print());
+
+            // then
+            assertThat(mateRepository.findById(post.getId())).isEmpty();
+            assertThat(visit.getPost()).isNull();
         }
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 메이트 게시글 삭제 기능 구현
- [x] 게시글-방문 엔티티 간 연관관계 개선
- [x] JaCoCo를 사용한 테스트 커버리지 측정 도구 추가

## 💡 자세한 설명

### 1. 메이트 게시글 삭제 기능
- 게시글 작성자만 삭제할 수 있도록 권한 검증 로직 구현
- 존재하지 않는 게시글에 대한 예외 처리 추가
- 게시글 삭제 시 204 No Content 응답 처리

### 2. 엔티티 연관관계 개선
- Visit 엔티티의 post 필드를 옵션널하게 변경
  - 게시글이 삭제되어도 Visit 기록은 유지하기 위함
- Visit 엔티티에 post 연관관계 제거 메서드(detachPost) 추가
- MatePost의 Visit cascade 설정 제거
  - 게시글 삭제 시 Visit 엔티티가 함께 삭제되는 것을 방지

### 3. TODO 사항
- 현재 memberId를 PathVariable로 받고 있으나, 추후 @AuthenticationPrincipal을 사용하도록 변경 예정

### 4. 테스트 커버리지 측정 도구 추가
- JaCoCo 플러그인을 통한 테스트 커버리지 측정 가능
- 테스트를 run with coverage 로 돌리고, 우측의 Coverage 를 누르면 클래스 하나하나 파악해볼수있습니다!
![image](https://github.com/user-attachments/assets/a592b1c2-124d-4242-8f02-9c6d69d2e345)


## 📢 리뷰 요구 사항
- Visit 엔티티 분리 방식에 대해서 검토 부탁드립니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?