### PR TITLE
MATE-50: [FEAT] 굿즈거래 판매글 페이징 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/goods/entity/GoodsPostImage.java
+++ b/src/main/java/com/example/mate/domain/goods/entity/GoodsPostImage.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +17,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "goods_post_image")
+@Table(
+        name = "goods_post_image",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        columnNames = {"post_id", "is_main_image"}
+                )
+        }
+)
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
@@ -29,8 +29,8 @@ public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long>, Goo
 
     @Query("""
             SELECT COUNT(gp)
-            FROM GoodsPost gp 
-            WHERE gp.buyer.id = :memberId 
+            FROM GoodsPost gp
+            WHERE gp.buyer.id = :memberId
             AND gp.status = :status
             """)
     int countGoodsPostsByBuyerIdAndStatus(@Param("memberId") Long memberId, @Param("status") Status status);

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long> {
+public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long>, GoodsPostRepositoryCustom {
 
     @Query("""
             SELECT gp
@@ -19,7 +19,7 @@ public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long> {
             """)
     List<GoodsPost> findMainGoodsPosts(@Param("teamId") Long teamId, @Param("status") Status status, Pageable pageable);
            
-   @Query("""
+    @Query("""
             SELECT COUNT(gp)
             FROM GoodsPost gp
             WHERE gp.seller.id = :memberId

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepositoryCustom.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.example.mate.domain.goods.repository;
+
+import com.example.mate.domain.goods.entity.Category;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface GoodsPostRepositoryCustom {
+    Page<GoodsPost> findPageGoodsPosts(Long teamId, Status status, Category category, Pageable pageable);
+}

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepositoryCustomImpl.java
@@ -28,6 +28,7 @@ public class GoodsPostRepositoryCustomImpl implements GoodsPostRepositoryCustom 
                 .selectFrom(goodsPost)
                 .join(goodsPost.goodsPostImages, goodsPostImage).fetchJoin()
                 .where(conditions)
+                .where(goodsPostImage.isMainImage.eq(true))
                 .orderBy(goodsPost.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepositoryCustomImpl.java
@@ -1,0 +1,57 @@
+package com.example.mate.domain.goods.repository;
+
+import static com.example.mate.domain.goods.entity.QGoodsPost.goodsPost;
+import static com.example.mate.domain.goods.entity.QGoodsPostImage.goodsPostImage;
+
+import com.example.mate.domain.goods.entity.Category;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.Status;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class GoodsPostRepositoryCustomImpl implements GoodsPostRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<GoodsPost> findPageGoodsPosts(Long teamId, Status status, Category category, Pageable pageable) {
+        BooleanBuilder conditions = createConditions(teamId, status, category);
+
+        List<GoodsPost> fetch = queryFactory
+                .selectFrom(goodsPost)
+                .join(goodsPost.goodsPostImages, goodsPostImage).fetchJoin()
+                .where(conditions)
+                .orderBy(goodsPost.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> total = queryFactory
+                .select(goodsPost.count())
+                .from(goodsPost)
+                .where(conditions);
+
+        return PageableExecutionUtils.getPage(fetch, pageable, total::fetchOne);
+    }
+
+    private BooleanBuilder createConditions(Long teamId, Status status, Category category) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(goodsPost.status.eq(status));
+
+        if (teamId != null) {
+            builder.and(goodsPost.teamId.eq(teamId));
+        }
+        if (category != null) {
+            builder.and(goodsPost.category.eq(category));
+        }
+        return builder;
+    }
+}

--- a/src/test/java/com/example/mate/domain/goods/service/GoodsServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goods/service/GoodsServiceTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
@@ -542,7 +541,6 @@ class GoodsServiceTest {
             // given
             Long teamId = 999L;
             Category category = Category.ACCESSORY;
-            PageImpl<GoodsPost> goodsPostPage = new PageImpl<>(List.of(goodsPost));
             PageRequest pageRequest = PageRequest.of(0, 10);
 
             // when & then

--- a/src/test/java/com/example/mate/domain/goods/service/GoodsServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goods/service/GoodsServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.goods.dto.LocationInfo;
 import com.example.mate.domain.goods.dto.request.GoodsPostRequest;
 import com.example.mate.domain.goods.dto.response.GoodsPostResponse;
@@ -31,6 +32,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -397,26 +400,155 @@ class GoodsServiceTest {
         }
 
         @Test
-        @DisplayName("메인페이지 굿즈거래 판매글 조회 실패 - 대표 이미지가 없는 경우")
-        void get_main_goods_posts_failed_with_no_main_image() {
+        @DisplayName("메인페이지 굿즈거래 판매글 조회 성공 - 대표 이미지가 없는 경우 기본 이미지를 반환")
+        void get_main_goods_posts_success_with_no_main_image() {
             // given
             Long teamId = 1L;
             List<GoodsPostImage> imagesWithoutMain = List.of(
                     GoodsPostImage.builder().imageUrl("upload/test_img_url_1").post(goodsPost).build(),
                     GoodsPostImage.builder().imageUrl("upload/test_img_url_2").post(goodsPost).build()
             );
+            // 직접 엔티티에 추가하여, 대표 사진 마설정
+            GoodsPost post = GoodsPost.builder()
+                    .id(1L)
+                    .teamId(1L)
+                    .title("test title")
+                    .category(Category.ACCESSORY)
+                    .price(10_000)
+                    .goodsPostImages(imagesWithoutMain).build();
 
-            GoodsPost post = GoodsPost.builder().goodsPostImages(imagesWithoutMain).build();
             List<GoodsPost> goodsPosts = List.of(post);
+            given(goodsPostRepository.findMainGoodsPosts(teamId, Status.OPEN, PageRequest.of(0, 4))).willReturn(
+                    goodsPosts);
 
-            given(goodsPostRepository.findMainGoodsPosts(teamId, Status.OPEN, PageRequest.of(0, 4))).willReturn(goodsPosts);
+            // when
+            List<GoodsPostSummaryResponse> responses = goodsService.getMainGoodsPosts(teamId);
+
+            // then
+            assertThat(responses).isNotEmpty();
+            assertThat(responses.size()).isEqualTo(goodsPosts.size());
+
+            GoodsPostSummaryResponse goodsPostSummaryResponse = responses.get(0);
+            assertThat(goodsPostSummaryResponse.getTitle()).isEqualTo(goodsPost.getTitle());
+            assertThat(goodsPostSummaryResponse.getPrice()).isEqualTo(goodsPost.getPrice());
+            assertThat(goodsPostSummaryResponse.getImageUrl()).isEqualTo("upload/default.jpg");
+
+            verify(goodsPostRepository).findMainGoodsPosts(1L, Status.OPEN, PageRequest.of(0, 4));
+        }
+    }
+
+    @Nested
+    @DisplayName("메인페이지 굿즈거래 판매글 페이징 조회 테스트")
+    class GoodsServiceGoodsPageTest {
+
+        private GoodsPost createGoodsPostWithoutFilters() {
+            return GoodsPost.builder()
+                    .seller(member)
+                    .teamId(10L)
+                    .title("No Filter Title")
+                    .content("No Filter Content")
+                    .price(10_000)
+                    .category(Category.UNIFORM)
+                    .location(LocationInfo.toEntity(createLocationInfo()))
+                    .build();
+        }
+
+        private GoodsPost createGoodsPostWithFilters() {
+            return GoodsPost.builder()
+                    .seller(member)
+                    .teamId(1L)
+                    .title("Filtered Title")
+                    .content("Filtered Content")
+                    .price(20_000)
+                    .category(Category.ACCESSORY)
+                    .location(LocationInfo.toEntity(createLocationInfo()))
+                    .build();
+        }
+
+        @Test
+        @DisplayName("메인페이지 굿즈거래 판매글 페이징 조회 성공 - 필터 비활성화")
+        void get_page_goods_posts_no_filters() {
+            // given
+            Long teamId = null;         // 팀 필터 비활성화
+            Category category = null;   // 카테고리 필터 비활성화
+            GoodsPost postWithoutFilters = createGoodsPostWithoutFilters();
+            GoodsPostImage image = GoodsPostImage.builder()
+                    .imageUrl("upload/test_img_url")
+                    .post(postWithoutFilters)
+                    .build();
+            postWithoutFilters.changeImages(List.of(image));
+
+            PageImpl<GoodsPost> goodsPostPage = new PageImpl<>(List.of(postWithoutFilters));
+            PageRequest pageRequest = PageRequest.of(0, 10);
+
+            given(goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest)).willReturn(goodsPostPage);
+
+            // when
+            PageResponse<GoodsPostSummaryResponse> pageGoodsPosts = goodsService.getPageGoodsPosts(teamId, null, pageRequest);
+
+            // then
+            assertThat(pageGoodsPosts).isNotNull();
+            assertThat(pageGoodsPosts.getContent()).isNotEmpty();
+            assertThat(pageGoodsPosts.getTotalElements()).isEqualTo(goodsPostPage.getTotalElements());
+            assertThat(pageGoodsPosts.getContent().size()).isEqualTo(goodsPostPage.getContent().size());
+
+            GoodsPostSummaryResponse summary = pageGoodsPosts.getContent().get(0);
+            assertThat(summary.getTitle()).isEqualTo(postWithoutFilters.getTitle());
+            assertThat(summary.getPrice()).isEqualTo(postWithoutFilters.getPrice());
+            assertThat(summary.getImageUrl()).isEqualTo(image.getImageUrl());
+
+            verify(goodsPostRepository).findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest);
+        }
+
+        @Test
+        @DisplayName("메인페이지 굿즈거래 판매글 페이징 조회 성공 - 필터 활성화")
+        void get_page_goods_posts_all_filters() {
+            // given
+            Long teamId = 1L;
+            Category category = Category.ACCESSORY;
+            GoodsPost postWithFilters = createGoodsPostWithFilters();
+            GoodsPostImage image = GoodsPostImage.builder()
+                    .imageUrl("upload/test_img_url")
+                    .post(postWithFilters)
+                    .build();
+            postWithFilters.changeImages(List.of(image));
+
+            PageImpl<GoodsPost> goodsPostPage = new PageImpl<>(List.of(postWithFilters));
+            PageRequest pageRequest = PageRequest.of(0, 10);
+
+            given(goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest)).willReturn(goodsPostPage);
+
+            // when
+            PageResponse<GoodsPostSummaryResponse> pageGoodsPosts
+                    = goodsService.getPageGoodsPosts(teamId, category.getValue(), pageRequest);
+
+            // then
+            assertThat(pageGoodsPosts).isNotNull();
+            assertThat(pageGoodsPosts.getContent()).isNotEmpty();
+            assertThat(pageGoodsPosts.getTotalElements()).isEqualTo(goodsPostPage.getTotalElements());
+            assertThat(pageGoodsPosts.getContent().size()).isEqualTo(goodsPostPage.getContent().size());
+
+            GoodsPostSummaryResponse summary = pageGoodsPosts.getContent().get(0);
+            assertThat(summary.getTitle()).isEqualTo(postWithFilters.getTitle());
+            assertThat(summary.getPrice()).isEqualTo(postWithFilters.getPrice());
+            assertThat(summary.getImageUrl()).isEqualTo(image.getImageUrl());
+
+            verify(goodsPostRepository).findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest);
+        }
+
+        @Test
+        @DisplayName("메인페이지 굿즈거래 판매글 페이징 조회 성공 - 유효하지 않은 팀 정보")
+        void get_page_goods_posts_team_filter_only() {
+            // given
+            Long teamId = 999L;
+            Category category = Category.ACCESSORY;
+            PageImpl<GoodsPost> goodsPostPage = new PageImpl<>(List.of(goodsPost));
+            PageRequest pageRequest = PageRequest.of(0, 10);
 
             // when & then
-            assertThatThrownBy(() -> goodsService.getMainGoodsPosts(teamId))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ErrorCode.GOODS_MAIN_IMAGE_IS_EMPTY.getMessage());
-
-            verify(goodsPostRepository).findMainGoodsPosts(teamId, Status.OPEN, PageRequest.of(0, 4));
+            assertThatThrownBy(() -> goodsService.getPageGoodsPosts(teamId, category.getValue(), pageRequest))
+                    .isExactlyInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.TEAM_NOT_FOUND.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 판매글 페이징 조회 기능 구현
- [x] 굿즈거래 판매글 페이징 조회 기능 테스트 코드 작성

## 💡 자세한 설명

### 굿즈거래 판매글 페이징 조회 `GET ` api/goods?teamId=&category=

<img width="383" alt="image" src="https://github.com/user-attachments/assets/614671d0-48df-4724-8346-a7862da4b8c2">

-  특정 조건에 따라 거래중인 판매글을 `최근 작성된 날짜`순으로 페이징 처리하여 조회합니다.
- `teamId`, `category` 요청이 없으면 `null` 값으로 처리하여 동적 조회 기능을 구현했습니다.
  - ex) `teamId`가 `null`이면 모든 팀의 게시글 조회, `category`가 `null`이면 모든 카테고리의 게시글 조회 
