### PR TITLE
MATE-37 : [FEAT] 내 프로필 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 
     // Member
     MEMBER_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "M001", "해당 ID의 회원 정보를 찾을 수 없습니다"),
+    UNSUPPORTED_RESPONSE_TYPE(HttpStatus.BAD_REQUEST, "M002", "회원 프로필 조회에서 지원하지 않는 응답 타입입니다."),
 
     // Follow
     ALREADY_FOLLOWED_MEMBER(HttpStatus.BAD_REQUEST, "F001", "이미 팔로우한 회원입니다."),

--- a/src/main/java/com/example/mate/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/mate/common/error/GlobalExceptionHandler.java
@@ -7,8 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -26,7 +28,8 @@ public class GlobalExceptionHandler {
 
     // MethodArgumentNotValidException 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
         // 유효성 검증 실패한 필드와 메시지 추출
         List<String> validationErrors = e.getBindingResult().getFieldErrors().stream()
                 .map(fieldError -> String.format("%s: %s", fieldError.getField(), fieldError.getDefaultMessage()))
@@ -47,6 +50,53 @@ public class GlobalExceptionHandler {
                         HttpStatus.BAD_REQUEST.value()
                 ));
     }
+
+    // NumberFormatException 처리
+    @ExceptionHandler(NumberFormatException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNumberFormatException(NumberFormatException e) {
+        log.error("NumberFormatException: {}", e.getMessage());
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(
+                        "잘못된 요청 형식입니다.",
+                        HttpStatus.BAD_REQUEST.value()
+                ));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        log.error("MethodArgumentTypeMismatchException: {}", e.getMessage());
+
+        String errorMessage = String.format("잘못된 입력 형식입니다. '%s' 타입이 '%s'로 변환될 수 없습니다.",
+                e.getValue(), e.getRequiredType().getSimpleName());
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(
+                        errorMessage,
+                        HttpStatus.BAD_REQUEST.value()
+                ));
+    }
+
+    // MissingServletRequestParameterException 처리
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e) {
+        log.error("MissingServletRequestParameterException: {}", e.getMessage());
+
+        // 누락된 파라미터를 메시지로 반환
+        String errorMessage = String.format("요청에 '%s' 파라미터가 누락되었습니다.", e.getParameterName());
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(
+                        errorMessage,
+                        HttpStatus.BAD_REQUEST.value()
+                ));
+    }
+
 
     // 모든 예외 타입 처리
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
@@ -9,4 +9,7 @@ public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long> {
 
     @Query("SELECT COUNT(gp) FROM GoodsPost gp WHERE gp.seller.id = :memberId AND gp.status = :status")
     int countGoodsPostsBySellerIdAndStatus(Long memberId, Status status);
+
+    @Query("SELECT COUNT(gp) FROM GoodsPost gp WHERE gp.buyer.id = :memberId AND gp.status = :status")
+    int countGoodsPostsByBuyerIdAndStatus(Long memberId, Status status);
 }

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsReviewRepository.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsReviewRepository.java
@@ -1,0 +1,9 @@
+package com.example.mate.domain.goods.repository;
+
+import com.example.mate.domain.goods.entity.GoodsReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GoodsReviewRepository extends JpaRepository<GoodsReview, Long> {
+
+    int countByRevieweeId(Long revieweeId);
+}

--- a/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepository.java
@@ -1,0 +1,9 @@
+package com.example.mate.domain.mate.repository;
+
+import com.example.mate.domain.mate.entity.MateReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MateReviewRepository extends JpaRepository<MateReview, Long> {
+
+    int countByRevieweeId(Long revieweeId);
+}

--- a/src/main/java/com/example/mate/domain/mate/repository/VisitPartRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/VisitPartRepository.java
@@ -1,0 +1,11 @@
+package com.example.mate.domain.mate.repository;
+
+import com.example.mate.domain.mate.entity.VisitPart;
+import com.example.mate.domain.mate.entity.VisitPartId;
+import com.example.mate.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VisitPartRepository extends JpaRepository<VisitPart, VisitPartId> {
+
+    int countByMember(Member member);
+}

--- a/src/main/java/com/example/mate/domain/mate/repository/VisitRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/VisitRepository.java
@@ -1,0 +1,7 @@
+package com.example.mate.domain.mate.repository;
+
+import com.example.mate.domain.mate.entity.Visit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VisitRepository extends JpaRepository<Visit, Long> {
+}

