### PR TITLE
MATE-36 : [FEAT] CATCH Mi 회원 가입 기능 구현

### DIFF
--- a/http/Member.http
+++ b/http/Member.http
@@ -14,3 +14,17 @@ POST http://localhost:8080/api/profile/follow/1?followerId=3
 ### 회원 언팔로우
 ## TODO : JWT 구현 시 쿼리스트링 삭제
 DELETE http://localhost:8080/api/profile/follow/1?unfollowerId=3
+
+
+### 자체 회원가입
+POST http://localhost:8080/api/members/join
+Content-Type: application/json
+
+{
+  "name": "홍길동",
+  "email": "new@example.com",
+  "gender": "M",
+  "birthyear": "2000",
+  "teamId": 1,
+  "nickname": "newTester"
+}

--- a/src/main/java/com/example/mate/domain/auth/dto/response/NaverProfileResponse.java
+++ b/src/main/java/com/example/mate/domain/auth/dto/response/NaverProfileResponse.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 public class NaverProfileResponse {
 
     private String name;
-    private String nickname;
+    //    private String nickname;  // 사용자 입력 nickname과 겹쳐 삭제 필요
     private String email;
     private String gender;
     private String birthyear;
@@ -21,7 +21,7 @@ public class NaverProfileResponse {
 
         return NaverProfileResponse.builder()
                 .name(element.getAsJsonObject().get("response").getAsJsonObject().get("name").getAsString())
-                .nickname(element.getAsJsonObject().get("response").getAsJsonObject().get("nickname").getAsString())
+//                .nickname(element.getAsJsonObject().get("response").getAsJsonObject().get("nickname").getAsString())
                 .email(element.getAsJsonObject().get("response").getAsJsonObject().get("email").getAsString())
                 .gender(element.getAsJsonObject().get("response").getAsJsonObject().get("gender").getAsString())
                 .birthyear(element.getAsJsonObject().get("response").getAsJsonObject().get("birthyear").getAsString())

--- a/src/main/java/com/example/mate/domain/constant/Gender.java
+++ b/src/main/java/com/example/mate/domain/constant/Gender.java
@@ -28,4 +28,13 @@ public enum Gender {
         }
         throw new CustomException(ErrorCode.INVALID_GENDER_VALUE);
     }
+
+    // M 또는 F를 기반으로 Gender를 반환하는 메서드 추가
+    public static Gender fromCode(String code) {
+        return switch (code.toUpperCase()) {
+            case "M" -> MALE;
+            case "F" -> FEMALE;
+            default -> throw new CustomException(ErrorCode.INVALID_GENDER_VALUE);
+        };
+    }
 }