- `page`, `size` 의 디폴트 값은 각각 0, 10 으로 설정했습니다.

<br>

### 대표사진 조회 로직 & 굿즈 판매글 이미지 제약조건 추가

- `GoodsPost`를 저장 및 수정할 때, `GoodsPostImage`의 저장과 대표사진 설정(`is_main_image`)이 보장됩니다.
-  따라서 판매글 조회 시 대표 사진이 없거나 이미지 리스트가 비어 있는 경우를 처리하지 않고, 대표 사진이 없는 경우에만 기본 사진 url을 반환하였습니다.
```java
private String getMainImageUrl(GoodsPost goodsPost) {
    return goodsPost.getGoodsPostImages().stream()
            .filter(GoodsPostImage::getIsMainImage)
            .findFirst()
            .map(GoodsPostImage::getImageUrl)
            .orElse("upload/default.jpg");
}
```
- `GoodsPostImage` 엔티티에 `postId`, `is_main_image` 컬럼의 조합에 대한 유니크 제약 조건을 추가했습니다.

<br>

### 동적 쿼리 구현
- `QueryDsl` 기술을 사용해서 구현했습니다.
- `fetchJoin`을 사용하여 연관된 `goodsPostImages`를 함께 로드해 N+1 문제를 방지했습니다.
- `PageableExecutionUtils.getPage`를 사용해 효율적으로 총 개수를 계산하도록 구현했습니다.

