### PR TITLE
MATE-28 : [FEAT] 메이트 게시글 모집상태 변경 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -42,7 +42,8 @@ public enum ErrorCode {
     INVALID_MATE_POST_COMPLETION(HttpStatus.BAD_REQUEST, "MP003", "모집완료 상태에서만 직관 완료가 가능합니다."),
     MATE_POST_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "MP004", "해당 ID의 메이트 게시글을 찾을 수 없습니다."),
     UNAUTHORIZED_MATE_POST_ACCESS(HttpStatus.FORBIDDEN, "MP005", "해당 메이트 게시글에 대한 권한이 없습니다."),
-    MATE_POST_DELETE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MP006", "메이트 게시글의 작성자가 아니라면, 게시글을 수정할 수 없습니다"),
+    MATE_POST_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MP006", "메이트 게시글의 작성자가 아니라면, 게시글을 수정할 수 없습니다"),
+    ALREADY_COMPLETED_POST(HttpStatus.FORBIDDEN, "MP008", "이미 직관완료한 게시글은 모집 상태를 변경할 수 없습니다."),
 
     // Goods
     GOODS_IMAGES_ARE_EMPTY(HttpStatus.BAD_REQUEST, "G001", "굿즈 이미지는 최소 1개 이상을 업로드 할 수 있습니다."),