--- a/src/main/java/com/example/mate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import com.example.mate.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,24 +33,16 @@ public class MemberController {
     private final MemberService memberService;
 
     /*
-        TODO : 2024/11/23 - 소셜 회원가입 후, 자체 회원가입 기능
-        1. JwtToken 을 통해 사용자 정보 조회
-        2. nickname, myTeam 정보 저장
-        */
+    TODO : 2024/11/29 - 소셜 회원가입 후, 자체 회원가입 기능
+    1. 소셜 로그인 후 사용자 정보가 바로 넘어오도록 처리
+    2. nickname, myTeam 정보 저장
+    */
+    @Operation(summary = "자체 회원가입 기능")
     @PostMapping("/join")
-    public ResponseEntity<JoinResponse> join(
-            @RequestBody JoinRequest joinRequest
+    public ResponseEntity<ApiResponse<JoinResponse>> join(
+            @Parameter(description = "소셜 로그인 정보와 사용자 추가 입력 정보") @RequestBody @Valid JoinRequest joinRequest
     ) {
-        JoinResponse joinResponse = JoinResponse.builder()
-                .name("홍길동")
-                .nickname(joinRequest.getNickname())
-                .email("test@gmail.com")
-                .age(25)
-                .gender("FEMALE")
-                .team("삼성")
-                .build();
-
-        return ResponseEntity.ok(joinResponse);
+        return ResponseEntity.ok(ApiResponse.success(memberService.join(joinRequest)));
     }
 
     /*

--- a/src/main/java/com/example/mate/domain/member/dto/request/JoinRequest.java
+++ b/src/main/java/com/example/mate/domain/member/dto/request/JoinRequest.java
@@ -1,10 +1,24 @@
 package com.example.mate.domain.member.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class JoinRequest {
 
+    private String name;
+    private String email;
+    private String gender;
+    private String birthyear;
+
+    @Min(value = 0, message = "teamId는 0 이상이어야 합니다.")
+    @Max(value = 10, message = "teamId는 10 이하이어야 합니다.")
     private Long teamId;
+
+    @Size(max = 20, message = "nickname은 최대 20자까지 입력할 수 있습니다.")
     private String nickname;
 }

--- a/src/main/java/com/example/mate/domain/member/dto/response/JoinResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/JoinResponse.java
@@ -1,5 +1,7 @@
 package com.example.mate.domain.member.dto.response;
 
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,4 +18,15 @@ public class JoinResponse {
     private Integer age;
     private String gender;
     private String team;
+
+    public static JoinResponse from(Member member) {
+        return JoinResponse.builder()
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .age(member.getAge())
+                .gender(member.getGender().getValue())
+                .team(TeamInfo.getById(member.getTeamId()).shortName)
+                .build();
+    }
 }

--- a/src/main/java/com/example/mate/domain/member/entity/Member.java
+++ b/src/main/java/com/example/mate/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.example.mate.domain.member.entity;
 
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.member.dto.request.JoinRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,8 +40,9 @@ public class Member {
     @Column(name = "email", length = 40, nullable = false, unique = true)
     private String email;
 
+    @Builder.Default
     @Column(name = "image_url", nullable = false)
-    private String imageUrl;
+    private String imageUrl = "/images/default.png"; // TODO : 이미지 기본 경로 설정 필요
 
     @Column(name = "age", nullable = false)
     private Integer age;
@@ -72,5 +75,16 @@ public class Member {
 
     public void changeAboutMe(String aboutMe) {
         this.aboutMe = aboutMe;
+    }
+
+    public static Member from(JoinRequest request) {
+        return Member.builder()
+                .name(request.getName())
+                .nickname(request.getNickname())
+                .email(request.getEmail())
+                .age(LocalDate.now().getYear() - Integer.parseInt(request.getBirthyear()))
+                .gender(Gender.fromCode(request.getGender()))
+                .teamId(request.getTeamId())
+                .build();
     }
 }

--- a/src/main/java/com/example/mate/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/mate/domain/member/service/MemberService.java
@@ -4,6 +4,8 @@ import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.member.dto.request.JoinRequest;
+import com.example.mate.domain.member.dto.response.JoinResponse;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.FollowRepository;
@@ -18,6 +20,12 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
     private final GoodsPostRepository goodsPostRepository;
+
+    // 자체 회원가입 기능
+    public JoinResponse join(JoinRequest request) {
+        Member savedMember = memberRepository.save(Member.from(request));
+        return JoinResponse.from(savedMember);
+    }
 
     // 다른 회원 프로필 조회
     public MemberProfileResponse getMemberProfile(Long memberId) {

--- a/src/test/java/com/example/mate/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/mate/domain/auth/controller/AuthControllerTest.java
@@ -55,7 +55,6 @@ public class AuthControllerTest {
                 .isNewMember(true)
                 .naverProfileResponse(NaverProfileResponse.builder()
                         .name("홍길동")
-                        .nickname("tester")
                         .email("tester@naver.com")
                         .gender("M")
                         .birthyear("2000")

--- a/src/test/java/com/example/mate/domain/auth/integration/NaverAuthIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/auth/integration/NaverAuthIntegrationTest.java
@@ -52,11 +52,11 @@ public class NaverAuthIntegrationTest {
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess(
                         "{ \"response\": { " +
-                                "\"name\": \"정원주\", " +
-                                "\"nickname\": \"뿔버섯\", " +
-                                "\"email\": \"jwxxjx@naver.com\", " +
+                                "\"name\": \"홍길동\", " +
+                                "\"nickname\": \"오리\", " +
+                                "\"email\": \"tester222\", " +
                                 "\"gender\": \"M\", " +
-                                "\"birthyear\": \"1993\" " +
+                                "\"birthyear\": \"2000\" " +
                                 "} }",
                         MediaType.APPLICATION_JSON));
     }
@@ -93,10 +93,9 @@ public class NaverAuthIntegrationTest {
                 .andExpect(jsonPath("$.accessToken", is("accessToken")))
                 .andExpect(jsonPath("$.refreshToken", is("refreshToken")))
                 .andExpect(jsonPath("$.isNewMember", is(true))) // 신규 회원 여부 확인
-                .andExpect(jsonPath("$.naverProfileResponse.name", is("정원주"))) // 사용자 이름 확인
-                .andExpect(jsonPath("$.naverProfileResponse.nickname", is("뿔버섯"))) // 닉네임 확인
-                .andExpect(jsonPath("$.naverProfileResponse.email", is("jwxxjx@naver.com"))) // 이메일 확인
+                .andExpect(jsonPath("$.naverProfileResponse.name", is("홍길동"))) // 사용자 이름 확인
+                .andExpect(jsonPath("$.naverProfileResponse.email", is("tester222"))) // 이메일 확인
                 .andExpect(jsonPath("$.naverProfileResponse.gender", is("M"))) // 성별 확인
-                .andExpect(jsonPath("$.naverProfileResponse.birthyear", is("1993"))); // 생년 확인
+                .andExpect(jsonPath("$.naverProfileResponse.birthyear", is("2000"))); // 생년 확인
     }
 }

--- a/src/test/java/com/example/mate/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/MemberControllerTest.java
@@ -1,10 +1,15 @@
 package com.example.mate.domain.member.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.mate.domain.member.dto.request.JoinRequest;
+import com.example.mate.domain.member.dto.response.JoinResponse;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
 import com.example.mate.domain.member.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,6 +49,93 @@ class MemberControllerTest {
                 .reviewsCount(5)
                 .goodsSoldCount(15)
                 .build();
+    }
+
+    private JoinRequest createTestJoinRequest() {
+        return JoinRequest.builder()
+                .name("홍길동")
+                .email("test@example.com")
+                .gender("M")
+                .birthyear("2000")
+                .teamId(1L)
+                .nickname("tester")
+                .build();
+    }
+
+    private JoinResponse createTestJoinResponse() {
+        return JoinResponse.builder()
+                .name("홍길동")
+                .nickname("tester")
+                .email("test@example.com")
+                .age(24)
+                .gender("남자")
+                .team("KIA")
+                .build();
+    }
+
+    @Test
+    @DisplayName("자체 회원 가입 - 성공")
+    void join_success() throws Exception {
+        // given
+        JoinRequest joinRequest = createTestJoinRequest();
+        JoinResponse joinResponse = createTestJoinResponse();
+
+        given(memberService.join(any(JoinRequest.class))).willReturn(joinResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.name").value("홍길동"))
+                .andExpect(jsonPath("$.data.email").value("test@example.com"))
+                .andExpect(jsonPath("$.data.nickname").value("tester"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원 가입 - teamId가 유효하지 않으면 400 오류 반환")
+    void join_fail_team_id_invalid() throws Exception {
+        // given
+        JoinRequest invalidJoinRequest = JoinRequest.builder()
+                .name("홍길동")
+                .email("test@example.com")
+                .gender("M")
+                .birthyear("2000")
+                .teamId(15L)  // 유효하지 않은 teamId
+                .nickname("tester")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidJoinRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value("teamId: teamId는 10 이하이어야 합니다."));
+    }
+
+    @Test
+    @DisplayName("회원 가입 - nickname이 최대 길이(20자)를 초과하면 오류")
+    void join_fail_invalid_nickname() throws Exception {
+        // given
+        JoinRequest invalidJoinRequest = JoinRequest.builder()
+                .name("홍길동")
+                .email("test@example.com")
+                .gender("M")
+                .birthyear("2000")
+                .teamId(5L)
+                .nickname("tester12345678901234567890")  // nickname 길이가 20자를 초과
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidJoinRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message")
+                        .value("nickname: nickname은 최대 20자까지 입력할 수 있습니다."));
     }
 
     @Test

--- a/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
@@ -1,14 +1,17 @@
 package com.example.mate.domain.member.integration;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.member.dto.request.JoinRequest;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import com.example.mate.domain.member.service.MemberService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
@@ -28,6 +32,9 @@ class MemberIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(MemberIntegrationTest.class);
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -55,6 +62,85 @@ class MemberIntegrationTest {
                 .build();
         memberRepository.save(member);
     }
+
+    private JoinRequest createTestJoinRequest() {
+        return JoinRequest.builder()
+                .name("김철수")
+                .email("tester2@example.com")
+                .gender("M")
+                .birthyear("2002")
+                .teamId(1L)
+                .nickname("tester2")
+                .build();
+    }
+
+    @Test
+    @DisplayName("자체 회원 가입 - 성공")
+    void join_success() throws Exception {
+        // given
+        JoinRequest joinRequest = createTestJoinRequest();
+
+        // when & then
+        mockMvc.perform(post("/api/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.name").value("김철수"))
+                .andExpect(jsonPath("$.data.email").value("tester2@example.com"))
+                .andExpect(jsonPath("$.data.age").value(22))
+                .andExpect(jsonPath("$.data.nickname").value("tester2"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원 가입 - teamId가 유효하지 않으면 오류")
+    void join_fail_invalid_teamId() throws Exception {
+        // given
+        JoinRequest invalidJoinRequest = JoinRequest.builder()
+                .name("김철수")
+                .email("tester2@example.com")
+                .gender("M")
+                .birthyear("2002")
+                .teamId(15L)  // 유효하지 않은 teamId
+                .nickname("tester2")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidJoinRequest)))
+                .andExpect(status().isBadRequest())  // 400 오류가 반환되기를 기대
+                .andExpect(jsonPath("$.status").value("ERROR"))
+                .andExpect(jsonPath("$.message").value("teamId: teamId는 10 이하이어야 합니다."))
+                .andExpect(jsonPath("$.code").value(400))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원 가입 - nickname이 최대 길이(20자)를 초과하면 오류")
+    void join_fail_invalid_nickname() throws Exception {
+        // given
+        JoinRequest invalidJoinRequest = JoinRequest.builder()
+                .name("김철수")
+                .email("tester2@example.com")
+                .gender("M")
+                .birthyear("2002")
+                .teamId(1L)
+                .nickname("tester12345678901234567890")  // nickname 길이가 20자를 초과
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/api/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidJoinRequest)))
+                .andExpect(status().isBadRequest())  // 400 오류가 반환되기를 기대
+                .andExpect(jsonPath("$.status").value("ERROR"))
+                .andExpect(jsonPath("$.message").value("nickname: nickname은 최대 20자까지 입력할 수 있습니다."))
+                .andExpect(jsonPath("$.code").value(400))
+                .andDo(print());
+    }
+
 
     @Test
     @DisplayName("다른 회원 프로필 조회 - 성공")

--- a/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
@@ -2,13 +2,17 @@ package com.example.mate.domain.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
+import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.member.dto.request.JoinRequest;
+import com.example.mate.domain.member.dto.response.JoinResponse;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.FollowRepository;
@@ -39,20 +43,24 @@ class MemberServiceTest {
 
     private Member member;
     private GoodsPost goodsPost;
+    private JoinRequest joinRequest;
 
     @BeforeEach
     void setUp() {
         createTestMember();
-        createTestGoodsPost();
+        createTestJoinRequest();
     }
 
     private void createTestMember() {
         member = Member.builder()
                 .id(1L)
                 .name("홍길동")
-                .teamId(1L)
-                .email("test@example.com")
                 .nickname("tester")
+                .email("test@example.com")
+                .age(30)
+                .gender(Gender.MALE)
+                .teamId(1L)
+                .manner(0.300F)
                 .build();
     }
 
@@ -62,6 +70,32 @@ class MemberServiceTest {
                 .seller(member)
                 .status(Status.CLOSED)
                 .build();
+    }
+
+    private void createTestJoinRequest() {
+        joinRequest = JoinRequest.builder()
+                .name("홍길동")
+                .email("test@example.com")
+                .gender("M")
+                .birthyear("1993")
+                .teamId(1L)
+                .nickname("tester")
+                .build();
+    }
+
+    @Test
+    @DisplayName("자체 회원 가입 - 성공")
+    void join_success() {
+        // given
+        given(memberRepository.save(any(Member.class)))
+                .willReturn(member);
+
+        // when
+        JoinResponse response = memberService.join(joinRequest);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getNickname()).isEqualTo(member.getNickname());
     }
 
     @Test


### PR DESCRIPTION
## 💡 작업 내용

- [x] 자체 회원 가입 기능 구현
- [x] 테스트 작성
- [x] 네이버 회원 응답 DTO 수정으로 발생한 테스트 오류 일부 수정

## 💡 자세한 설명

### 자체 회원 가입 기능 구현
- 소셜 로그인 이후 회원 가입 화면에서 넘어오는 정보를 바탕으로 자체 회원 가입
- 팀 선택과 닉네임 길이 제한 처리

### 네이버 회원 응답 DTO 수정
- 기존 네이버 소셜 로그인에서 nickname까지 받아오던 값을 제외
    - 자체 회원가입 창에서 nickname을 또다시 기입하여, Request Body 안에서 중복으로 인한 에러 발생

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?