### PR TITLE
MATE-64 : [FEAT] 메이트 게시글 조회 응답 DTO 필드 추가

### DIFF
--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -54,7 +54,7 @@ public class MateController {
                                                                                                @RequestParam(required = false) String gender,
                                                                                                @RequestParam(required = false) Integer maxParticipants,
                                                                                                @RequestParam(required = false) String transportType,
-                                                                                               @PageableDefault(size = 10) Pageable pageable) {
+                                                                                               @PageableDefault Pageable pageable) {
 
         MatePostSearchRequest request = MatePostSearchRequest.builder()
                 .teamId(teamId)

--- a/src/main/java/com/example/mate/domain/mate/dto/response/MatePostSummaryResponse.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/response/MatePostSummaryResponse.java
@@ -19,6 +19,7 @@ public class MatePostSummaryResponse {
     private String imageUrl;
     private String title;
     private Status status;
+    private String myTeamName;
     private String rivalTeamName;
     private LocalDateTime rivalMatchTime;
     private String location;
@@ -27,14 +28,29 @@ public class MatePostSummaryResponse {
     private Gender gender;
     private TransportType transportType;
 
-    public static MatePostSummaryResponse from(MatePost post) {
+    public static MatePostSummaryResponse from(MatePost post, Long selectedTeamId) {
+        Match match = post.getMatch();
+        String myTeamName;
+        String rivalTeamName;
+
+        if (selectedTeamId != null) {
+            // 특정 팀 선택한 경우: 게시글 작성자의 팀이 myTeam
+            myTeamName = TeamInfo.getById(post.getTeamId()).shortName;
+            rivalTeamName = getRivalTeamName(post);
+        } else {
+            // KBO 선택한 경우: 홈팀이 myTeam
+            myTeamName = TeamInfo.getById(match.getHomeTeamId()).shortName;
+            rivalTeamName = TeamInfo.getById(match.getAwayTeamId()).shortName;
+        }
+
         return MatePostSummaryResponse.builder()
                 .imageUrl(post.getImageUrl())
                 .title(post.getTitle())
                 .status(post.getStatus())
-                .rivalTeamName(getRivalTeamName(post))
-                .rivalMatchTime(post.getMatch().getMatchTime())
-                .location(post.getMatch().getStadium().name)
+                .myTeamName(myTeamName)
+                .rivalTeamName(rivalTeamName)
+                .rivalMatchTime(match.getMatchTime())
+                .location(match.getStadium().name)
                 .maxParticipants(post.getMaxParticipants())
                 .age(post.getAge())
                 .gender(post.getGender())
@@ -44,14 +60,11 @@ public class MatePostSummaryResponse {
 
     private static String getRivalTeamName(MatePost post) {
         Match match = post.getMatch();
-        Long postTeamId = post.getTeamId(); // 게시글 작성자가 선택한 팀
+        Long postTeamId = post.getTeamId();
 
-        // 게시글 작성자가 선택한 팀이 홈팀인 경우 원정팀이 상대팀
         if (postTeamId.equals(match.getHomeTeamId())) {
             return TeamInfo.getById(match.getAwayTeamId()).shortName;
-        }
-        // 게시글 작성자가 선택한 팀이 원정팀인 경우 홈팀이 상대팀
-        else {
+        } else {
             return TeamInfo.getById(match.getHomeTeamId()).shortName;
         }
     }

--- a/src/main/java/com/example/mate/domain/mate/dto/response/MatePostSummaryResponse.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/response/MatePostSummaryResponse.java
@@ -21,27 +21,17 @@ public class MatePostSummaryResponse {
     private Status status;
     private String myTeamName;
     private String rivalTeamName;
-    private LocalDateTime rivalMatchTime;
+    private LocalDateTime matchTime;
     private String location;
     private Integer maxParticipants;
     private Age age;
     private Gender gender;
     private TransportType transportType;
 
-    public static MatePostSummaryResponse from(MatePost post, Long selectedTeamId) {
-        Match match = post.getMatch();
-        String myTeamName;
-        String rivalTeamName;
-
-        if (selectedTeamId != null) {
-            // 특정 팀 선택한 경우: 게시글 작성자의 팀이 myTeam
-            myTeamName = TeamInfo.getById(post.getTeamId()).shortName;
-            rivalTeamName = getRivalTeamName(post);
-        } else {
-            // KBO 선택한 경우: 홈팀이 myTeam
-            myTeamName = TeamInfo.getById(match.getHomeTeamId()).shortName;
-            rivalTeamName = TeamInfo.getById(match.getAwayTeamId()).shortName;
-        }
+    public static MatePostSummaryResponse from(MatePost post) {
+        // 게시글 작성자의 팀이 myTeam
+        String myTeamName = TeamInfo.getById(post.getTeamId()).shortName;
+        String rivalTeamName = getRivalTeamName(post);
 
         return MatePostSummaryResponse.builder()
                 .imageUrl(post.getImageUrl())
@@ -49,8 +39,8 @@ public class MatePostSummaryResponse {
                 .status(post.getStatus())
                 .myTeamName(myTeamName)
                 .rivalTeamName(rivalTeamName)
-                .rivalMatchTime(match.getMatchTime())
-                .location(match.getStadium().name)
+                .matchTime(post.getMatch().getMatchTime())
+                .location(post.getMatch().getStadium().name)
                 .maxParticipants(post.getMaxParticipants())
                 .age(post.getAge())
                 .gender(post.getGender())

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -28,7 +28,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.example.mate.common.error.ErrorCode.*;
 
@@ -86,8 +85,8 @@ public class MateService {
                 PageRequest.of(0, 3));
 
         return mainPagePosts.stream()
-                .map(MatePostSummaryResponse::from)
-                .collect(Collectors.toList());
+                .map(post -> MatePostSummaryResponse.from(post, teamId))
+                .toList();
     }
 
     public PageResponse<MatePostSummaryResponse> getMatePagePosts(MatePostSearchRequest request, Pageable pageable) {
@@ -98,7 +97,7 @@ public class MateService {
         Page<MatePost> matePostPage = mateRepository.findMatePostsByFilter(request ,pageable);
 
         List<MatePostSummaryResponse> content = matePostPage.getContent().stream()
-                .map(MatePostSummaryResponse::from)
+                .map(post -> MatePostSummaryResponse.from(post, request.getTeamId()))
                 .toList();
 
         return PageResponse.<MatePostSummaryResponse>builder()

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -85,7 +85,7 @@ public class MateService {
                 PageRequest.of(0, 3));
 
         return mainPagePosts.stream()
-                .map(post -> MatePostSummaryResponse.from(post, teamId))
+                .map(MatePostSummaryResponse::from)
                 .toList();
     }
 
@@ -97,7 +97,7 @@ public class MateService {
         Page<MatePost> matePostPage = mateRepository.findMatePostsByFilter(request ,pageable);
 
         List<MatePostSummaryResponse> content = matePostPage.getContent().stream()
-                .map(post -> MatePostSummaryResponse.from(post, request.getTeamId()))
+                .map(MatePostSummaryResponse::from)
                 .toList();
 
         return PageResponse.<MatePostSummaryResponse>builder()

--- a/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
+++ b/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
@@ -59,7 +59,7 @@ class MateControllerTest {
                 .title("테스트 제목")
                 .status(Status.OPEN)
                 .rivalTeamName("두산")
-                .rivalMatchTime(LocalDateTime.now().plusDays(1))
+                .matchTime(LocalDateTime.now().plusDays(1))
                 .location("잠실야구장")
                 .maxParticipants(4)
                 .age(Age.TWENTIES)


### PR DESCRIPTION
## 💡 작업 내용

- [x] 메이트 게시글 조회 응답 DTO에 myTeamName 필드 추가

## 💡 자세한 설명
### 최종 구현
메이트 게시글 조회 시
myTeamName은 사용자가 선택한 팀, rivalTeamName은 반대팀

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
사용자가 KBO를 선택한 경우에는 홈팀이 동그라미 친 부분으로 표시되게 구현했는데 어떻게 생각하시나요?
동인님이 주체팀 정보를 넣는다고 디스코드에 말씀하셔서 이렇게 구현해봤습니다. 만약 게시글의 마이팀이 원정팀인 경우라면, 제목에 ~ 원정 가요 를 넣으면 구분이 가겠네요
![image](https://github.com/user-attachments/assets/2e4a68d4-51ee-4428-93e5-18f72efcbd32)



### 다시 생각해보니까 KBO를 선택한 경우에도 메이트 게시물 작성자가 응원팀으로 선택한 팀이 동그라미 부분으로 들어가야할거같네요..
## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?