### PR TITLE
MATE-39 : [FEAT] 회원 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/MemberController.java
@@ -64,20 +64,22 @@ public class MemberController {
     TODO : 회원 정보 수정 :
     1. JwtToken 을 통해 사용자 정보 조회 -> 본인만 수정 가능하도록
     */
+    @Operation(summary = "회원 내 정보 수정")
     @PutMapping(value = "/me")
     public ResponseEntity<ApiResponse<MyProfileResponse>> updateMemberInfo(
-            @RequestPart(value = "image", required = false) MultipartFile image,
-            @Valid @RequestPart(value = "data") MemberInfoUpdateRequest updateRequest) {
+            @Parameter(description = "프로필 사진") @RequestPart(value = "image", required = false) MultipartFile image,
+            @Parameter(description = "수정할 회원 정보") @Valid @RequestPart(value = "data") MemberInfoUpdateRequest updateRequest) {
         return ResponseEntity.ok(ApiResponse.success(memberService.updateMyProfile(image, updateRequest)));
     }
 
     /*
-    TODO : 2024/11/23 - 회원 삭제
-    1. JwtToken 을 통해 사용자 정보 조회
-    2. 회원 삭제
+    TODO : 회원 삭제 : 임시로 @RequestParam Long memberId
+    1. JwtToken 을 통해 사용자 정보 조회 -> 본인만 수정 가능하도록
     */
+    @Operation(summary = "회원 탈퇴")
     @DeleteMapping("/me")
-    public ResponseEntity<Void> deleteMember() {
+    public ResponseEntity<Void> deleteMember(@RequestParam Long memberId) {
+        memberService.deleteMember(memberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/mate/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/mate/domain/member/service/MemberService.java
@@ -70,6 +70,13 @@ public class MemberService {
         return MyProfileResponse.from(memberRepository.save(member));
     }
 
+    // TODO : JWT 도입 이후 본인만 접근할 수 있도록 수정
+    // 회원 탈퇴
+    public void deleteMember(Long memberId) {
+        findByMemberId(memberId);
+        memberRepository.deleteById(memberId);
+    }
+
     private void checkNickNameAndChange(Member member, String request) {
         if (member.getNickname().equals(request)) {
             return;

--- a/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
@@ -2,6 +2,7 @@ package com.example.mate.domain.member.integration;
 
 import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
 import static com.example.mate.domain.mate.entity.Status.CLOSED;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -280,7 +281,7 @@ class MemberIntegrationTest {
                     .andDo(print());
         }
     }
-    
+
     @Nested
     @DisplayName("내 프로필 조회")
     class GetMyProfile {
@@ -408,6 +409,35 @@ class MemberIntegrationTest {
                     .andExpect(jsonPath("$.status").value("ERROR"))
                     .andExpect(jsonPath("$.message").value("nickname: 닉네임은 필수 항목입니다."))
                     .andExpect(jsonPath("$.code").value(400));
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴")
+    class DeleteMember {
+
+        @Test
+        @DisplayName("회원 탈퇴 성공")
+        void delete_member_success() throws Exception {
+            mockMvc.perform(delete("/api/members/me")
+                            .param("memberId", member.getId().toString()))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("회원 탈퇴 실패 - 존재하지 않는 회원")
+        void delete_member_fail_not_exists_member() throws Exception {
+            // given
+            Long memberId = member.getId() + 999L;
+
+            // when & then
+            mockMvc.perform(delete("/api/members/me")
+                            .param("memberId", memberId.toString()))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value("해당 ID의 회원 정보를 찾을 수 없습니다"));
         }
     }
 }

--- a/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
@@ -430,4 +430,41 @@ class MemberServiceTest {
             verify(memberRepository).findById(memberId);
         }
     }
+
+    @Nested
+    @DisplayName("회원 탈퇴")
+    class DeleteMember {
+
+        @Test
+        @DisplayName("회원 탈퇴 성공")
+        void delete_member_success() {
+            // given
+            Long memberId = 1L;
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+            // when
+            memberService.deleteMember(memberId);
+
+            // then
+            verify(memberRepository).findById(memberId);
+            verify(memberRepository).deleteById(memberId);
+        }
+
+        @Test
+        @DisplayName("회원 탈퇴 실패 - 존재하지 않는 회원")
+        void delete_member_fail_not_exists_member() {
+            // given
+            Long memberId = 999L;
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberService.deleteMember(memberId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage());
+
+            verify(memberRepository).findById(memberId);
+        }
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 회원 삭제 기능(회원 탈퇴)
- [x] 서비스, 컨트롤러, 통합 테스트 및 Swagger 추가

## 💡 자세한 설명

### 회원 삭제 구현
- 이후 본인만 삭제 가능하도록 로직 추가 필요

### 도메인 규칙
- 노션에 "사용자는 회원을 탈퇴할 수 있다." 추가

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

간단한 삭제 처리 작업입니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?