@@ -68,7 +69,11 @@ public enum ErrorCode {
     INVALID_TRANSPORT_TYPE_VALUE(HttpStatus.BAD_REQUEST, "TRANSPORT001", "유효하지 않은 교통 수단 값입니다."),
 
     // SortType
-    INVALID_SORT_TYPE_VALUE(HttpStatus.BAD_REQUEST, "ST001", "유효하지 않은 정렬 기준 값입니다.");
+    INVALID_SORT_TYPE_VALUE(HttpStatus.BAD_REQUEST, "ST001", "유효하지 않은 정렬 기준 값입니다."),
+
+    // Status
+    INVALID_STATUS_TYPE_VALUE(HttpStatus.BAD_REQUEST, "STATUS001", "유효하지 않은 모집 상태 값입니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -10,7 +10,6 @@ import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
 import com.example.mate.domain.mate.dto.response.MateReviewCreateResponse;
 import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.mate.entity.SortType;
-import com.example.mate.domain.mate.entity.Status;
 import com.example.mate.domain.mate.entity.TransportType;
 import com.example.mate.domain.mate.service.MateService;
 import jakarta.validation.Valid;
@@ -81,13 +80,15 @@ public class MateController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
     // 메이트 게시글 모집 상태 변경(모집중, 모집완료)
-    @PatchMapping("/{postId}/status")
-    public ResponseEntity<MatePostResponse> updateMatePostStatus(
-            @PathVariable Long postId,
-            @AuthenticationPrincipal UserDetails userDetails,
-            @RequestBody MatePostStatusRequest request) {
-        return ResponseEntity.ok(MatePostResponse.builder().id(1L).status(Status.CLOSED).build());
+    @PatchMapping("/{memberId}/{postId}/status")
+    public ResponseEntity<ApiResponse<MatePostResponse>> updateMatePostStatus(@PathVariable(value = "memberId") Long memberId,
+                                                                              @PathVariable(value = "postId") Long postId,
+                                                                              @Valid @RequestBody MatePostStatusRequest request) {
+
+        MatePostResponse response = mateService.updateMatePostStatus(memberId, postId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
@@ -102,7 +103,6 @@ public class MateController {
     // 메이트 게시글 직관 완료로 상태 변경
     @PostMapping("/{postId}/complete")
     public ResponseEntity<MatePostResponse> completeMatePost(@PathVariable Long postId,
-                                                             @AuthenticationPrincipal UserDetails userDetails,
                                                              @RequestBody MatePostCompleteRequest request) {
         // 1. 게시글 상태 COMPLETE로 변경
         // 2. visit 테이블에 직관 기록 생성

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MatePostStatusRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MatePostStatusRequest.java
@@ -1,9 +1,17 @@
 package com.example.mate.domain.mate.dto.request;
 
+import com.example.mate.common.utils.validator.ValidEnum;
 import com.example.mate.domain.mate.entity.Status;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MatePostStatusRequest {
+    @ValidEnum(message = "모집 상태의 입력 값이 잘못되었습니다.", enumClass = Status.class)
     private Status status;
 }

--- a/src/main/java/com/example/mate/domain/mate/entity/MatePost.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/MatePost.java
@@ -1,13 +1,17 @@
 package com.example.mate.domain.mate.entity;
 
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.member.entity.Member;
-import com.example.mate.domain.constant.Gender;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.List;
+
+import static com.example.mate.common.error.ErrorCode.MATE_POST_UPDATE_NOT_ALLOWED;
 
 @Entity
 @Table(name = "mate_post")
@@ -95,18 +99,24 @@ public class MatePost {
         this.transport = transport;
     }
 
-    // 모집 상태 변경
-    public void changeStatus(Status status) {
-        if (status == Status.COMPLETE) {
-            throw new IllegalStateException("직관 완료는 completeVisit()을 통해서만 가능합니다.");
+    // 상태 변경 가능 여부 검증과 변경
+    public void changeStatus(Status newStatus) {
+        if (newStatus == Status.COMPLETE) {
+            throw new CustomException(ErrorCode.MATE_POST_UPDATE_NOT_ALLOWED);
         }
 
-        // 이미 직관 완료된 게시글은 상태 변경 불가
         if (this.status == Status.COMPLETE) {
-            throw new IllegalStateException("직관 완료된 게시글은 상태를 변경할 수 없습니다.");
+            throw new CustomException(ErrorCode.ALREADY_COMPLETED_POST);
         }
 
-        this.status = status;
+        this.status = newStatus;
+    }
+
+    // 작성자 검증
+    public void validateAuthor(Long memberId) {
+        if (!this.author.getId().equals(memberId)) {
+            throw new CustomException(MATE_POST_UPDATE_NOT_ALLOWED);
+        }
     }
 
     // 직관 완료 처리

--- a/src/main/java/com/example/mate/domain/mate/entity/Status.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/Status.java
@@ -1,5 +1,9 @@
 package com.example.mate.domain.mate.entity;
 
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 @Getter
@@ -8,9 +12,20 @@ public enum Status {
     CLOSED("모집완료"),
     COMPLETE("직관완료");
 
+    @JsonValue
     private final String value;
 
     Status(String value) {
         this.value = value;
+    }
+
+    @JsonCreator
+    public static Status from(String value) {
+        for (Status status : Status.values()) {
+            if (status.getValue().equals(value)) {
+                return status;
+            }
+        }
+        throw new CustomException(ErrorCode.INVALID_STATUS_TYPE_VALUE);
     }
 }

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -8,6 +8,7 @@ import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
 import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
 import com.example.mate.domain.mate.dto.request.MatePostSearchRequest;
+import com.example.mate.domain.mate.dto.request.MatePostStatusRequest;
 import com.example.mate.domain.mate.dto.response.MatePostDetailResponse;
 import com.example.mate.domain.mate.dto.response.MatePostResponse;
 import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
@@ -116,13 +117,21 @@ public class MateService {
         return MatePostDetailResponse.from(matePost);
     }
 
+    public MatePostResponse updateMatePostStatus(Long memberId, Long postId, MatePostStatusRequest request) {
+        MatePost matePost = mateRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND_BY_ID));
+
+        matePost.validateAuthor(memberId);
+        matePost.changeStatus(request.getStatus());
+
+        return MatePostResponse.from(matePost);
+    }
+
     public void deleteMatePost(Long memberId, Long postId) {
         MatePost matePost = mateRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND_BY_ID));
 
-        if (!matePost.getAuthor().getId().equals(memberId)) {
-            throw new CustomException(MATE_POST_DELETE_NOT_ALLOWED);
-        }
+        matePost.validateAuthor(memberId);
 
         if (matePost.getStatus() == Status.COMPLETE) {
             matePost.getVisit().detachPost();

--- a/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
+++ b/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
@@ -5,6 +5,7 @@ import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
+import com.example.mate.domain.mate.dto.request.MatePostStatusRequest;
 import com.example.mate.domain.mate.dto.response.MatePostDetailResponse;
 import com.example.mate.domain.mate.dto.response.MatePostResponse;
 import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
@@ -124,7 +125,7 @@ class MateControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value("SUCCESS"))
                     .andExpect(jsonPath("$.data.id").value(1L))
-                    .andExpect(jsonPath("$.data.status").value("OPEN"))
+                    .andExpect(jsonPath("$.data.status").value("모집중"))
                     .andExpect(jsonPath("$.code").value(200));
         }
 
@@ -152,7 +153,7 @@ class MateControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value("SUCCESS"))
                     .andExpect(jsonPath("$.data.id").value(1L))
-                    .andExpect(jsonPath("$.data.status").value("OPEN"))
+                    .andExpect(jsonPath("$.data.status").value("모집중"))
                     .andExpect(jsonPath("$.code").value(200));
         }
     }
@@ -391,7 +392,7 @@ class MateControllerTest {
                     .andExpect(jsonPath("$.status").value("SUCCESS"))
                     .andExpect(jsonPath("$.data.postId").value(postId))
                     .andExpect(jsonPath("$.data.title").value(response.getTitle()))
-                    .andExpect(jsonPath("$.data.status").value(response.getStatus().toString()))
+                    .andExpect(jsonPath("$.data.status").value(response.getStatus().getValue()))
                     .andExpect(jsonPath("$.data.rivalTeamName").value(response.getRivalTeamName()))
                     .andExpect(jsonPath("$.data.location").value(response.getLocation()))
                     .andExpect(jsonPath("$.data.age").value(response.getAge().getValue()))
@@ -470,7 +471,7 @@ class MateControllerTest {
             Long memberId = 2L;  // 작성자가 아닌 다른 사용자
             Long postId = 1L;
 
-            doThrow(new CustomException(ErrorCode.MATE_POST_DELETE_NOT_ALLOWED))
+            doThrow(new CustomException(ErrorCode.MATE_POST_UPDATE_NOT_ALLOWED))
                     .when(mateService)
                     .deleteMatePost(memberId, postId);
 
@@ -482,6 +483,136 @@ class MateControllerTest {
                     .andExpect(jsonPath("$.status").value("ERROR"))
                     .andExpect(jsonPath("$.message").exists())
                     .andExpect(jsonPath("$.code").value(403));
+        }
+    }
+
+    @Nested
+    @DisplayName("메이트 게시글 상태 변경")
+    class UpdateMatePostStatus {
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 성공")
+        void updateMatePostStatus_success() throws Exception {
+            // given
+            Long memberId = 1L;
+            Long postId = 1L;
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.CLOSED);
+            MatePostResponse response = MatePostResponse.builder()
+                    .id(postId)
+                    .status(Status.CLOSED)
+                    .build();
+
+            given(mateService.updateMatePostStatus(eq(memberId), eq(postId), any(MatePostStatusRequest.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", memberId, postId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.id").value(postId))
+                    .andExpect(jsonPath("$.data.status").value("모집완료"))
+                    .andExpect(jsonPath("$.code").value(200));
+
+            verify(mateService).updateMatePostStatus(eq(memberId), eq(postId), any(MatePostStatusRequest.class));
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 실패 - 존재하지 않는 게시글")
+        void updateMatePostStatus_failPostNotFound() throws Exception {
+            // given
+            Long memberId = 1L;
+            Long nonExistentPostId = 999L;
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.CLOSED);
+
+            given(mateService.updateMatePostStatus(eq(memberId), eq(nonExistentPostId), any(MatePostStatusRequest.class)))
+                    .willThrow(new CustomException(ErrorCode.MATE_POST_NOT_FOUND_BY_ID));
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", memberId, nonExistentPostId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.code").value(404));
+
+            verify(mateService).updateMatePostStatus(eq(memberId), eq(nonExistentPostId), any(MatePostStatusRequest.class));
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 실패 - 권한 없음")
+        void updateMatePostStatus_failNotAuthorized() throws Exception {
+            // given
+            Long memberId = 2L;
+            Long postId = 1L;
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.CLOSED);
+
+            given(mateService.updateMatePostStatus(eq(memberId), eq(postId), any(MatePostStatusRequest.class)))
+                    .willThrow(new CustomException(ErrorCode.MATE_POST_UPDATE_NOT_ALLOWED));
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", memberId, postId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.code").value(403));
+
+            verify(mateService).updateMatePostStatus(eq(memberId), eq(postId), any(MatePostStatusRequest.class));
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 실패 - COMPLETE로 변경 시도")
+        void updateMatePostStatus_failWithCompleteStatus() throws Exception {
+            // given
+            Long memberId = 1L;
+            Long postId = 1L;
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.COMPLETE);
+
+            given(mateService.updateMatePostStatus(eq(memberId), eq(postId), any(MatePostStatusRequest.class)))
+                    .willThrow(new CustomException(ErrorCode.MATE_POST_UPDATE_NOT_ALLOWED));
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", memberId, postId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.code").value(403));
+
+            verify(mateService).updateMatePostStatus(eq(memberId), eq(postId), any(MatePostStatusRequest.class));
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 실패 - 이미 완료된 게시글")
+        void updateMatePostStatus_failAlreadyCompleted() throws Exception {
+            // given
+            Long memberId = 1L;
+            Long postId = 1L;
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.CLOSED);
+
+            given(mateService.updateMatePostStatus(eq(memberId), eq(postId), any(MatePostStatusRequest.class)))
+                    .willThrow(new CustomException(ErrorCode.MATE_POST_UPDATE_NOT_ALLOWED));
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", memberId, postId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").exists())
+                    .andExpect(jsonPath("$.code").value(403));
+
+            verify(mateService).updateMatePostStatus(eq(memberId), eq(postId), any(MatePostStatusRequest.class));
         }
     }
 }

