### PR TITLE
MATE-63 : [REFACTOR] 굿즈거래 판매글 삭제 로직 수정

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     GOODS_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "G002", "해당 ID의 굿즈 판매글 정보를 찾을 수 없습니다."),
     GOODS_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "G003", "판매글의 판매자가 아니라면, 판매글을 수정할 수 없습니다."),
     GOODS_MAIN_IMAGE_IS_EMPTY(HttpStatus.NOT_FOUND, "G004", "굿즈 게시물의 대표사진을 찾을 수 없습니다."),
+    GOODS_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "G005", "거래완료 상태에서 판매글을 삭제할 수 없습니다."),
 
     // FILE
     FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "F001", "빈 파일을 업로드할 수 없습니다. 파일 내용을 확인해주세요."),

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
@@ -18,8 +18,8 @@ public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long> {
             ORDER BY gp.createdAt DESC
             """)
     List<GoodsPost> findMainGoodsPosts(@Param("teamId") Long teamId, @Param("status") Status status, Pageable pageable);
-           
-   @Query("""
+
+    @Query("""
             SELECT COUNT(gp)
             FROM GoodsPost gp
             WHERE gp.seller.id = :memberId

--- a/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/example/mate/domain/goods/service/GoodsService.java
@@ -75,6 +75,10 @@ public class GoodsService {
         Member seller = getSellerAndValidate(memberId);
         GoodsPost goodsPost = getGoodsPostAndValidate(seller, goodsPostId);
 
+        if (goodsPost.getStatus() == Status.CLOSED) {
+            throw new CustomException(ErrorCode.GOODS_DELETE_NOT_ALLOWED);
+        }
+
         // 업로된 이미지 파일 삭제
         deleteExistingImages(goodsPostId);
         goodsPostRepository.delete(goodsPost);

--- a/src/test/java/com/example/mate/domain/goods/service/GoodsServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goods/service/GoodsServiceTest.java
@@ -325,6 +325,27 @@ class GoodsServiceTest {
             verify(imageRepository, never()).deleteAllByPostId(any(Long.class));
             verify(goodsPostRepository, never()).delete(any(GoodsPost.class));
         }
+
+        @Test
+        @DisplayName("굿즈거래 판매글 삭제 실패 - 거래완료 상태인 판매글")
+        void delete_goods_post_failed_with_closed_status() {
+            // given
+            Long memberId = member.getId();
+            GoodsPost post = GoodsPost.builder().seller(member).status(Status.CLOSED).build();
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(goodsPostRepository.findById(post.getId())).willReturn(Optional.of(post));
+
+            // when & then
+            assertThatThrownBy(() -> goodsService.deleteGoodsPost(memberId, post.getId()))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.GOODS_DELETE_NOT_ALLOWED.getMessage());
+
+            verify(memberRepository).findById(memberId);
+            verify(goodsPostRepository).findById(post.getId());
+            verify(imageRepository, never()).deleteAllByPostId(any(Long.class));
+            verify(goodsPostRepository, never()).delete(any(GoodsPost.class));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 판매글 삭제 로직 수정
- [x] 시나리오 추가에 대한 테스트 코드 추가 작성

## 💡 자세한 설명

#### 거래완료 상태 예외 처리 로직 추가
- `GoodsPost`가 이미 `Status.CLOSED`인 경우, 삭제 요청이 발생하면 적절한 예외(`CustomException`)를 발생시키도록 로직을 추가했습니다.
- 도메인 규칙이 추가됨에 따라 관련 내용에 대한 테스트 코드를 추가했습니다.
- 노션 도메인 규칙에 해당 내용을 추가하였습니다.

<img width="505" alt="image" src="https://github.com/user-attachments/assets/5ec232c4-f9b2-45c4-a524-2ea198df33b2">

## 📢 리뷰 요구 사항 (선택)
간단한 로직 수정이니 가볍게 봐주시면 될 것 같습니다!

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?