### PR TITLE
MATE-51: [FEAT] 굿즈거래 판매글 판매완료 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -60,6 +60,8 @@ public enum ErrorCode {
     GOODS_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "G003", "판매글의 판매자가 아니라면, 판매글을 수정할 수 없습니다."),
     GOODS_MAIN_IMAGE_IS_EMPTY(HttpStatus.NOT_FOUND, "G004", "굿즈 게시물의 대표사진을 찾을 수 없습니다."),
     GOODS_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "G005", "거래완료 상태에서 판매글을 삭제할 수 없습니다."),
+    GOODS_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "G006", "이미 거래완료 상태인 굿즈는 거래를 완료할 수 없습니다."),
+    SELLER_CANNOT_BE_BUYER(HttpStatus.BAD_REQUEST, "G007", "판매자와 구매자는 동일할 수 없습니다."),
 
     // FILE
     FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "F001", "빈 파일을 업로드할 수 없습니다. 파일 내용을 확인해주세요."),

--- a/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
+++ b/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
@@ -105,10 +105,18 @@ public class GoodsController {
         return ResponseEntity.ok(ApiResponse.success(pageGoodsPosts));
     }
 
-    // 굿즈 채팅창 - 알럿창 : 굿즈 거래 완료
-    @PostMapping("/{goodsPostId}/complete")
-    public ResponseEntity<Void> completeGoodsPost(@PathVariable Long goodsPostId) {
-        return ResponseEntity.ok().build();
+    /*
+    굿즈 채팅창 - 알럿창 : 굿즈 거래 완료
+    TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
+    */
+    @PostMapping("{sellerId}/{goodsPostId}/complete")
+    public ResponseEntity<ApiResponse<Void>> completeGoodsPost(
+            @PathVariable Long sellerId,
+            @PathVariable Long goodsPostId,
+            @RequestParam Long buyerId
+    ) {
+        goodsService.completeTransaction(sellerId, goodsPostId, buyerId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     // 굿즈 거래후기 : 굿즈 거래후기 페이지 조회

--- a/src/main/java/com/example/mate/domain/goods/entity/GoodsPost.java
+++ b/src/main/java/com/example/mate/domain/goods/entity/GoodsPost.java
@@ -53,11 +53,11 @@ public class GoodsPost extends BaseTimeEntity {
     private Long teamId;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderBy("id ASC")
+    @OrderBy("isMainImage DESC, id ASC")
     @Builder.Default
     private List<GoodsPostImage> goodsPostImages = new ArrayList<>();
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 100)
     private String title;
 
     @Column(nullable = false, length = 500)
@@ -95,12 +95,20 @@ public class GoodsPost extends BaseTimeEntity {
     }
 
     // 굿즈 판매글 수정 메서드
-    public void update(GoodsPost post) {
+    public void updatePostDetails(GoodsPost post, List<GoodsPostImage> goodsPostImages) {
         this.teamId = post.getTeamId();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.price = post.getPrice();
         this.category = post.getCategory();
         this.location = post.getLocation();
+
+        changeImages(goodsPostImages);
+    }
+
+    // 거래 완료 메서드
+    public void completeTransaction(Member buyer) {
+        this.buyer = buyer;
+        this.status = Status.CLOSED;
     }
 }

--- a/src/test/java/com/example/mate/domain/goods/controller/GoodsControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goods/controller/GoodsControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -266,5 +267,26 @@ class GoodsControllerTest {
                 .andExpect(jsonPath("$.code").value(200));
 
         verify(goodsService).getPageGoodsPosts(teamId, categoryVal, pageRequest);
+    }
+
+    @Test
+    @DisplayName("굿즈 판매글 거래 완료 - API 테스트")
+    void complete_goods_post_success() throws Exception {
+        // given
+        Long memberId = 1L;
+        Long goodsPostId = 1L;
+        Long buyerId = 2L;
+
+        willDoNothing().given(goodsService).completeTransaction(memberId, goodsPostId, buyerId);
+
+        // when & then
+        mockMvc.perform(post("/api/goods/{memberId}/{goodsPostId}/complete", memberId, goodsPostId)
+                        .param("buyerId", String.valueOf(buyerId)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(goodsService).completeTransaction(memberId, goodsPostId, buyerId);
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 판매글 판매완료 기능 구현
- [x] 테스트 코드 작성
- [x] 도메인 규칙 작성

## 💡 자세한 설명
<img width="502" alt="image" src="https://github.com/user-attachments/assets/5b649d71-ae8b-4376-93e4-37c3f7d34c08">

### `POST api/goods/{sellerId}/{goodsPostId}/complete`
- 채팅방에서 판매자가 거래완료 버튼을 누르면 `판매글 id, 판매자 id, 구매자 id` 를 통해 거래완료 요청을 하게 됩니다.
- 서버에서 유효성 검사를 마친 후, 판매글의 상태를 `거래완료` 로 바꾸고, 구매자를 판매글에 등록합니다.
  - 판매글의 구매자 정보는 추후 프로필 페이지에서 `구매기록`을 조회하기 위함입니다.
- 이미 거래완료된 상태, 구매자와 판매자가 같을 경우 예외 처리를 추가했습니다.  

### 도메인 규칙
<img width="647" alt="image" src="https://github.com/user-attachments/assets/86face39-1699-4a20-9860-349801a47e8d">

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?