### PR TITLE
MATE-49 : [FEAT] 메인페이지 굿즈거래 판매글 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ application-local.yml
 
 ### VS Code ###
 .vscode/
+
+### SQL ###
+*.sql

--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -37,8 +37,9 @@ public enum ErrorCode {
   
     // Goods
     GOODS_IMAGES_ARE_EMPTY(HttpStatus.BAD_REQUEST, "G001", "굿즈 이미지는 최소 1개 이상을 업로드 할 수 있습니다."),
-    GOODS_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "G002", "해당 ID의 굿즈 판매글 정보를 찾을 수 없습니다"),
-    GOODS_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "G003", "판매글의 판매자가 아니라면, 판매글을 수정할 수 없습니다"),
+    GOODS_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "G002", "해당 ID의 굿즈 판매글 정보를 찾을 수 없습니다."),
+    GOODS_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "G003", "판매글의 판매자가 아니라면, 판매글을 수정할 수 없습니다."),
+    GOODS_MAIN_IMAGE_IS_EMPTY(HttpStatus.NOT_FOUND, "G004", "굿즈 게시물의 대표사진을 찾을 수 없습니다."),
 
     // FILE
     FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "F001", "빈 파일을 업로드할 수 없습니다. 파일 내용을 확인해주세요."),

--- a/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
+++ b/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
@@ -83,13 +83,12 @@ public class GoodsController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /*
-    메인 페이지 : 굿즈 거래글 요약 4개 리스트 조회
-    테스트 용도로, 가상의 동일한 거래글 데이터 4개를 생성
-     */
+
+    // 메인 페이지 : 굿즈 거래글 요약 4개 리스트 조회
     @GetMapping("/main")
