### PR TITLE
MATE-38 : [FEAT] 회원 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     // Member
     MEMBER_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "M001", "해당 ID의 회원 정보를 찾을 수 없습니다"),
     UNSUPPORTED_RESPONSE_TYPE(HttpStatus.BAD_REQUEST, "M002", "회원 프로필 조회에서 지원하지 않는 응답 타입입니다."),
+    ALREADY_USED_NICKNAME(HttpStatus.BAD_REQUEST, "M003", "이미 사용 중인 닉네임입니다."),
 
     // Follow
     ALREADY_FOLLOWED_MEMBER(HttpStatus.BAD_REQUEST, "F001", "이미 팔로우한 회원입니다."),

--- a/src/main/java/com/example/mate/common/utils/file/FileValidator.java
+++ b/src/main/java/com/example/mate/common/utils/file/FileValidator.java
@@ -19,6 +19,11 @@ public class FileValidator {
         }
     }
 
+    // 회원 프로필 이미지 파일 유효성 검사
+    public static void validateMyProfileImage(MultipartFile file) {
+        isNotImage(file);
+    }
+
     private static void validateNotEmpty(MultipartFile file) {
         if (file == null || file.isEmpty()) {
             throw new CustomException(ErrorCode.FILE_IS_EMPTY);

--- a/src/main/java/com/example/mate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/MemberController.java
@@ -61,33 +61,14 @@ public class MemberController {
     }
 
     /*
-    TODO : 2024/11/23 - 회원 정보 수정
-    1. JwtToken 을 통해 사용자 정보 조회
-    2. nickname, profileImage, aboutMe, myTeam 수정
-    3. 회원 정보 update 및 저장
+    TODO : 회원 정보 수정 :
+    1. JwtToken 을 통해 사용자 정보 조회 -> 본인만 수정 가능하도록
     */
     @PutMapping(value = "/me")
-    public ResponseEntity<MyProfileResponse> updateMemberInfo(
+    public ResponseEntity<ApiResponse<MyProfileResponse>> updateMemberInfo(
             @RequestPart(value = "image", required = false) MultipartFile image,
-            @RequestPart(value = "data") MemberInfoUpdateRequest updateRequest) {
-
-        String imageUrl = (image != null && image.getOriginalFilename() != null)
-                ? "upload/" + image.getOriginalFilename() : "upload/defaultImage.jpg";
-        String nickname = updateRequest.getNickname() != null ? updateRequest.getNickname() : "삼성빠돌이";
-        String myTeam = updateRequest.getTeamId() != null ? "삼성" : "한화";
-        String aboutMe = updateRequest.getAboutMe() != null ? updateRequest.getAboutMe() : "삼성을 사랑하는 삼성빠돌이입니다!";
-
-        MyProfileResponse myProfileResponse = MyProfileResponse.builder()
-                .nickname(nickname)
-                .imageUrl(imageUrl)
-                .teamName(myTeam)
-                .manner(0.3f)
-                .aboutMe(aboutMe)
-                .followingCount(10)
-                .followerCount(20)
-                .build();
-
-        return ResponseEntity.ok(myProfileResponse);
+            @Valid @RequestPart(value = "data") MemberInfoUpdateRequest updateRequest) {
+        return ResponseEntity.ok(ApiResponse.success(memberService.updateMyProfile(image, updateRequest)));
     }
 
     /*

--- a/src/main/java/com/example/mate/domain/member/dto/request/MemberInfoUpdateRequest.java
+++ b/src/main/java/com/example/mate/domain/member/dto/request/MemberInfoUpdateRequest.java
@@ -1,11 +1,31 @@
 package com.example.mate.domain.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class MemberInfoUpdateRequest {
 
+    @Schema(description = "팀 ID", example = "1")
+    @Min(value = 0, message = "팀 ID는 0 이상이어야 합니다.")
+    @Max(value = 10, message = "팀 ID는 10 이하이어야 합니다.")
     private Long teamId;
+
+    @Schema(description = "사용자 닉네임", example = "newTester")
+    @NotBlank(message = "닉네임은 필수 항목입니다.")
+    @Size(max = 20, message = "닉네임은 최대 20자까지 입력 가능합니다.")
     private String nickname;
+
+    @Schema(description = "사용자 소개글", example = "안녕하세요")
+    @Size(max = 100, message = "소개글은 최대 100자까지 입력 가능합니다.")
     private String aboutMe;
+
+    @Min(value = 1, message = "회원 ID는 1 이상이어야 합니다.")
+    private Long memberId;
 }

--- a/src/main/java/com/example/mate/domain/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MyProfileResponse.java
@@ -2,6 +2,7 @@ package com.example.mate.domain.member.dto.response;
 
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,17 +13,37 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MyProfileResponse {
 
+    @Schema(description = "사용자 닉네임", example = "tester")
     private String nickname;
+
+    @Schema(description = "사용자의 프로필 이미지 URL", example = "/images/default.png")
     private String imageUrl;
+
+    @Schema(description = "사용자 응원팀 이름", example = "KIA")
     private String teamName;
+
+    @Schema(description = "매너 타율", example = "0.300")
     private Float manner;
+
+    @Schema(description = "소개글", example = "안녕하세요.")
     private String aboutMe;
 
+    @Schema(description = "사용자가 팔로잉한 사람 수", example = "120")
     private Integer followingCount;
+
+    @Schema(description = "사용자를 팔로우한 사람 수", example = "200")
     private Integer followerCount;
+
+    @Schema(description = "사용자가 받은 총 리뷰 수", example = "15")
     private Integer reviewsCount;
+
+    @Schema(description = "사용자가 판매한 상품의 개수", example = "8")
     private Integer goodsSoldCount;
+
+    @Schema(description = "사용자가 구매한 상품의 개수", example = "12")
     private Integer goodsBoughtCount;
+
+    @Schema(description = "사용자의 직관 수", example = "5")
     private Integer visitsCount;
 
     public static MyProfileResponse of(Member member, int followingCount, int followerCount, int reviewsCount,
@@ -39,6 +60,15 @@ public class MyProfileResponse {
                 .goodsSoldCount(goodsSoldCount)
                 .goodsBoughtCount(goodsBoughtCount)
                 .visitsCount(visitsCount)
+                .build();
+    }
+
+    public static MyProfileResponse from(Member member) {
+        return MyProfileResponse.builder()
+                .nickname(member.getNickname())
+                .imageUrl(member.getImageUrl())
+                .teamName(TeamInfo.getById(member.getTeamId()).shortName)
+                .aboutMe(member.getAboutMe())
                 .build();
     }
 }

--- a/src/main/java/com/example/mate/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/mate/domain/member/repository/MemberRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/mate/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/mate/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.example.mate.domain.member.service;
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.utils.file.FileUploader;
+import com.example.mate.common.utils.file.FileValidator;
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
@@ -60,6 +61,7 @@ public class MemberService {
         member.changeTeam(TeamInfo.getById(request.getTeamId()));
         member.changeAboutMe(request.getAboutMe());
         if (image != null && !image.isEmpty()) {
+            FileValidator.validateMyProfileImage(image);
             member.changeImageUrl(FileUploader.uploadFile(image)); // TODO : 실제 업로드 처리 필요
         } else {
             member.changeImageUrl(DEFAULT_IMAGE_URL);

--- a/src/main/java/com/example/mate/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/mate/domain/member/service/MemberService.java
@@ -2,12 +2,15 @@ package com.example.mate.domain.member.service;
 
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
+import com.example.mate.common.utils.file.FileUploader;
+import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
 import com.example.mate.domain.goods.repository.GoodsReviewRepository;
 import com.example.mate.domain.mate.repository.MateReviewRepository;
 import com.example.mate.domain.mate.repository.VisitPartRepository;
 import com.example.mate.domain.member.dto.request.JoinRequest;
+import com.example.mate.domain.member.dto.request.MemberInfoUpdateRequest;
 import com.example.mate.domain.member.dto.response.JoinResponse;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
 import com.example.mate.domain.member.dto.response.MyProfileResponse;
@@ -16,6 +19,7 @@ import com.example.mate.domain.member.repository.FollowRepository;
 import com.example.mate.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +31,8 @@ public class MemberService {
     private final GoodsReviewRepository goodsReviewRepository;
     private final MateReviewRepository mateReviewRepository;
     private final VisitPartRepository visitPartRepository;
+
+    private static final String DEFAULT_IMAGE_URL = "image/default.png";
 
     // 자체 회원가입 기능
     public JoinResponse join(JoinRequest request) {
@@ -43,6 +49,33 @@ public class MemberService {
     // 다른 회원 프로필 조회
     public MemberProfileResponse getMemberProfile(Long memberId) {
         return getProfile(memberId, MemberProfileResponse.class);
+    }
+
+    // TODO : JWT 도입 이후 본인만 접근할 수 있도록 수정
+    // 회원 정보 수정
+    public MyProfileResponse updateMyProfile(MultipartFile image, MemberInfoUpdateRequest request) {
+        Member member = findByMemberId(request.getMemberId());
+
+        checkNickNameAndChange(member, request.getNickname()); // 닉네임 중복 검증한 뒤 바뀐 경우에만 수정
+        member.changeTeam(TeamInfo.getById(request.getTeamId()));
+        member.changeAboutMe(request.getAboutMe());
+        if (image != null && !image.isEmpty()) {
+            member.changeImageUrl(FileUploader.uploadFile(image)); // TODO : 실제 업로드 처리 필요
+        } else {
+            member.changeImageUrl(DEFAULT_IMAGE_URL);
+        }
+
+        return MyProfileResponse.from(memberRepository.save(member));
+    }
+
+    private void checkNickNameAndChange(Member member, String request) {
+        if (member.getNickname().equals(request)) {
+            return;
+        }
+        if (memberRepository.existsByNickname(request)) {
+            throw new CustomException(ErrorCode.ALREADY_USED_NICKNAME);
+        }
+        member.changeNickname(request);
     }
 
     // 공통 프로필 생성 팩토리 메서드. DTO 클래스 타입에 따라 다른 타입 리턴
@@ -66,7 +99,7 @@ public class MemberService {
                     MyProfileResponse.of(member, followCount, followerCount, reviewsCount,
                             goodsSoldCount, goodsBoughtCount, visitsCount));
         }
-        
+
         throw new CustomException(ErrorCode.UNSUPPORTED_RESPONSE_TYPE);
     }
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] 회원 정보 수정 구현
- [x] 서비스 단위, 컨트롤러 단위, 통합 테스트

## 💡 자세한 설명

### 회원 정보 수정 구현
- 이후 본인만 수정 가능하도록 로직 추가 필요
- 이미지 파일을 첨부하지 않으면 기본 이미지 경로를 삽입

### 테스트 관련
- 테스트 코드의 가독성을 위해 회원 쪽 테스트는 @Nested로 묶음

### 도메인 규칙
- 노션에 프로필 사진에 대한 내용 추가
![스크린샷 2024-11-30 오후 4 56 40](https://github.com/user-attachments/assets/14b03dc2-9269-4f6d-86c8-1842d511f66d)

## 📗 참고 자료 (선택)



## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?