### PR TITLE
MATE-35 : [FEAT] 특정 회원의 팔로우 목록 페이징 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/member/controller/FollowController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/FollowController.java
@@ -1,15 +1,13 @@
 package com.example.mate.domain.member.controller;
 
 import com.example.mate.common.response.ApiResponse;
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.member.dto.response.MemberSummaryResponse;
 import com.example.mate.domain.member.service.FollowService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import java.util.Collections;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -54,22 +52,15 @@ public class FollowController {
         return ResponseEntity.noContent().build();
     }
 
-    /*
-    TODO : 2024/11/25 - 특정 사용자가 팔로우하는 회원들 페이징 조회
-    1. memberId 을 통해 회원 정보 조회
-    2. 회원이 팔로우하는 회원 정보 조회
-    3. 페이징 처리 후 반환
-    */
+    @Operation(summary = "특정 회원이 팔로우하는 회원 리스트 페이징 조회")
     @GetMapping("{memberId}/followings")
-    public ResponseEntity<Page<MemberSummaryResponse>> getFollowings(
-            @PathVariable Long memberId,
-            @PageableDefault(size = 10) Pageable pageable
+    public ResponseEntity<ApiResponse<PageResponse<MemberSummaryResponse>>> getFollowings(
+            @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
+            @Parameter(description = "페이지 번호") @RequestParam(required = false, defaultValue = "1") int pageNumber,
+            @Parameter(description = "페이지 크기") @RequestParam(required = false, defaultValue = "10") int pageSize
     ) {
-        MemberSummaryResponse response = MemberSummaryResponse.from();
-        List<MemberSummaryResponse> responses = Collections.nCopies(10, response);
-        Page<MemberSummaryResponse> page = new PageImpl<>(responses, pageable, responses.size());
-
-        return ResponseEntity.ok(page);
+        PageResponse<MemberSummaryResponse> response = followService.getFollowingsPage(memberId, pageNumber, pageSize);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /*
@@ -83,10 +74,10 @@ public class FollowController {
             @PathVariable Long memberId,
             @PageableDefault(size = 10) Pageable pageable
     ) {
-        MemberSummaryResponse response = MemberSummaryResponse.from();
-        List<MemberSummaryResponse> responses = Collections.nCopies(10, response);
-        Page<MemberSummaryResponse> page = new PageImpl<>(responses, pageable, responses.size());
+//        MemberSummaryResponse response = MemberSummaryResponse.from();
+//        List<MemberSummaryResponse> responses = Collections.nCopies(10, response);
+//        Page<MemberSummaryResponse> page = new PageImpl<>(responses, pageable, responses.size());
 
-        return ResponseEntity.ok(page);
+        return ResponseEntity.ok(null);
     }
 }

--- a/src/main/java/com/example/mate/domain/member/controller/FollowController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/FollowController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -56,10 +57,10 @@ public class FollowController {
     @GetMapping("{memberId}/followings")
     public ResponseEntity<ApiResponse<PageResponse<MemberSummaryResponse>>> getFollowings(
             @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
-            @Parameter(description = "페이지 번호") @RequestParam(required = false, defaultValue = "1") int pageNumber,
-            @Parameter(description = "페이지 크기") @RequestParam(required = false, defaultValue = "10") int pageSize
+            @PageableDefault(size = 10) Pageable pageable
     ) {
-        PageResponse<MemberSummaryResponse> response = followService.getFollowingsPage(memberId, pageNumber, pageSize);
+        pageable = validatePageable(pageable);
+        PageResponse<MemberSummaryResponse> response = followService.getFollowingsPage(memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -79,5 +80,15 @@ public class FollowController {
 //        Page<MemberSummaryResponse> page = new PageImpl<>(responses, pageable, responses.size());
 
         return ResponseEntity.ok(null);
+    }
+
+    // Pageable 검증 메서드
+    private Pageable validatePageable(Pageable pageable) {
+        // pageNumber 검증: 0보다 작은 값은 0으로 처리
+        int pageNumber = Math.max(pageable.getPageNumber(), 0);
+
+        // pageSize 검증: 0 이하이면 기본값 10으로 설정
+        int pageSize = pageable.getPageSize() <= 0 ? 10 : pageable.getPageSize();
+        return PageRequest.of(pageNumber, pageSize, pageable.getSort());
     }
 }

--- a/src/main/java/com/example/mate/domain/member/dto/response/MemberSummaryResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MemberSummaryResponse.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.member.dto.response;
 
+import com.example.mate.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,11 +15,11 @@ public class MemberSummaryResponse {
     private String nickname;
     private String imageUrl;
 
-    public static MemberSummaryResponse from() {
+    public static MemberSummaryResponse from(Member member) {
         return MemberSummaryResponse.builder()
-                .memberId(1L)
-                .nickname("홍길동")
-                .imageUrl("upload/default.jpg")
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .imageUrl(member.getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
+++ b/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
@@ -2,6 +2,9 @@ package com.example.mate.domain.member.repository;
 
 
 import com.example.mate.domain.member.entity.Follow;
+import com.example.mate.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +23,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
 
     void deleteByFollowerIdAndFollowingId(Long followerId, Long followingId);
+
+    // 특정 회원의 팔로잉 리스트
+    @Query("SELECT f.following FROM Follow f WHERE f.follower.id = :followerId")
+    Page<Member> findFollowingsByFollowerId(@Param("followerId") Long followerId, Pageable pageable);
 }

--- a/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
+++ b/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
@@ -25,6 +25,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     void deleteByFollowerIdAndFollowingId(Long followerId, Long followingId);
 
     // 특정 회원의 팔로잉 리스트
-    @Query("SELECT f.following FROM Follow f WHERE f.follower.id = :followerId")
+    @Query("SELECT f.following FROM Follow f WHERE f.follower.id = :followerId ORDER BY f.id DESC ")
     Page<Member> findFollowingsByFollowerId(@Param("followerId") Long followerId, Pageable pageable);
 }

--- a/src/main/java/com/example/mate/domain/member/service/FollowService.java
+++ b/src/main/java/com/example/mate/domain/member/service/FollowService.java
@@ -13,10 +13,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -48,13 +45,10 @@ public class FollowService {
     }
 
     // 특정 회원의 팔로우 리스트 페이징 조회
-    public PageResponse<MemberSummaryResponse> getFollowingsPage(Long memberId, int pageNumber, int pageSize) {
+    public PageResponse<MemberSummaryResponse> getFollowingsPage(Long memberId, Pageable pageable) {
         findByMemberId(memberId); // 회원 존재 검증
-        pageNumber = pageNumber < 1 ? 0 : pageNumber - 1;
-        pageSize = pageSize < 1 ? 10 : pageSize;
 
         // 해당 회원이 팔로우하는 리스트 최신 팔로우 순으로 페이징
-        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Direction.DESC, "id"));
         Page<Member> followingsPage = followRepository.findFollowingsByFollowerId(memberId, pageable);
 
         // MemberSummaryResponse 변환

--- a/src/test/java/com/example/mate/domain/member/controller/FollowControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/FollowControllerTest.java
@@ -1,22 +1,30 @@
 package com.example.mate.domain.member.controller;
 
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.member.dto.response.MemberSummaryResponse;
 import com.example.mate.domain.member.entity.Follow;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.service.FollowService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,6 +33,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(FollowController.class)
@@ -40,6 +49,14 @@ class FollowControllerTest {
 
     @MockBean
     private FollowService followService;
+
+    private MemberSummaryResponse createMemberSummaryResponse() {
+        return MemberSummaryResponse.builder()
+                .nickname("tester1")
+                .memberId(1L)
+                .imageUrl("tester1.png")
+                .build();
+    }
 
     @Nested
     @DisplayName("회원 팔로우 테스트")
@@ -186,4 +203,59 @@ class FollowControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("팔로우 리스트 페이징")
+    class FollowingPage {
+
+        @Test
+        @DisplayName("팔로우 리스트 페이징 성공")
+        void get_followings_page_success() throws Exception {
+            // given
+            Long memberId = 2L;
+            PageResponse<MemberSummaryResponse> responses = PageResponse.<MemberSummaryResponse>builder()
+                    .content(List.of(createMemberSummaryResponse()))
+                    .totalPages(1)
+                    .totalElements(1L)
+                    .hasNext(false)
+                    .pageNumber(0)
+                    .pageSize(10)
+                    .build();
+
+            given(followService.getFollowingsPage(eq(memberId), anyInt(), anyInt())).willReturn(responses);
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/followings", memberId)
+                            .param("pageNumber", "1")
+                            .param("pageSize", "10")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(1))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("팔로우 리스트 페이징 실패 - 해당 회원이 없는 경우")
+        void get_followings_page_member_not_found() throws Exception {
+            // given
+            Long memberId = 999L;  // 존재하지 않는 회원 ID
+
+            given(followService.getFollowingsPage(eq(memberId), anyInt(), anyInt()))
+                    .willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/followings", memberId)
+                            .param("pageNumber", "1")
+                            .param("pageSize", "10")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andExpect(jsonPath("$.message").value(
+                            ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage()));
+        }
+    }
 }

--- a/src/test/java/com/example/mate/domain/member/controller/FollowControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/FollowControllerTest.java
@@ -1,7 +1,7 @@
 package com.example.mate.domain.member.controller;
 
 
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -221,12 +222,12 @@ class FollowControllerTest {
                     .pageSize(10)
                     .build();
 
-            given(followService.getFollowingsPage(eq(memberId), anyInt(), anyInt())).willReturn(responses);
+            given(followService.getFollowingsPage(eq(memberId), any(Pageable.class))).willReturn(responses);
 
             // when & then
             mockMvc.perform(get("/api/profile/{memberId}/followings", memberId)
-                            .param("pageNumber", "1")
-                            .param("pageSize", "10")
+                            .param("page", "1")
+                            .param("size", "10")
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -242,13 +243,13 @@ class FollowControllerTest {
             // given
             Long memberId = 999L;  // 존재하지 않는 회원 ID
 
-            given(followService.getFollowingsPage(eq(memberId), anyInt(), anyInt()))
+            given(followService.getFollowingsPage(eq(memberId), any(Pageable.class)))
                     .willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
 
             // when & then
             mockMvc.perform(get("/api/profile/{memberId}/followings", memberId)
-                            .param("pageNumber", "1")
-                            .param("pageSize", "10")
+                            .param("page", "1")
+                            .param("size", "10")
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isNotFound())

--- a/src/test/java/com/example/mate/domain/member/integration/FollowIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/FollowIntegrationTest.java
@@ -232,8 +232,8 @@ public class FollowIntegrationTest {
 
             // when & then
             mockMvc.perform(get("/api/profile/{memberId}/followings", memberId)
-                            .param("pageNumber", "1")
-                            .param("pageSize", "10")
+                            .param("page", "0")
+                            .param("size", "10")
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isOk())

--- a/src/test/java/com/example/mate/domain/member/integration/FollowIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/FollowIntegrationTest.java
@@ -2,11 +2,13 @@ package com.example.mate.domain.member.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.mate.common.error.ErrorCode;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.member.entity.Follow;
 import com.example.mate.domain.member.entity.Member;
@@ -21,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
@@ -83,11 +86,11 @@ public class FollowIntegrationTest {
     }
 
     @Nested
-    @DisplayName("회원 팔로우 테스트")
+    @DisplayName("회원 팔로우")
     class FollowMember {
 
         @Test
-        @DisplayName("다른 회원 팔로우 성공")
+        @DisplayName("회원 팔로우 성공")
         void follow_member_success() throws Exception {
             // given
             Long followerId = member2.getId();
@@ -108,7 +111,7 @@ public class FollowIntegrationTest {
         }
 
         @Test
-        @DisplayName("이미 팔로우한 회원을 다시 팔로우하려는 경우 예외 발생")
+        @DisplayName("회원 팔로우 실패 -이미 팔로우한 회원을 다시 팔로우하려는 경우 예외 발생")
         void follow_member_already_followed() throws Exception {
             // given - 이미 팔로우 되어 있는 상태인 member1가 member2 팔로우 상황 가정
             Long followerId = member1.getId();
@@ -131,7 +134,7 @@ public class FollowIntegrationTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 팔로워 또는 팔로잉을 팔로우하려는 경우 예외 발생")
+        @DisplayName("회원 팔로우 실패 - 존재하지 않는 팔로워 또는 팔로잉을 팔로우하려는 경우 예외 발생")
         void follow_member_not_found() throws Exception {
             // given
             Long followerId = member1.getId() + 999L;
@@ -155,7 +158,7 @@ public class FollowIntegrationTest {
     }
 
     @Nested
-    @DisplayName("회원 언팔로우 테스트")
+    @DisplayName("회원 언팔로우")
     class UnfollowMember {
 
         @Test
@@ -177,7 +180,7 @@ public class FollowIntegrationTest {
         }
 
         @Test
-        @DisplayName("팔로우 관계가 없는 회원을 언팔로우하려는 경우 예외 발생")
+        @DisplayName("회원 언팔로우 실패 - 팔로우 관계가 없는 회원을 언팔로우하려는 경우 예외 발생")
         void unfollow_member_not_followed() throws Exception {
             // given
             Long unfollowerId = member2.getId();  // member2가 member1을 팔로우하지 않은 상태
@@ -197,7 +200,7 @@ public class FollowIntegrationTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 팔로워 또는 팔로잉을 언팔로우하려는 경우 예외 발생")
+        @DisplayName("회원 언팔로우 실패 - 존재하지 않는 팔로워 또는 팔로잉을 언팔로우하려는 경우 예외 발생")
         void unfollow_member_not_found() throws Exception {
             // given
             Long unfollowerId = 999L;  // 존재하지 않는 팔로워 ID
@@ -214,6 +217,49 @@ public class FollowIntegrationTest {
             // 팔로우 관계가 여전히 존재하는지 확인
             List<Follow> savedFollows = followRepository.findAll();
             assertThat(savedFollows).size().isEqualTo(1);  // 기존에 설정한 팔로우 관계는 삭제되지 않음
+        }
+    }
+
+    @Nested
+    @DisplayName("팔로우 리스트 페이징")
+    class FollowingPage {
+
+        @Test
+        @DisplayName("팔로우 리스트 페이징 성공")
+        void get_followings_page_success() throws Exception {
+            // given
+            Long memberId = member1.getId();
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/followings", memberId)
+                            .param("pageNumber", "1")
+                            .param("pageSize", "10")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(1))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("팔로우 리스트 페이징 실패 - 해당 회원이 없는 경우")
+        void get_followings_page_member_not_found() throws Exception {
+            // given
+            Long memberId = member1.getId() + 999L;  // 존재하지 않는 회원 ID
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/followings", memberId)
+                            .param("pageNumber", "1")
+                            .param("pageSize", "10")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andExpect(jsonPath("$.message").value(
+                            ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage()));
         }
     }
 }

--- a/src/test/java/com/example/mate/domain/member/service/FollowServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/FollowServiceTest.java
@@ -4,26 +4,39 @@ import static com.example.mate.common.error.ErrorCode.ALREADY_FOLLOWED_MEMBER;
 import static com.example.mate.common.error.ErrorCode.ALREADY_UNFOLLOWED_MEMBER;
 import static com.example.mate.common.error.ErrorCode.FOLLOWER_NOT_FOUND_BY_ID;
 import static com.example.mate.common.error.ErrorCode.UNFOLLOWER_NOT_FOUND_BY_ID;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.common.response.PageResponse;
+import com.example.mate.domain.member.dto.response.MemberSummaryResponse;
 import com.example.mate.domain.member.entity.Follow;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.FollowRepository;
 import com.example.mate.domain.member.repository.MemberRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 
 @ExtendWith(MockitoExtension.class)
 class FollowServiceTest {
@@ -69,150 +82,219 @@ class FollowServiceTest {
                 .following(following).build();
     }
 
-    @Test
-    @DisplayName("다른 회원 팔로우 성공")
-    void follow_member_success() {
-        // given
-        Long followerId = 1L;
-        Long followingId = 2L;
-        Follow follow = createTestFollow();
-
-        given(memberRepository.findById(followerId))
-                .willReturn(Optional.of(follower));
-        given(memberRepository.findById(followingId))
-                .willReturn(Optional.of(following));
-        given(followRepository.existsByFollowerIdAndFollowingId(followerId, followingId))
-                .willReturn(false);
-        given(followRepository.save(any(Follow.class)))
-                .willReturn(follow);
-
-        // when
-        followService.follow(followerId, followingId);
-
-        // then
-        verify(memberRepository, times(1)).findById(followerId);
-        verify(memberRepository, times(1)).findById(followingId);
-        verify(followRepository).existsByFollowerIdAndFollowingId(followerId, followingId);
-        verify(followRepository).save(any(Follow.class));
+    private Page<Member> createTestMemberPage() {
+        createTestMember();
+        return new PageImpl<>(List.of(follower, following));
     }
 
-    @Test
-    @DisplayName("이미 팔로우한 회원을 다시 팔로우하려는 경우 예외 발생")
-    void follow_member_already_followed() {
-        // given
-        Long followerId = 1L;
-        Long followingId = 2L;
+    @Nested
+    @DisplayName("팔로우")
+    class Following {
 
-        given(memberRepository.findById(followerId))
-                .willReturn(Optional.of(follower));
-        given(memberRepository.findById(followingId))
-                .willReturn(Optional.of(following));
-        given(followRepository.existsByFollowerIdAndFollowingId(followerId, followingId))
-                .willReturn(true); // 이미 팔로우한 상태
+        @Test
+        @DisplayName("팔로우 성공")
+        void follow_member_success() {
+            // given
+            Long followerId = 1L;
+            Long followingId = 2L;
+            Follow follow = createTestFollow();
 
-        // when & then
-        assertThatThrownBy(() -> followService.follow(followerId, followingId))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ALREADY_FOLLOWED_MEMBER);
+            given(memberRepository.findById(followerId))
+                    .willReturn(Optional.of(follower));
+            given(memberRepository.findById(followingId))
+                    .willReturn(Optional.of(following));
+            given(followRepository.existsByFollowerIdAndFollowingId(followerId, followingId))
+                    .willReturn(false);
+            given(followRepository.save(any(Follow.class)))
+                    .willReturn(follow);
 
-        verify(memberRepository, times(1)).findById(followerId);
-        verify(memberRepository, times(1)).findById(followingId);
-        verify(followRepository, never()).save(any());
+            // when
+            followService.follow(followerId, followingId);
 
+            // then
+            verify(memberRepository, times(1)).findById(followerId);
+            verify(memberRepository, times(1)).findById(followingId);
+            verify(followRepository).existsByFollowerIdAndFollowingId(followerId, followingId);
+            verify(followRepository).save(any(Follow.class));
+        }
+
+        @Test
+        @DisplayName("팔로우 실패 - 이미 팔로우한 회원을 다시 팔로우하려는 경우 예외 발생")
+        void follow_member_already_followed() {
+            // given
+            Long followerId = 1L;
+            Long followingId = 2L;
+
+            given(memberRepository.findById(followerId))
+                    .willReturn(Optional.of(follower));
+            given(memberRepository.findById(followingId))
+                    .willReturn(Optional.of(following));
+            given(followRepository.existsByFollowerIdAndFollowingId(followerId, followingId))
+                    .willReturn(true); // 이미 팔로우한 상태
+
+            // when & then
+            assertThatThrownBy(() -> followService.follow(followerId, followingId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ALREADY_FOLLOWED_MEMBER);
+
+            verify(memberRepository, times(1)).findById(followerId);
+            verify(memberRepository, times(1)).findById(followingId);
+            verify(followRepository, never()).save(any());
+
+        }
+
+        @Test
+        @DisplayName("팔로우 실패 - 존재하지 않는 팔로워 또는 팔로잉을 팔로우하려는 경우 예외 발생")
+        void follow_member_not_found() {
+            // given
+            Long followerId = 1L;
+            Long followingId = 2L;
+
+            // 팔로워가 존재하지 않는 경우
+            given(memberRepository.findById(followerId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> followService.follow(followerId, followingId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", FOLLOWER_NOT_FOUND_BY_ID);
+
+            // 팔로워 조회는 한 번 호출되었고, 팔로잉은 조회되지 않음
+            verify(memberRepository, times(1)).findById(followerId);
+            verify(memberRepository, never()).findById(followingId);
+            verify(followRepository, never()).existsByFollowerIdAndFollowingId(any(), any());
+            verify(followRepository, never()).save(any());
+        }
     }
 
-    @Test
-    @DisplayName("존재하지 않는 팔로워 또는 팔로잉을 팔로우하려는 경우 예외 발생")
-    void follow_member_not_found() {
-        // given
-        Long followerId = 1L;
-        Long followingId = 2L;
+    @Nested
+    @DisplayName("언팔로우")
+    class Unfollowing {
 
-        // 팔로워가 존재하지 않는 경우
-        given(memberRepository.findById(followerId))
-                .willReturn(Optional.empty());
+        @Test
+        @DisplayName("언팔로우 성공")
+        void unfollow_member_success() {
+            // given
+            Long unfollowerId = 1L;
+            Long unfollowingId = 2L;
+            Follow follow = createTestFollow();
 
-        // when & then
-        assertThatThrownBy(() -> followService.follow(followerId, followingId))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", FOLLOWER_NOT_FOUND_BY_ID);
+            given(memberRepository.findById(unfollowerId))
+                    .willReturn(Optional.of(follower));
+            given(memberRepository.findById(unfollowingId))
+                    .willReturn(Optional.of(following));
+            given(followRepository.existsByFollowerIdAndFollowingId(unfollowerId, unfollowingId))
+                    .willReturn(true); // 팔로우 관계가 존재
 
-        // 팔로워 조회는 한 번 호출되었고, 팔로잉은 조회되지 않음
-        verify(memberRepository, times(1)).findById(followerId);
-        verify(memberRepository, never()).findById(followingId);
-        verify(followRepository, never()).existsByFollowerIdAndFollowingId(any(), any());
-        verify(followRepository, never()).save(any());
+            // when
+            followService.unfollow(unfollowerId, unfollowingId);
+
+            // then
+            verify(memberRepository, times(1)).findById(unfollowerId);
+            verify(memberRepository, times(1)).findById(unfollowingId);
+            verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(unfollowerId, unfollowingId);
+            verify(followRepository, times(1)).deleteByFollowerIdAndFollowingId(unfollowerId, unfollowingId);
+        }
+
+        @Test
+        @DisplayName("언팔로우 실패 - 이미 언팔로우한 회원을 다시 언팔로우하려는 경우 예외 발생")
+        void unfollow_member_already_unfollowed() {
+            // given
+            Long unfollowerId = 1L;
+            Long unfollowingId = 2L;
+
+            given(memberRepository.findById(unfollowerId))
+                    .willReturn(Optional.of(follower));
+            given(memberRepository.findById(unfollowingId))
+                    .willReturn(Optional.of(following));
+            given(followRepository.existsByFollowerIdAndFollowingId(unfollowerId, unfollowingId))
+                    .willReturn(false); // 이미 언팔로우된 상태
+
+            // when & then
+            assertThatThrownBy(() -> followService.unfollow(unfollowerId, unfollowingId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ALREADY_UNFOLLOWED_MEMBER);
+
+            verify(memberRepository, times(1)).findById(unfollowerId);
+            verify(memberRepository, times(1)).findById(unfollowingId);
+            verify(followRepository, never()).deleteByFollowerIdAndFollowingId(any(), any());
+        }
+
+        @Test
+        @DisplayName("언팔로우 실패 - 존재하지 않는 언팔로워 또는 언팔로잉을 언팔로우하려는 경우 예외 발생")
+        void unfollow_member_not_found() {
+            // given
+            Long unfollowerId = 1L;
+            Long unfollowingId = 2L;
+
+            // 언팔로워가 존재하지 않는 경우
+            given(memberRepository.findById(unfollowerId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> followService.unfollow(unfollowerId, unfollowingId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", UNFOLLOWER_NOT_FOUND_BY_ID);
+
+            // 언팔로워 조회는 한 번 호출되었고, 언팔로잉은 조회되지 않음
+            verify(memberRepository, times(1)).findById(unfollowerId);
+            verify(memberRepository, never()).findById(unfollowingId);
+            verify(followRepository, never()).existsByFollowerIdAndFollowingId(any(), any());
+            verify(followRepository, never()).deleteByFollowerIdAndFollowingId(any(), any());
+        }
     }
 
-    @Test
-    @DisplayName("다른 회원 언팔로우 성공")
-    void unfollow_member_success() {
-        // given
-        Long unfollowerId = 1L;
-        Long unfollowingId = 2L;
-        Follow follow = createTestFollow();
+    @Nested
+    @DisplayName("팔로우 리스트 페이징")
+    class FollowingPage {
 
-        given(memberRepository.findById(unfollowerId))
-                .willReturn(Optional.of(follower));
-        given(memberRepository.findById(unfollowingId))
-                .willReturn(Optional.of(following));
-        given(followRepository.existsByFollowerIdAndFollowingId(unfollowerId, unfollowingId))
-                .willReturn(true); // 팔로우 관계가 존재
+        @Test
+        @DisplayName("팔로우 리스트 페이징 성공")
+        void get_followings_page_success() {
+            // given
+            Long memberId = 1L;
+            int pageNumber = 1;
+            int pageSize = 2;
 
-        // when
-        followService.unfollow(unfollowerId, unfollowingId);
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(follower));
 
-        // then
-        verify(memberRepository, times(1)).findById(unfollowerId);
-        verify(memberRepository, times(1)).findById(unfollowingId);
-        verify(followRepository, times(1)).existsByFollowerIdAndFollowingId(unfollowerId, unfollowingId);
-        verify(followRepository, times(1)).deleteByFollowerIdAndFollowingId(unfollowerId, unfollowingId);
-    }
+            Pageable pageable = PageRequest.of(pageNumber - 1, pageSize, Sort.by(Direction.DESC, "id"));
+            Page<Member> membersPage = createTestMemberPage();
 
-    @Test
-    @DisplayName("이미 언팔로우한 회원을 다시 언팔로우하려는 경우 예외 발생")
-    void unfollow_member_already_unfollowed() {
-        // given
-        Long unfollowerId = 1L;
-        Long unfollowingId = 2L;
+            given(followRepository.findFollowingsByFollowerId(eq(memberId), eq(pageable)))
+                    .willReturn(membersPage);
 
-        given(memberRepository.findById(unfollowerId))
-                .willReturn(Optional.of(follower));
-        given(memberRepository.findById(unfollowingId))
-                .willReturn(Optional.of(following));
-        given(followRepository.existsByFollowerIdAndFollowingId(unfollowerId, unfollowingId))
-                .willReturn(false); // 이미 언팔로우된 상태
+            // when
+            PageResponse<MemberSummaryResponse> response = followService.getFollowingsPage(memberId, pageNumber,
+                    pageSize);
 
-        // when & then
-        assertThatThrownBy(() -> followService.unfollow(unfollowerId, unfollowingId))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ALREADY_UNFOLLOWED_MEMBER);
+            // then
+            assertThat(response.getTotalElements()).isEqualTo(2);
+            assertThat(response.getContent()).hasSize(2);
+            assertThat(response.getContent().get(0).getNickname()).isEqualTo("tester1");
+            assertThat(response.getContent().get(1).getNickname()).isEqualTo("tester2");
 
-        verify(memberRepository, times(1)).findById(unfollowerId);
-        verify(memberRepository, times(1)).findById(unfollowingId);
-        verify(followRepository, never()).deleteByFollowerIdAndFollowingId(any(), any());
-    }
+            verify(memberRepository, times(1)).findById(memberId);
+            verify(followRepository, times(1))
+                    .findFollowingsByFollowerId(memberId, pageable);
+        }
 
-    @Test
-    @DisplayName("존재하지 않는 언팔로워 또는 언팔로잉을 언팔로우하려는 경우 예외 발생")
-    void unfollow_member_not_found() {
-        // given
-        Long unfollowerId = 1L;
-        Long unfollowingId = 2L;
+        @Test
+        @DisplayName("팔로우 리스트 페이징 실패 - 회원 없음")
+        void get_followings_page_member_not_found() {
+            // given
+            Long memberId = 999L;  // 존재하지 않는 회원 ID
+            int pageNumber = 1;
+            int pageSize = 2;
 
-        // 언팔로워가 존재하지 않는 경우
-        given(memberRepository.findById(unfollowerId))
-                .willReturn(Optional.empty());
+            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> followService.unfollow(unfollowerId, unfollowingId))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", UNFOLLOWER_NOT_FOUND_BY_ID);
+            // when & then
+            assertThatThrownBy(() -> followService.getFollowingsPage(memberId, pageNumber, pageSize))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage());
 
-        // 언팔로워 조회는 한 번 호출되었고, 언팔로잉은 조회되지 않음
-        verify(memberRepository, times(1)).findById(unfollowerId);
-        verify(memberRepository, never()).findById(unfollowingId);
-        verify(followRepository, never()).existsByFollowerIdAndFollowingId(any(), any());
-        verify(followRepository, never()).deleteByFollowerIdAndFollowingId(any(), any());
+            verify(memberRepository, times(1)).findById(memberId);
+        }
     }
 }

--- a/src/test/java/com/example/mate/domain/member/service/FollowServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/FollowServiceTest.java
@@ -253,20 +253,19 @@ class FollowServiceTest {
         void get_followings_page_success() {
             // given
             Long memberId = 1L;
-            int pageNumber = 1;
+            int pageNumber = 0;
             int pageSize = 2;
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(follower));
 
-            Pageable pageable = PageRequest.of(pageNumber - 1, pageSize, Sort.by(Direction.DESC, "id"));
+            Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Direction.DESC, "id"));
             Page<Member> membersPage = createTestMemberPage();
 
             given(followRepository.findFollowingsByFollowerId(eq(memberId), eq(pageable)))
                     .willReturn(membersPage);
 
             // when
-            PageResponse<MemberSummaryResponse> response = followService.getFollowingsPage(memberId, pageNumber,
-                    pageSize);
+            PageResponse<MemberSummaryResponse> response = followService.getFollowingsPage(memberId, pageable);
 
             // then
             assertThat(response.getTotalElements()).isEqualTo(2);
@@ -286,11 +285,12 @@ class FollowServiceTest {
             Long memberId = 999L;  // 존재하지 않는 회원 ID
             int pageNumber = 1;
             int pageSize = 2;
+            Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Direction.DESC, "id"));
 
             given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> followService.getFollowingsPage(memberId, pageNumber, pageSize))
+            assertThatThrownBy(() -> followService.getFollowingsPage(memberId, pageable))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage());
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] 팔로우 목록 조회 기능
- [x] 서비스, 컨트롤러, 통합 테스트

## 💡 자세한 설명

### 팔로우 목록 조회
- 회원의 프로필 페이지에서 팔로우를 눌렀을 때, 해당 회원이 팔로우 하고 있는 목록 페이지입니다.
- 컨트롤러에서 pageNumber, pageSize를 쿼리 파라미터로 보내지 않으면, 각각 기본값 "1페이지 / 크기10"으로 서비스 레이어로 보냅니다.
- 서비스에서는 해당 회원이 존재하는지 검증한 뒤, pageNumber와 pageSize에 대한 값 조정
    - `pageNumber = pageNumber < 1 ? 0 : pageNumber - 1;`를 통해 페이지 번호 1 감소
    - `pageSize = pageSize < 1 ? 10 : pageSize;`를 통해 페이지 크기가 0 이하일 때만 기본값 10으로 설정

### 도메인 규칙
- 노션에 "상대방의 팔로우 목록, 팔로워 목록을 확인할 수 있다." 추가


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?