#### `PageableExecutionUtils.getPage()`
일반적으로 페이징 처리를 할 때, 데이터의 일부를 가져오는 `SELECT` 쿼리와 전체 데이터의 개수를 계산하는 `COUNT` 쿼리를 두 번 실행해야 하지만, `PageableExecutionUtils.getPage`는 `COUNT` 쿼리를 무조건 실행하지 않고, 필요할 때만 실행합니다.

예를 들어, 조회된 데이터의 크기가 `Pageable`에서 요청한 `Page Size`보다 작으면 더 이상 데이터가 없다는 것을 알 수 있는데, `PageableExecutionUtils.getPage` 를 사용하면 이러한 경우 `COUNT` 쿼리를 실행하지 않고, 조회된 데이터(`content`)의 갯수를 데이터의 개수로 계산합니다.

<br>

### 도메인 규칙
<img width="496" alt="image" src="https://github.com/user-attachments/assets/90cd543f-b4ab-4eeb-8d2a-257cabeb4452">
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8b56ef62-b284-44e8-a9c5-5272f6b26004">

<br>

### 📄 Hibernate Fetch Join 오류 트러블슈팅
> 노션 작성 완료

## 📗 참고 자료 (선택)
[PageableExecutionUtils - 1](https://junior-datalist.tistory.com/342)
[PageableExecutionUtils - 2](https://code-list.tistory.com/102)

## 📢 리뷰 요구 사항 (선택)
제가 `QueryDsl` 을 사용하는 것이 미숙해서 동적 쿼리에 대한 부분에 중점적으로 리뷰해주셨으면 좋겠습니다!

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?