### PR TITLE
MATE-34 : [FEAT] 특정 회원의 팔로워 목록 페이징 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/member/controller/FollowController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/FollowController.java
@@ -7,7 +7,6 @@ import com.example.mate.domain.member.service.FollowService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -53,7 +52,7 @@ public class FollowController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "특정 회원이 팔로우하는 회원 리스트 페이징 조회")
+    @Operation(summary = "특정 회원의 팔로우 회원 리스트 페이징 조회")
     @GetMapping("{memberId}/followings")
     public ResponseEntity<ApiResponse<PageResponse<MemberSummaryResponse>>> getFollowings(
             @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
@@ -64,22 +63,16 @@ public class FollowController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /*
-    TODO : 2024/11/25 - 특정 사용자를 팔로우하는 회원들 페이징 조회
-    1. memberId 을 통해 회원 정보 조회
-    2. 회원을 팔로우하는 회원 정보 조회
-    3. 페이징 처리 후 반환
-    */
+    @Operation(summary = "특정 회원의 팔로워 회원 리스트 페이징 조회")
     @GetMapping("{memberId}/followers")
-    public ResponseEntity<Page<MemberSummaryResponse>> getFollowers(
-            @PathVariable Long memberId,
+    public ResponseEntity<ApiResponse<PageResponse<MemberSummaryResponse>>> getFollowers(
+            @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
             @PageableDefault(size = 10) Pageable pageable
     ) {
-//        MemberSummaryResponse response = MemberSummaryResponse.from();
-//        List<MemberSummaryResponse> responses = Collections.nCopies(10, response);
-//        Page<MemberSummaryResponse> page = new PageImpl<>(responses, pageable, responses.size());
+        pageable = validatePageable(pageable);
+        PageResponse<MemberSummaryResponse> response = followService.getFollowersPage(memberId, pageable);
 
-        return ResponseEntity.ok(null);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // Pageable 검증 메서드

--- a/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
+++ b/src/main/java/com/example/mate/domain/member/repository/FollowRepository.java
@@ -27,4 +27,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     // 특정 회원의 팔로잉 리스트
     @Query("SELECT f.following FROM Follow f WHERE f.follower.id = :followerId ORDER BY f.id DESC ")
     Page<Member> findFollowingsByFollowerId(@Param("followerId") Long followerId, Pageable pageable);
+
+    // 특정 회원의 팔로워 리스트
+    @Query("SELECT f.follower FROM Follow f WHERE f.following.id = :followingId ORDER BY f.id DESC ")
+    Page<Member> findFollowersByFollowingId(@Param("followingId") Long followingId, Pageable pageable);
 }

--- a/src/main/java/com/example/mate/domain/member/service/FollowService.java
+++ b/src/main/java/com/example/mate/domain/member/service/FollowService.java
@@ -66,6 +66,28 @@ public class FollowService {
                 .build();
     }
 
+    // 특정 회원의 팔로워 리스트 페이징 조회
+    public PageResponse<MemberSummaryResponse> getFollowersPage(Long memberId, Pageable pageable) {
+        findByMemberId(memberId);
+
+        // 해당 회원이 팔로우하는 리스트 최신 팔로우 순으로 페이징
+        Page<Member> followingsPage = followRepository.findFollowersByFollowingId(memberId, pageable);
+
+        // MemberSummaryResponse 변환
+        List<MemberSummaryResponse> content = followingsPage.getContent().stream()
+                .map(MemberSummaryResponse::from)
+                .toList();
+
+        return PageResponse.<MemberSummaryResponse>builder()
+                .content(content)
+                .totalPages(followingsPage.getTotalPages())
+                .totalElements(followingsPage.getTotalElements())
+                .hasNext(followingsPage.hasNext())
+                .pageNumber(followingsPage.getNumber())
+                .pageSize(followingsPage.getSize())
+                .build();
+    }
+
     private Map<String, Member> isValidMemberFollow(Long followerId, Long followingId) {
         Member follower = memberRepository.findById(followerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.FOLLOWER_NOT_FOUND_BY_ID));

--- a/src/test/java/com/example/mate/domain/member/integration/FollowIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/FollowIntegrationTest.java
@@ -262,4 +262,48 @@ public class FollowIntegrationTest {
                             ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage()));
         }
     }
+
+    @Nested
+    @DisplayName("팔로워 리스트 페이징")
+    class FollowerPage {
+
+        @Test
+        @DisplayName("팔로워 리스트 페이징 성공")
+        void get_followers_page_success() throws Exception {
+            // given
+            Long memberId = member2.getId(); // member2의 팔로워 목록 조회
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/followers", memberId)
+                            .param("page", "0")
+                            .param("size", "10")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(1)) // member1이 팔로워로 존재
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("팔로워 리스트 페이징 실패 - 해당 회원이 없는 경우")
+        void get_followers_page_member_not_found() throws Exception {
+            // given
+            Long memberId = member2.getId() + 999L;  // 존재하지 않는 회원 ID
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/followers", memberId)
+                            .param("page", "0")
+                            .param("size", "10")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andExpect(jsonPath("$.message").value(
+                            ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage()));
+        }
+    }
+
 }

--- a/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
@@ -38,6 +38,7 @@ import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.FollowRepository;
 import com.example.mate.domain.member.repository.MemberRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -90,6 +91,9 @@ class MemberIntegrationTest {
 
     @Autowired
     private VisitPartRepository visitPartRepository;
+
+    @Autowired
+    private EntityManager entityManager;
 
     private Member member;
     private Member member2;
@@ -218,8 +222,10 @@ class MemberIntegrationTest {
                     .member(member)
                     .visit(visit)
                     .build();
-            visit.getParticipants().add(visitPart);
             visitPartRepository.save(visitPart);
+
+            // 1차 캐시에서 분리
+            entityManager.detach(visitPart);
         });
         return visit;
     }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 팔로워 목록 조회 기능
- [x] 서비스, 컨트롤러, 통합 테스트

## 💡 자세한 설명

### 팔로워 목록 조회
- 회원의 프로필 페이지에서 팔로워를 눌렀을 때, 해당 회원을 팔로우 하고 있는 목록 페이지입니다.
- 페이지 파라미터를 `Pageable pageable` 객체를 사용했고, 기본 사이즈 10, 기본 페이지 번호 0으로 설정했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?