--- a/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
@@ -5,6 +5,7 @@ import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
 import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
+import com.example.mate.domain.mate.dto.request.MatePostStatusRequest;
 import com.example.mate.domain.mate.entity.*;
 import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.member.entity.Member;
@@ -166,7 +167,7 @@ public class MateIntegrationTest {
                             .file(data))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value("SUCCESS"))
-                    .andExpect(jsonPath("$.data.status").value("OPEN"))
+                    .andExpect(jsonPath("$.data.status").value("모집중"))
                     .andExpect(jsonPath("$.code").value(200))
                     .andDo(print());
 
@@ -256,7 +257,7 @@ public class MateIntegrationTest {
                     .andExpect(jsonPath("$.data.length()").value(2))
                     // 첫 번째 게시글 (OPEN) 검증
                     .andExpect(jsonPath("$.data[0].title").value("테스트 제목"))
-                    .andExpect(jsonPath("$.data[0].status").value("OPEN"))
+                    .andExpect(jsonPath("$.data[0].status").value("모집중"))
                     .andExpect(jsonPath("$.data[0].maxParticipants").value(4))
                     .andExpect(jsonPath("$.data[0].age").value("20대"))
                     .andExpect(jsonPath("$.data[0].gender").value("여자"))
@@ -265,7 +266,7 @@ public class MateIntegrationTest {
                     .andExpect(jsonPath("$.data[0].location").value("광주-기아 챔피언스 필드"))
                     // 두 번째 게시글 (CLOSED) 검증
                     .andExpect(jsonPath("$.data[1].title").value("테스트 제목"))
-                    .andExpect(jsonPath("$.data[1].status").value("CLOSED"))
+                    .andExpect(jsonPath("$.data[1].status").value("모집완료"))
                     .andExpect(jsonPath("$.data[1].maxParticipants").value(4))
                     .andExpect(jsonPath("$.data[1].age").value("20대"))
                     .andExpect(jsonPath("$.data[1].gender").value("여자"))
@@ -288,7 +289,7 @@ public class MateIntegrationTest {
                     .andExpect(jsonPath("$.data.length()").value(2))
                     // 첫 번째 게시글 (OPEN) 검증
                     .andExpect(jsonPath("$.data[0].title").value("테스트 제목"))
-                    .andExpect(jsonPath("$.data[0].status").value("OPEN"))
+                    .andExpect(jsonPath("$.data[0].status").value("모집중"))
                     .andExpect(jsonPath("$.data[0].maxParticipants").value(4))
                     .andExpect(jsonPath("$.data[0].age").value("20대"))
                     .andExpect(jsonPath("$.data[0].gender").value("여자"))
@@ -297,7 +298,7 @@ public class MateIntegrationTest {
                     .andExpect(jsonPath("$.data[0].location").value("광주-기아 챔피언스 필드"))
                     // 두 번째 게시글 (CLOSED) 검증
                     .andExpect(jsonPath("$.data[1].title").value("테스트 제목"))
-                    .andExpect(jsonPath("$.data[1].status").value("CLOSED"))
+                    .andExpect(jsonPath("$.data[1].status").value("모집완료"))
                     .andExpect(jsonPath("$.data[1].maxParticipants").value(4))
                     .andExpect(jsonPath("$.data[1].age").value("20대"))
                     .andExpect(jsonPath("$.data[1].gender").value("여자"))
@@ -317,8 +318,8 @@ public class MateIntegrationTest {
                     .andExpect(jsonPath("$.status").value("SUCCESS"))
                     .andExpect(jsonPath("$.data").isArray())
                     .andExpect(jsonPath("$.data.length()").value(2))
-                    .andExpect(jsonPath("$.data[0].status").value("OPEN"))
-                    .andExpect(jsonPath("$.data[1].status").value("CLOSED"))
+                    .andExpect(jsonPath("$.data[0].status").value("모집중"))
+                    .andExpect(jsonPath("$.data[1].status").value("모집완료"))
                     .andDo(print());
 
             // DB 검증
@@ -480,7 +481,7 @@ public class MateIntegrationTest {
                     .andExpect(jsonPath("$.data.postId").value(openPost.getId()))
                     .andExpect(jsonPath("$.data.title").value("테스트 제목"))
                     .andExpect(jsonPath("$.data.content").value("테스트 내용"))
-                    .andExpect(jsonPath("$.data.status").value("OPEN"))
+                    .andExpect(jsonPath("$.data.status").value("모집중"))
                     .andExpect(jsonPath("$.data.maxParticipants").value(4))
                     .andExpect(jsonPath("$.data.age").value("20대"))
                     .andExpect(jsonPath("$.data.gender").value("여자"))
@@ -513,19 +514,19 @@ public class MateIntegrationTest {
             mockMvc.perform(get("/api/mates/" + openPost.getId())
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.status").value("OPEN"));
+                    .andExpect(jsonPath("$.data.status").value("모집중"));
 
             // Test CLOSED status
             mockMvc.perform(get("/api/mates/" + closedPost.getId())
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.status").value("CLOSED"));
+                    .andExpect(jsonPath("$.data.status").value("모집완료"));
 
             // Test COMPLETE status
             mockMvc.perform(get("/api/mates/" + completedPost.getId())
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.status").value("COMPLETE"));
+                    .andExpect(jsonPath("$.data.status").value("직관완료"));
         }
     }
 
@@ -581,7 +582,7 @@ public class MateIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.status").value("ERROR"))
-                    .andExpect(jsonPath("$.message").value(ErrorCode.MATE_POST_DELETE_NOT_ALLOWED.getMessage()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MATE_POST_UPDATE_NOT_ALLOWED.getMessage()))
                     .andExpect(jsonPath("$.code").value(403))
                     .andDo(print());
 
@@ -606,6 +607,145 @@ public class MateIntegrationTest {
             // then
             assertThat(mateRepository.findById(post.getId())).isEmpty();
             assertThat(visit.getPost()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("메이트 게시글 상태 변경")
+    class UpdateMatePostStatus {
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 성공 - 모집중에서 모집완료로")
+        void updateMatePostStatus_OpenToClosed_Success() throws Exception {
+            // given
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.CLOSED);
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", testMember.getId(), openPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.id").value(openPost.getId()))
+                    .andExpect(jsonPath("$.data.status").value("모집완료"))
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andDo(print());
+
+            // DB 검증
+            MatePost updatedPost = mateRepository.findById(openPost.getId()).orElseThrow();
+            assertThat(updatedPost.getStatus()).isEqualTo(Status.CLOSED);
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 성공 - 모집완료에서 모집중으로")
+        void updateMatePostStatus_ClosedToOpen_Success() throws Exception {
+            // given
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.OPEN);
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", testMember.getId(), closedPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.id").value(closedPost.getId()))
+                    .andExpect(jsonPath("$.data.status").value("모집중"))
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andDo(print());
+
+            // DB 검증
+            MatePost updatedPost = mateRepository.findById(closedPost.getId()).orElseThrow();
+            assertThat(updatedPost.getStatus()).isEqualTo(Status.OPEN);
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 실패 - 직관완료로 변경 시도")
+        void updateMatePostStatus_ToComplete_Failure() throws Exception {
+            // given
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.COMPLETE);
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", testMember.getId(), openPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MATE_POST_UPDATE_NOT_ALLOWED.getMessage()))
+                    .andExpect(jsonPath("$.code").value(403))
+                    .andDo(print());
+
+            // DB 검증
+            MatePost unchangedPost = mateRepository.findById(openPost.getId()).orElseThrow();
+            assertThat(unchangedPost.getStatus()).isEqualTo(Status.OPEN);
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 실패 - 이미 직관완료된 게시글")
+        void updateMatePostStatus_AlreadyCompleted_Failure() throws Exception {
+            // given
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.OPEN);
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", testMember.getId(), completedPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.ALREADY_COMPLETED_POST.getMessage()))
+                    .andExpect(jsonPath("$.code").value(403))
+                    .andDo(print());
+
+            // DB 검증
+            MatePost unchangedPost = mateRepository.findById(completedPost.getId()).orElseThrow();
+            assertThat(unchangedPost.getStatus()).isEqualTo(Status.COMPLETE);
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 실패 - 권한 없음")
+        void updateMatePostStatus_NotAuthor_Failure() throws Exception {
+            // given
+            Member otherMember = memberRepository.save(Member.builder()
+                    .name("다른유저")
+                    .email("other@test.com")
+                    .nickname("다른계정")
+                    .imageUrl("other.jpg")
+                    .gender(Gender.MALE)
+                    .age(30)
+                    .manner(0.3f)
+                    .build());
+
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.CLOSED);
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", otherMember.getId(), openPost.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MATE_POST_UPDATE_NOT_ALLOWED.getMessage()))
+                    .andExpect(jsonPath("$.code").value(403))
+                    .andDo(print());
+
+            // DB 검증
+            MatePost unchangedPost = mateRepository.findById(openPost.getId()).orElseThrow();
+            assertThat(unchangedPost.getStatus()).isEqualTo(Status.OPEN);
+        }
+
+        @Test
+        @DisplayName("메이트 게시글 상태 변경 실패 - 존재하지 않는 게시글")
+        void updateMatePostStatus_PostNotFound_Failure() throws Exception {
+            // given
+            MatePostStatusRequest request = new MatePostStatusRequest(Status.CLOSED);
+
+            // when & then
+            mockMvc.perform(patch("/api/mates/{memberId}/{postId}/status", testMember.getId(), 999L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MATE_POST_NOT_FOUND_BY_ID.getMessage()))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andDo(print());
         }
     }
 }


### PR DESCRIPTION
## 💡 작업 내용
- [x] 메이트 게시글의 모집 상태 변경 기능 구현 (모집중 ↔ 모집완료)
- [x] 상태 변경 권한 검증 로직 구현
- [x] 상태 변경 제약조건 검증 로직 구현
- [x] 단위 테스트, 통합 테스트 작성

## 💡 자세한 설명
### 기능 흐름
1. 클라이언트가 게시글 ID와 변경할 상태(OPEN/CLOSED)를 요청
2. 게시글 작성자 검증
3. 상태 변경 가능 여부 검증
4. 상태 변경 수행
5. 변경된 상태 응답

### 주요 구현 내용
1. **상태 변경 제약조건**
   - 직관완료(COMPLETE) 상태로 직접 변경 불가
   - 이미 직관완료된 게시글은 상태 변경 불가
   - 모집중(OPEN) ↔ 모집완료(CLOSED) 변경만 가능

2. **권한 검증**
   - 게시글 작성자만 상태 변경 가능
   - 다른 사용자 접근 시 403 Forbidden 응답

3. **예외 처리**
   - 게시글 미존재: 404 Not Found
   - 권한 없음: 403 Forbidden
   - 잘못된 상태값: 400 Bad Request
   - 이미 직관완료: 403 Forbidden

4. **테스트 케이스**
   - 정상 케이스: OPEN → CLOSED, CLOSED → OPEN 변경
   - 예외 케이스: 권한 없음, 잘못된 상태값, 존재하지 않는 게시글 등

## 📗 참고 자료

## 📢 리뷰 요구 사항

✅ 셀프 체크리스트 
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요? 
- [x] 불필요한 코드는 제거했나요?