--- a/src/main/java/com/example/mate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/MemberController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -45,27 +46,11 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.success(memberService.join(joinRequest)));
     }
 
-    /*
-    TODO : 2024/11/23 - 내 프로필 조회
-    1. JwtToken 을 통해 사용자 정보 조회
-    */
+    // TODO : 2024/11/29 - 내 프로필 조회 : 추후 @AuthenticationPrincipal Long memberId 받음
+    @Operation(summary = "내 프로필 조회")
     @GetMapping("/me")
-    public ResponseEntity<MyProfileResponse> findMemberInfo() {
-        MyProfileResponse myProfileResponse = MyProfileResponse.builder()
-                .nickname("삼성빠돌이")
-                .imageUrl("default.jpg")
-                .teamName("삼성")
-                .manner(0.3f)
-                .aboutMe("삼성을 사랑하는 삼성빠돌이입니다!")
-                .followingCount(10)
-                .followerCount(20)
-                .reviewsCount(10)
-                .goodsSoldCount(20)
-                .goodsBoughtCount(10)
-                .visitsCount(20)
-                .build();
-
-        return ResponseEntity.ok(myProfileResponse);
+    public ResponseEntity<ApiResponse<MyProfileResponse>> findMyInfo(@RequestParam Long memberId) {
+        return ResponseEntity.ok(ApiResponse.success(memberService.getMyProfile(memberId)));
     }
 
     @Operation(summary = "다른 회원 프로필 조회")

--- a/src/main/java/com/example/mate/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MemberProfileResponse.java
@@ -23,8 +23,8 @@ public class MemberProfileResponse {
     private Integer reviewsCount;
     private Integer goodsSoldCount;
 
-    // TODO : rewviewsCount, goodsSoldCount 추가
-    public static MemberProfileResponse of(Member member, int followingCount, int followerCount, int goodsSoldCount) {
+    public static MemberProfileResponse of(Member member, int followingCount, int followerCount,
+                                           int reviewsCount, int goodsSoldCount) {
         return MemberProfileResponse.builder()
                 .nickname(member.getNickname())
                 .imageUrl(member.getImageUrl())
@@ -33,6 +33,7 @@ public class MemberProfileResponse {
                 .aboutMe(member.getAboutMe())
                 .followingCount(followingCount)
                 .followerCount(followerCount)
+                .reviewsCount(reviewsCount)
                 .goodsSoldCount(goodsSoldCount)
                 .build();
     }

--- a/src/main/java/com/example/mate/domain/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MyProfileResponse.java
@@ -1,5 +1,7 @@
 package com.example.mate.domain.member.dto.response;
 
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,4 +24,21 @@ public class MyProfileResponse {
     private Integer goodsSoldCount;
     private Integer goodsBoughtCount;
     private Integer visitsCount;
+
+    public static MyProfileResponse of(Member member, int followingCount, int followerCount, int reviewsCount,
+                                       int goodsSoldCount, int goodsBoughtCount, int visitsCount) {
+        return MyProfileResponse.builder()
+                .nickname(member.getNickname())
+                .imageUrl(member.getImageUrl())
+                .teamName(TeamInfo.getById(member.getTeamId()).shortName)
+                .manner(member.getManner())
+                .aboutMe(member.getAboutMe())
+                .followingCount(followingCount)
+                .followerCount(followerCount)
+                .reviewsCount(reviewsCount)
+                .goodsSoldCount(goodsSoldCount)
+                .goodsBoughtCount(goodsBoughtCount)
+                .visitsCount(visitsCount)
+                .build();
+    }
 }

--- a/src/main/java/com/example/mate/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/mate/domain/member/service/MemberService.java
@@ -4,9 +4,13 @@ import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.goods.repository.GoodsReviewRepository;
+import com.example.mate.domain.mate.repository.MateReviewRepository;
+import com.example.mate.domain.mate.repository.VisitPartRepository;
 import com.example.mate.domain.member.dto.request.JoinRequest;
 import com.example.mate.domain.member.dto.response.JoinResponse;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
+import com.example.mate.domain.member.dto.response.MyProfileResponse;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.FollowRepository;
 import com.example.mate.domain.member.repository.MemberRepository;
@@ -20,6 +24,9 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
     private final GoodsPostRepository goodsPostRepository;
+    private final GoodsReviewRepository goodsReviewRepository;
+    private final MateReviewRepository mateReviewRepository;
+    private final VisitPartRepository visitPartRepository;
 
     // 자체 회원가입 기능
     public JoinResponse join(JoinRequest request) {
@@ -27,13 +34,40 @@ public class MemberService {
         return JoinResponse.from(savedMember);
     }
 
+    // TODO : JWT 도입 이후 본인만 접근할 수 있도록 수정
+    // 내 프로필 조회
+    public MyProfileResponse getMyProfile(Long memberId) {
+        return getProfile(memberId, MyProfileResponse.class);
+    }
+
     // 다른 회원 프로필 조회
     public MemberProfileResponse getMemberProfile(Long memberId) {
+        return getProfile(memberId, MemberProfileResponse.class);
+    }
+
+    // 공통 프로필 생성 팩토리 메서드. DTO 클래스 타입에 따라 다른 타입 리턴
+    private <T> T getProfile(Long memberId, Class<T> responseType) {
         Member member = findByMemberId(memberId);
         int followCount = followRepository.countByFollowerId(memberId);
         int followerCount = followRepository.countByFollowingId(memberId);
+        int reviewsCount = goodsReviewRepository.countByRevieweeId(memberId) +
+                mateReviewRepository.countByRevieweeId(memberId);
         int goodsSoldCount = goodsPostRepository.countGoodsPostsBySellerIdAndStatus(memberId, Status.CLOSED);
-        return MemberProfileResponse.of(member, followCount, followerCount, goodsSoldCount);
+
+        if (responseType == MemberProfileResponse.class) { // MemberProfileResponse가 요청된 경우, 불필요한 조회를 생략하고 바로 리턴
+            return responseType.cast(
+                    MemberProfileResponse.of(member, followCount, followerCount, reviewsCount, goodsSoldCount));
+        }
+
+        if (responseType == MyProfileResponse.class) { // MyProfileResponse가 요청된 경우, 추가적인 조회를 수행
+            int goodsBoughtCount = goodsPostRepository.countGoodsPostsByBuyerIdAndStatus(memberId, Status.CLOSED);
+            int visitsCount = visitPartRepository.countByMember(member);
+            return responseType.cast(
+                    MyProfileResponse.of(member, followCount, followerCount, reviewsCount,
+                            goodsSoldCount, goodsBoughtCount, visitsCount));
+        }
+        
+        throw new CustomException(ErrorCode.UNSUPPORTED_RESPONSE_TYPE);
     }
 
     private Member findByMemberId(Long memberId) {

--- a/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.example.mate.domain.member.integration;
 
+import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
+import static com.example.mate.domain.mate.entity.Status.CLOSED;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -7,17 +9,38 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.constant.Rating;
+import com.example.mate.domain.goods.dto.LocationInfo;
+import com.example.mate.domain.goods.entity.Category;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.GoodsReview;
+import com.example.mate.domain.goods.entity.Status;
+import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.goods.repository.GoodsReviewRepository;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.match.repository.MatchRepository;
+import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.domain.mate.entity.MatePost;
+import com.example.mate.domain.mate.entity.MateReview;
+import com.example.mate.domain.mate.entity.TransportType;
+import com.example.mate.domain.mate.entity.Visit;
+import com.example.mate.domain.mate.entity.VisitPart;
+import com.example.mate.domain.mate.repository.MateRepository;
+import com.example.mate.domain.mate.repository.MateReviewRepository;
+import com.example.mate.domain.mate.repository.VisitPartRepository;
+import com.example.mate.domain.mate.repository.VisitRepository;
 import com.example.mate.domain.member.dto.request.JoinRequest;
+import com.example.mate.domain.member.entity.Follow;
 import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.FollowRepository;
 import com.example.mate.domain.member.repository.MemberRepository;
-import com.example.mate.domain.member.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,7 +52,6 @@ import org.springframework.test.web.servlet.MockMvc;
 @Transactional
 class MemberIntegrationTest {
 
-    private static final Logger log = LoggerFactory.getLogger(MemberIntegrationTest.class);
     @Autowired
     private MockMvc mockMvc;
 
@@ -40,77 +62,199 @@ class MemberIntegrationTest {
     private MemberRepository memberRepository;
 
     @Autowired
-    private MemberService memberService;
+    private FollowRepository followRepository;
+
+    @Autowired
+    private GoodsPostRepository goodsPostRepository;
+
+    @Autowired
+    private GoodsReviewRepository goodsReviewRepository;
+
+    @Autowired
+    private MatchRepository matchRepository;
+
+    @Autowired
+    private MateRepository mateRepository;
+
+    @Autowired
+    private VisitRepository visitRepository;
+
+    @Autowired
+    private MateReviewRepository mateReviewRepository;
+
+    @Autowired
+    private VisitPartRepository visitPartRepository;
 
     private Member member;
+    private Member member2;
+    private GoodsPost goodsPost;
+    private GoodsReview goodsReview;
+    private Match match;
+    private MatePost matePost;
+    private Visit visit;
+    private MateReview mateReview;
 
     @BeforeEach
     void setUp() {
-        memberRepository.deleteAll();
+        // 테스트용 회원 및 관련 데이터 생성
+        member = createMember("홍길동", "tester", "tester@example.com", Gender.MALE, 20);
+        member2 = createMember("김철수", "tester2", "test2@example.com", Gender.MALE, 22);
 
-        // 데이터베이스에 테스트 회원을 삽입
-        member = Member.builder()
-                .name("홍길동")
-                .nickname("tester")
-                .email("tester@example.com")
-                .imageUrl("default.jpg")
-                .age(20)
-                .gender(Gender.MALE)
-                .teamId(1L)
-                .manner(0.300F)
-                .aboutMe("tester입니다.")
-                .build();
-        memberRepository.save(member);
+        // 팔로우 관계 설정
+        createFollow(member, member2);
+        createFollow(member2, member);
+
+        // 상품 리뷰 생성
+        goodsPost = createGoodsPost(member, member2);
+        goodsReview = createGoodsReview(member2, member);
+
+        // 메이트 리뷰 생성
+        match = createMatch(LocalDateTime.now().minusDays(2));
+        matePost = createMatePost(member, match);
+        visit = createVisit(matePost, List.of(member, member2));
+        mateReview = createMateReview(member2, member, matePost);
     }
 
-    private JoinRequest createTestJoinRequest() {
-        return JoinRequest.builder()
-                .name("김철수")
-                .email("tester2@example.com")
-                .gender("M")
-                .birthyear("2002")
+    private Member createMember(String name, String nickname, String email, Gender gender, int age) {
+        return memberRepository.save(Member.builder()
+                .name(name)
+                .nickname(nickname)
+                .email(email)
+                .imageUrl("default.jpg")
+                .age(age)
+                .gender(gender)
                 .teamId(1L)
-                .nickname("tester2")
+                .manner(0.300F)
+                .aboutMe("테스트 회원입니다.")
+                .build());
+    }
+
+    private void createFollow(Member follower, Member following) {
+        followRepository.save(Follow.builder().follower(follower).following(following).build());
+    }
+
+    private GoodsPost createGoodsPost(Member seller, Member buyer) {
+        return goodsPostRepository.save(GoodsPost.builder()
+                .seller(seller)
+                .buyer(buyer)
+                .teamId(1L)
+                .title("상품 제목")
+                .content("상품 내용")
+                .price(10_000)
+                .category(Category.ACCESSORY)
+                .location(LocationInfo.toEntity(createLocationInfo()))
+                .status(Status.CLOSED)
+                .build());
+    }
+
+    private GoodsReview createGoodsReview(Member reviewer, Member reviewee) {
+        return goodsReviewRepository.save(GoodsReview.builder()
+                .goodsPost(goodsPost)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .rating(Rating.GOOD)
+                .reviewContent("좋은 상품입니다. 만족합니다.")
+                .build());
+    }
+
+    private LocationInfo createLocationInfo() {
+        return LocationInfo.builder()
+                .placeName("스포츠 스타디움")
+                .longitude("127.12345")
+                .latitude("37.56789")
                 .build();
+    }
+
+    private JoinRequest createJoinRequest(String name, String nickname, String email, String gender, String birthyear,
+                                          Long teamId) {
+        return JoinRequest.builder()
+                .name(name)
+                .email(email)
+                .gender(gender)
+                .birthyear(birthyear)
+                .teamId(teamId)
+                .nickname(nickname)
+                .build();
+    }
+
+    private Match createMatch(LocalDateTime matchTime) {
+        return matchRepository.save(Match.builder()
+                .homeTeamId(1L)
+                .awayTeamId(2L)
+                .stadiumId(1L)
+                .status(SCHEDULED)
+                .matchTime(matchTime)
+                .build());
+    }
+
+    private MatePost createMatePost(Member author, Match match) {
+        return mateRepository.save(MatePost.builder()
+                .author(author)
+                .teamId(1L)
+                .match(match)
+                .title("매칭 제목")
+                .content("매칭 내용")
+                .status(CLOSED)
+                .maxParticipants(5)
+                .currentParticipants(1)
+                .age(Age.ALL)
+                .gender(Gender.MALE)
+                .transport(TransportType.CAR)
+                .imageUrl("mate_image.jpg")
+                .build());
+    }
+
+    private Visit createVisit(MatePost matePost, List<Member> participants) {
+        Visit visit = visitRepository.save(Visit.builder().post(matePost).build());
+
+        participants.forEach(member -> {
+            VisitPart visitPart = VisitPart.builder()
+                    .member(member)
+                    .visit(visit)
+                    .build();
+            visit.getParticipants().add(visitPart);
+            visitPartRepository.save(visitPart);
+        });
+        return visit;
+    }
+
+    private MateReview createMateReview(Member reviewer, Member reviewee, MatePost matePost) {
+        return mateReviewRepository.save(MateReview.builder()
+                .visit(visit)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .reviewContent("매칭 후기입니다. 아주 즐거웠어요!")
+                .rating(Rating.GOOD)
+                .createdAt(LocalDateTime.now())
+                .build());
     }
 
     @Test
     @DisplayName("자체 회원 가입 - 성공")
     void join_success() throws Exception {
-        // given
-        JoinRequest joinRequest = createTestJoinRequest();
+        JoinRequest joinRequest = createJoinRequest("이철수", "tester3", "tester3@example.com", "M", "2002", 1L);
 
-        // when & then
         mockMvc.perform(post("/api/members/join")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(joinRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.name").value("김철수"))
-                .andExpect(jsonPath("$.data.email").value("tester2@example.com"))
+                .andExpect(jsonPath("$.data.name").value("이철수"))
+                .andExpect(jsonPath("$.data.email").value("tester3@example.com"))
                 .andExpect(jsonPath("$.data.age").value(22))
-                .andExpect(jsonPath("$.data.nickname").value("tester2"))
+                .andExpect(jsonPath("$.data.nickname").value("tester3"))
                 .andDo(print());
     }
 
     @Test
     @DisplayName("회원 가입 - teamId가 유효하지 않으면 오류")
     void join_fail_invalid_teamId() throws Exception {
-        // given
-        JoinRequest invalidJoinRequest = JoinRequest.builder()
-                .name("김철수")
-                .email("tester2@example.com")
-                .gender("M")
-                .birthyear("2002")
-                .teamId(15L)  // 유효하지 않은 teamId
-                .nickname("tester2")
-                .build();
+        JoinRequest invalidJoinRequest = createJoinRequest("김철수", "tester2", "tester2@example.com", "M", "2002", 15L);
 
-        // when & then
         mockMvc.perform(post("/api/members/join")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidJoinRequest)))
-                .andExpect(status().isBadRequest())  // 400 오류가 반환되기를 기대
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value("ERROR"))
                 .andExpect(jsonPath("$.message").value("teamId: teamId는 10 이하이어야 합니다."))
                 .andExpect(jsonPath("$.code").value(400))
@@ -118,58 +262,59 @@ class MemberIntegrationTest {
     }
 
     @Test
-    @DisplayName("회원 가입 - nickname이 최대 길이(20자)를 초과하면 오류")
-    void join_fail_invalid_nickname() throws Exception {
-        // given
-        JoinRequest invalidJoinRequest = JoinRequest.builder()
-                .name("김철수")
-                .email("tester2@example.com")
-                .gender("M")
-                .birthyear("2002")
-                .teamId(1L)
-                .nickname("tester12345678901234567890")  // nickname 길이가 20자를 초과
-                .build();
-
-        // when & then
-        mockMvc.perform(post("/api/members/join")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidJoinRequest)))
-                .andExpect(status().isBadRequest())  // 400 오류가 반환되기를 기대
-                .andExpect(jsonPath("$.status").value("ERROR"))
-                .andExpect(jsonPath("$.message").value("nickname: nickname은 최대 20자까지 입력할 수 있습니다."))
-                .andExpect(jsonPath("$.code").value(400))
-                .andDo(print());
-    }
-
-
-    @Test
-    @DisplayName("다른 회원 프로필 조회 - 성공")
-    void find_member_info_success() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/members/" + member.getId()))
+    @DisplayName("내 프로필 조회 - 성공")
+    void find_my_info_success() throws Exception {
+        mockMvc.perform(get("/api/members/me")
+                        .param("memberId", member.getId().toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.nickname").value("tester"))
                 .andExpect(jsonPath("$.data.imageUrl").value("default.jpg"))
-                .andExpect(jsonPath("$.data.teamName").value("KIA"))
-                .andExpect(jsonPath("$.data.aboutMe").value("tester입니다."))
                 .andExpect(jsonPath("$.data.manner").value(0.300F))
+                .andExpect(jsonPath("$.data.aboutMe").value("테스트 회원입니다."))
+                .andExpect(jsonPath("$.data.followingCount").value(1))
+                .andExpect(jsonPath("$.data.followerCount").value(1))
+                .andExpect(jsonPath("$.data.reviewsCount").value(2))
+                .andExpect(jsonPath("$.data.goodsSoldCount").value(1))
+                .andExpect(jsonPath("$.data.goodsBoughtCount").value(0))
+                .andExpect(jsonPath("$.data.visitsCount").value(1))
                 .andDo(print());
     }
 
     @Test
-    @DisplayName("다른 회원 프로필 조회 - 실패 (해당 회원 없음)")
-    void find_member_info_fail_member_not_found() throws Exception {
-        // given
-        long invalidMemberId = member.getId() + 999L;
-
-        // when & then
-        mockMvc.perform(get("/api/members/" + invalidMemberId))
+    @DisplayName("내 프로필 조회 - 존재하지 않는 회원 ID 실패")
+    void find_member_info_fail_not_found() throws Exception {
+        // 존재하지 않는 memberId를 사용
+        mockMvc.perform(get("/api/members/me")
+                        .param("memberId", "99999999"))  // 존재하지 않는 ID
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value("ERROR"))
                 .andExpect(jsonPath("$.message").value("해당 ID의 회원 정보를 찾을 수 없습니다"))
                 .andExpect(jsonPath("$.code").value(404))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("내 프로필 조회 - 회원 ID 누락 실패")
+    void find_member_info_fail_missing_memberId() throws Exception {
+        // memberId 파라미터를 누락
+        mockMvc.perform(get("/api/members/me"))
+                .andExpect(status().isBadRequest())  // 400 상태 코드
+                .andExpect(jsonPath("$.status").value("ERROR"))
+                .andExpect(jsonPath("$.message").value("요청에 'memberId' 파라미터가 누락되었습니다."))
+                .andExpect(jsonPath("$.code").value(400))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("다른 회원 프로필 조회 - 성공")
+    void find_member_info_success() throws Exception {
+        mockMvc.perform(get("/api/members/" + member.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.nickname").value("tester"))
+                .andExpect(jsonPath("$.data.imageUrl").value("default.jpg"))
+                .andExpect(jsonPath("$.data.manner").value(0.300F))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
@@ -8,12 +8,21 @@ import static org.mockito.BDDMockito.given;
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.constant.Rating;
 import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.GoodsReview;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.goods.repository.GoodsReviewRepository;
+import com.example.mate.domain.mate.entity.MateReview;
+import com.example.mate.domain.mate.entity.VisitPart;
+import com.example.mate.domain.mate.repository.MateReviewRepository;
+import com.example.mate.domain.mate.repository.VisitPartRepository;
 import com.example.mate.domain.member.dto.request.JoinRequest;
 import com.example.mate.domain.member.dto.response.JoinResponse;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
+import com.example.mate.domain.member.dto.response.MyProfileResponse;
+import com.example.mate.domain.member.entity.Follow;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.FollowRepository;
 import com.example.mate.domain.member.repository.MemberRepository;
@@ -41,14 +50,37 @@ class MemberServiceTest {
     @Mock
     private FollowRepository followRepository;
 
+    @Mock
+    private GoodsReviewRepository goodsReviewRepository;
+
+    @Mock
+    private MateReviewRepository mateReviewRepository;
+
+    @Mock
+    private VisitPartRepository visitPartRepository;
+
+
     private Member member;
+    private Member member2;
+    private Member member3;
     private GoodsPost goodsPost;
     private JoinRequest joinRequest;
+    private Follow follow;
+    private Follow follow2;
+    private Follow follow3;
+    private GoodsReview goodsReview;
+    private MateReview mateReview;
+    private VisitPart visitPart;
 
     @BeforeEach
     void setUp() {
         createTestMember();
+        createTestGoodsPost();
         createTestJoinRequest();
+        createTestFollow();
+        createTestGoodsReview();
+        createTestMateReview();
+        createTestVisitPart();
     }
 
     private void createTestMember() {
@@ -60,6 +92,26 @@ class MemberServiceTest {
                 .age(30)
                 .gender(Gender.MALE)
                 .teamId(1L)
+                .manner(0.300F)
+                .build();
+        member2 = Member.builder()
+                .id(2L)
+                .name("김철수")
+                .nickname("tester2")
+                .email("test2@example.com")
+                .age(20)
+                .gender(Gender.MALE)
+                .teamId(2L)
+                .manner(0.300F)
+                .build();
+        member3 = Member.builder()
+                .id(3L)
+                .name("김영수")
+                .nickname("tester3")
+                .email("test3@example.com")
+                .age(30)
+                .gender(Gender.MALE)
+                .teamId(3L)
                 .manner(0.300F)
                 .build();
     }
@@ -83,6 +135,51 @@ class MemberServiceTest {
                 .build();
     }
 
+    private void createTestFollow() {
+        follow = Follow.builder()
+                .id(1L)
+                .follower(member)
+                .following(member2)
+                .build();
+        follow2 = Follow.builder()
+                .id(2L)
+                .follower(member2)
+                .following(member)
+                .build();
+        follow3 = Follow.builder()
+                .id(3L)
+                .follower(member3)
+                .following(member)
+                .build();
+    }
+
+    private void createTestGoodsReview() {
+        goodsReview = GoodsReview.builder()
+                .id(1L)
+                .goodsPost(goodsPost)
+                .reviewer(member2)
+                .reviewee(member)
+                .rating(Rating.GOOD)
+                .reviewContent("good")
+                .build();
+    }
+
+    private void createTestMateReview() {
+        mateReview = MateReview.builder()
+                .id(1L)
+                .reviewer(member3)
+                .reviewee(member)
+                .rating(Rating.GOOD)
+                .reviewContent("good")
+                .build();
+    }
+
+    private void createTestVisitPart() {
+        visitPart = VisitPart.builder()
+                .member(member)
+                .build();
+    }
+
     @Test
     @DisplayName("자체 회원 가입 - 성공")
     void join_success() {
@@ -99,17 +196,78 @@ class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("내 프로필 조회 - 성공")
+    void get_my_profile_success() {
+        // given
+        Long memberId = 1L;
+        int followCount = 1;
+        int followerCount = 2;
+        int goodsReviewsCount = 1;
+        int mateReviewsCount = 1;
+        int reviewsCount = goodsReviewsCount + mateReviewsCount;
+        int goodsSoldCount = 1;
+        int goodsBoughtCount = 0;
+        int visitsCount = 1;
+
+        given(memberRepository.findById(memberId)).willReturn(java.util.Optional.of(member));
+        given(followRepository.countByFollowerId(memberId)).willReturn(followCount);
+        given(followRepository.countByFollowingId(memberId)).willReturn(followerCount);
+        given(goodsReviewRepository.countByRevieweeId(memberId)).willReturn(goodsReviewsCount);
+        given(mateReviewRepository.countByRevieweeId(memberId)).willReturn(mateReviewsCount);
+        given(goodsPostRepository.countGoodsPostsBySellerIdAndStatus(memberId, Status.CLOSED)).
+                willReturn(goodsSoldCount);
+        given(goodsPostRepository.countGoodsPostsByBuyerIdAndStatus(memberId, Status.CLOSED)).
+                willReturn(goodsBoughtCount);
+        given(visitPartRepository.countByMember(member)).
+                willReturn(visitsCount);
+
+        // when
+        MyProfileResponse response = memberService.getMyProfile(memberId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getNickname()).isEqualTo(member.getNickname());
+        assertThat(response.getManner()).isEqualTo(member.getManner());
+        assertThat(response.getAboutMe()).isEqualTo(member.getAboutMe());
+        assertThat(response.getFollowingCount()).isEqualTo(followCount);
+        assertThat(response.getFollowerCount()).isEqualTo(followerCount);
+        assertThat(response.getReviewsCount()).isEqualTo(reviewsCount);
+        assertThat(response.getGoodsSoldCount()).isEqualTo(goodsSoldCount);
+        assertThat(response.getGoodsBoughtCount()).isEqualTo(goodsBoughtCount);
+        assertThat(response.getVisitsCount()).isEqualTo(visitsCount);
+    }
+
+    @Test
+    @DisplayName("내 프로필 조회 - 실패 (회원이 존재하지 않는 경우)")
+    void get_my_profile_fail_member_not_found() {
+        // given
+        Long memberId = 999L;  // 존재하지 않는 회원 ID
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.getMyProfile(memberId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage());
+    }
+    
+    @Test
     @DisplayName("다른 회원 프로필 조회 - 성공")
     void get_member_profile_success() {
         // given
         Long memberId = 1L;
         int followCount = 10;
         int followerCount = 20;
+        int goodsReviewsCount = 7;
+        int mateReviewsCount = 8;
+        int reviewsCount = goodsReviewsCount + mateReviewsCount;
         int goodsSoldCount = 1;
 
         given(memberRepository.findById(memberId)).willReturn(java.util.Optional.of(member));
         given(followRepository.countByFollowerId(memberId)).willReturn(followCount);
         given(followRepository.countByFollowingId(memberId)).willReturn(followerCount);
+        given(goodsReviewRepository.countByRevieweeId(memberId)).willReturn(goodsReviewsCount);
+        given(mateReviewRepository.countByRevieweeId(memberId)).willReturn(mateReviewsCount);
         given(goodsPostRepository.countGoodsPostsBySellerIdAndStatus(memberId, Status.CLOSED)).
                 willReturn(goodsSoldCount);
 
@@ -121,6 +279,7 @@ class MemberServiceTest {
         assertThat(result.getNickname()).isEqualTo(member.getNickname());
         assertThat(result.getFollowingCount()).isEqualTo(followCount);
         assertThat(result.getFollowerCount()).isEqualTo(followerCount);
+        assertThat(result.getReviewsCount()).isEqualTo(reviewsCount);
         assertThat(result.getGoodsSoldCount()).isEqualTo(goodsSoldCount);
     }
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] 내 프로필 조회 기능 구현
- [x] 다른 유저 프로필 조회에 누락됐던 리뷰 수 구현
- [x] 리뷰, 직관 쪽 레포지토리 생성
- [x] 단일, 통합 테스트

## 💡 자세한 설명

### 내 프로필 조회 기능 구현
- 마이 페이지에서 보이는 화면에 더해 굿즈 구매 기록, 직관 기록의 카운트까지 추가
    - 카운트 쿼리를 사용하기 위해, 해당 도메인의 레포지토리 생성

### 다른 회원 프로필 조회 기능 수정
- 기존에는 리뷰 수를 가져오지 않았지만, 굿즈 리뷰 + 메이트 리뷰의 수를 표기하도록 수정

### 각종 ExceptionHandler 추가
- 테스트 예외 처리에서 발생하는 전역적 예외 추가 -> NumberFormatException, MethodArgumentTypeMismatchException, MissingServletRequestParameterException

## 📢 리뷰 요구 사항 (선택)


- `private <T> T getProfile(Long memberId, Class<T> responseType)` : 
- "내 프로필 조회" 기능과 "다른 회원 프로필 조회" 기능이 사실상 두 필드(판매 수, 직관 수)를 제외한 모든 값들을 동일한 로직으로 가져오다보니, 코드 중복이 심해 제너릭을 사용하여 팩토리 메서드를 구현해 봤습니다. 
    - 매개 변수의 클래스 타입에 따라 서로 다른 프로필 응답 객체를 반환하도록 구현했는데, 가독성면에서 좋은지는 모르겠습니다...
- 참고 : https://jjingho.tistory.com/74

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?