-    public ResponseEntity<List<GoodsPostSummaryResponse>> getGoodsPostsMain(@RequestParam Long teamId) {
-        return ResponseEntity.ok(Collections.nCopies(4, GoodsPostSummaryResponse.createResponse(teamId)));
+    public ResponseEntity<ApiResponse<List<GoodsPostSummaryResponse>>> getGoodsPostsMain(@RequestParam(required = false) Long teamId) {
+        List<GoodsPostSummaryResponse> responses = goodsService.getMainGoodsPosts(teamId);
+        return ResponseEntity.ok(ApiResponse.success(responses));
     }
 
     /*

--- a/src/main/java/com/example/mate/domain/goods/dto/MemberInfo.java
+++ b/src/main/java/com/example/mate/domain/goods/dto/MemberInfo.java
@@ -17,13 +17,15 @@ public class MemberInfo {
     private String nickname;
     private Float manner;
     private Role role;
+    private String imageUrl;
 
     @Builder
-    public MemberInfo(Long memberId, String nickname, Float manner, Role role) {
+    public MemberInfo(Long memberId, String nickname, Float manner, Role role, String imageUrl) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.manner = manner;
         this.role = role;
+        this.imageUrl = imageUrl;
     }
 
     public static MemberInfo from(Member member, Role role) {
@@ -31,6 +33,7 @@ public class MemberInfo {
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .manner(member.getManner())
+                .imageUrl(member.getImageUrl())
                 .role(role)
                 .build();
     }

--- a/src/main/java/com/example/mate/domain/goods/dto/request/GoodsPostRequest.java
+++ b/src/main/java/com/example/mate/domain/goods/dto/request/GoodsPostRequest.java
@@ -17,7 +17,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GoodsPostRequest {
 
-    @NotNull(message = "팀 ID는 필수 입력 값입니다.")
     @Min(value = 0, message = "팀 ID는 0 이상이어야 합니다.")
     @Max(value = 10, message = "팀 ID는 10 이하이어야 합니다.")
     private Long teamId;

--- a/src/main/java/com/example/mate/domain/goods/dto/response/GoodsPostResponse.java
+++ b/src/main/java/com/example/mate/domain/goods/dto/response/GoodsPostResponse.java
@@ -29,10 +29,12 @@ public class GoodsPostResponse {
     private final String status;
 
     public static GoodsPostResponse of(GoodsPost goodsPost) {
+        String teamName = goodsPost.getTeamId() == null ? null : TeamInfo.getById(goodsPost.getTeamId()).shortName;
+
         return GoodsPostResponse.builder()
                 .id(goodsPost.getId())
                 .seller(MemberInfo.from(goodsPost.getSeller(), Role.SELLER))
-                .teamName(TeamInfo.getById(goodsPost.getTeamId()).shortName)
+                .teamName(teamName)
                 .title(goodsPost.getTitle())
                 .category(goodsPost.getCategory().getValue())
                 .price(goodsPost.getPrice())

--- a/src/main/java/com/example/mate/domain/goods/dto/response/GoodsPostSummaryResponse.java
+++ b/src/main/java/com/example/mate/domain/goods/dto/response/GoodsPostSummaryResponse.java
@@ -2,8 +2,7 @@ package com.example.mate.domain.goods.dto.response;
 
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.goods.entity.Category;
-
-import java.util.Arrays;
+import com.example.mate.domain.goods.entity.GoodsPost;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -20,19 +19,16 @@ public class GoodsPostSummaryResponse {
     private final Integer price;
     private final String imageUrl;
 
-    /*
-    팀 선택에 따른 굿즈 거래글 요약 조회 요청을 GoodsPostSummaryResponse로 반환
-    거래글 id, 제목, 카테고리, 가격, 이미지 경로는 하드코딩
-    요청한 team과 cateogory에 따른 반환 값 확인
-     */
-    public static GoodsPostSummaryResponse createResponse(Long teamId) {
+    public static GoodsPostSummaryResponse of(GoodsPost goodsPost, String mainImageUrl) {
+        String teamName = goodsPost.getTeamId() == null ? null : TeamInfo.getById(goodsPost.getTeamId()).shortName;
+
         return GoodsPostSummaryResponse.builder()
-                .id(1L)
-                .teamName(getTeamName(teamId))
-                .title("NC 다이노스 배틀크러쉬 모자")
-                .category(Category.CAP.getValue())
-                .price(40000)
-                .imageUrl("upload/thumbnail.png")
+                .id(goodsPost.getId())
+                .teamName(teamName)
+                .title(goodsPost.getTitle())
+                .category(goodsPost.getCategory().getValue())
+                .price(goodsPost.getPrice())
+                .imageUrl(mainImageUrl)
                 .build();
     }
 

--- a/src/main/java/com/example/mate/domain/goods/entity/GoodsPost.java
+++ b/src/main/java/com/example/mate/domain/goods/entity/GoodsPost.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.goods.entity;
 
+import com.example.mate.common.BaseTimeEntity;
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.domain.member.entity.Member;
@@ -34,7 +35,7 @@ import lombok.ToString;
 @ToString
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GoodsPost {
+public class GoodsPost extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
@@ -21,7 +21,7 @@ public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long> {
             SELECT gp FROM GoodsPost gp
             WHERE (:teamId IS NULL OR gp.teamId = :teamId)
             AND gp.status = :status
-            ORDER BY gp.id ASC
+            ORDER BY gp.createdAt DESC
             """)
     List<GoodsPost> findMainGoodsPosts(@Param("teamId") Long teamId, @Param("status") Status status, Pageable pageable);
 }

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
@@ -2,11 +2,26 @@ package com.example.mate.domain.goods.repository;
 
 import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.Status;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long> {
 
-    @Query("SELECT COUNT(gp) FROM GoodsPost gp WHERE gp.seller.id = :memberId AND gp.status = :status")
+    @Query("""
+            SELECT COUNT(gp) FROM GoodsPost gp WHERE
+            gp.seller.id = :memberId
+            AND gp.status = :status
+            """)
     int countGoodsPostsBySellerIdAndStatus(Long memberId, Status status);
+
+    @Query("""
+            SELECT gp FROM GoodsPost gp
+            WHERE (:teamId IS NULL OR gp.teamId = :teamId)
+            AND gp.status = :status
+            ORDER BY gp.id ASC
+            """)
+    List<GoodsPost> findMainGoodsPosts(@Param("teamId") Long teamId, @Param("status") Status status, Pageable pageable);
 }

--- a/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
@@ -89,7 +89,7 @@ public class GoodsService {
     }
 
     private void validateTeamInfo(Long teamId) {
-        if (!TeamInfo.existById(teamId)) {
+        if (teamId != null && !TeamInfo.existById(teamId)) {
             throw new CustomException(ErrorCode.TEAM_NOT_FOUND);
         }
     }

--- a/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
@@ -7,8 +7,10 @@ import com.example.mate.common.utils.file.FileValidator;
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.goods.dto.request.GoodsPostRequest;
 import com.example.mate.domain.goods.dto.response.GoodsPostResponse;
+import com.example.mate.domain.goods.dto.response.GoodsPostSummaryResponse;
 import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.GoodsPostImage;
+import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostImageRepository;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
 import com.example.mate.domain.member.entity.Member;
@@ -16,6 +18,8 @@ import com.example.mate.domain.member.repository.MemberRepository;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -23,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class GoodsService {
 
     private final MemberRepository memberRepository;
@@ -83,6 +88,15 @@ public class GoodsService {
         return GoodsPostResponse.of(goodsPost);
     }
 
+    @Transactional(readOnly = true)
+    public List<GoodsPostSummaryResponse> getMainGoodsPosts(Long teamId) {
+        validateTeamInfo(teamId);
+        List<GoodsPost> goodsPosts = goodsPostRepository.findMainGoodsPosts(teamId, Status.OPEN, PageRequest.of(0, 4));
+
+        return goodsPosts.stream()
+                .map(this::convertToSummaryResponse).toList();
+    }
+
     private Member getSellerAndValidate(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(()
                 -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
@@ -126,5 +140,15 @@ public class GoodsService {
             images.add(image);
         }
         return images;
+    }
+
+    private GoodsPostSummaryResponse convertToSummaryResponse(GoodsPost goodsPost) {
+        String mainImageUrl = goodsPost.getGoodsPostImages().stream()
+                .filter(GoodsPostImage::getIsMainImage)
+                .findFirst()
+                .map(GoodsPostImage::getImageUrl)
+                .orElseThrow(() -> new CustomException(ErrorCode.GOODS_MAIN_IMAGE_IS_EMPTY));
+
+        return GoodsPostSummaryResponse.of(goodsPost, mainImageUrl);
     }
 }

--- a/src/test/java/com/example/mate/domain/goods/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goods/controller/GoodsControllerTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.example.mate.domain.goods.dto.LocationInfo;
 import com.example.mate.domain.goods.dto.request.GoodsPostRequest;
 import com.example.mate.domain.goods.dto.response.GoodsPostResponse;
+import com.example.mate.domain.goods.dto.response.GoodsPostSummaryResponse;
 import com.example.mate.domain.goods.entity.Category;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.service.GoodsService;
@@ -70,6 +71,17 @@ class GoodsControllerTest {
         return GoodsPostResponse.builder()
                 .id(1L)
                 .status(Status.OPEN.getValue())
+                .build();
+    }
+
+    private GoodsPostSummaryResponse createGoodsPostSummaryResponse() {
+        return GoodsPostSummaryResponse.builder()
+                .id(1L)
+                .teamName("KIA")
+                .title("test title")
+                .category(Category.CLOTHING.getValue())
+                .price(10_000)
+                .imageUrl("test.jpg")
                 .build();
     }
 
@@ -183,5 +195,29 @@ class GoodsControllerTest {
                 .andExpect(jsonPath("$.data.status").value(response.getStatus()));
 
         verify(goodsService).getGoodsPost(goodsPostId);
+    }
+
+    @Test
+    @DisplayName("메인페이지 굿즈 판매글 리스트 조회 - API 테스트")
+    void get_main_goods_posts_success() throws Exception {
+        // given
+        Long teamId = 1L;
+        GoodsPostSummaryResponse response = createGoodsPostSummaryResponse();
+        List<GoodsPostSummaryResponse> goodsPosts = List.of(response);
+
+        given(goodsService.getMainGoodsPosts(teamId)).willReturn(goodsPosts);
+
+        // when & then
+        mockMvc.perform(get("/api/goods/main")
+                        .param("teamId", String.valueOf(teamId)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.size()").value(goodsPosts.size()))
+                .andExpect(jsonPath("$.data[0].id").value(response.getId()))
+                .andExpect(jsonPath("$.data[0].price").value(response.getPrice()))
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(goodsService).getMainGoodsPosts(teamId);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 팀 정보 검증 로직 변경
- [x] 메인페이지 굿즈거래 판매글 조회 기능 구현
- [x] 메인페이지 굿즈거래 판매글 조회 기능 테스트 코드 작성

## 💡 자세한 설명

#### `GET /api/goods/main`
- 메인페이지에서 4개의 굿즈거래 게시물을 조회하는 기능을 구현했습니다.
- `RequestParam` 으로 `teamId` 를 전달받아 해당 팀 굿즈거래 판매글을 조회합니다.
- `teamId` 는 `null`일 수 있고, 이 경우에는 모든 판매글을 조회힙니다.
- 판매글의 대표 이미지 업로드 url 만 조회해서 응답하는 로직을 구현했습니다. 대표 이미지가 없다면 `CustomException` 을 발생하도록 구현했습니다.

- `Figma` 페이지
<img width="330" alt="image" src="https://github.com/user-attachments/assets/cfb67943-c238-4c3d-9ac4-ae9d392fe88d">


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
궁금하신 부분, 개선해야하는 부분 편하게 코멘트 남겨주세요 !

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?