### PR TITLE
MATE-31 : [FEAT] 직관 후기 작성 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -89,8 +89,10 @@ public enum ErrorCode {
     INVALID_SORT_TYPE_VALUE(HttpStatus.BAD_REQUEST, "ST001", "유효하지 않은 정렬 기준 값입니다."),
 
     // Status
-    INVALID_STATUS_TYPE_VALUE(HttpStatus.BAD_REQUEST, "STATUS001", "유효하지 않은 모집 상태 값입니다.");
+    INVALID_STATUS_TYPE_VALUE(HttpStatus.BAD_REQUEST, "STATUS001", "유효하지 않은 모집 상태 값입니다."),
 
+    // Rating
+    INVALID_RATING_VALUE(HttpStatus.BAD_REQUEST, "Rating001", "유효하지 않은 리뷰 평가 값입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -61,6 +61,12 @@ public enum ErrorCode {
     GOODS_MAIN_IMAGE_IS_EMPTY(HttpStatus.NOT_FOUND, "G004", "굿즈 게시물의 대표사진을 찾을 수 없습니다."),
     GOODS_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "G005", "거래완료 상태에서 판매글을 삭제할 수 없습니다."),
 
+
+    // REVIEW
+    NOT_PARTICIPANT_OR_AUTHOR(HttpStatus.FORBIDDEN, "R002", "리뷰어와 리뷰 대상자 모두 직관 참여자여야 합니다."),
+    SELF_REVIEW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "R004", "자기 자신에 대한 리뷰는 작성할 수 없습니다."),
+    REVIEW_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "R005", "해당 ID의 리뷰를 찾을 수 없습니다."),
+
     // FILE
     FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "F001", "빈 파일을 업로드할 수 없습니다. 파일 내용을 확인해주세요."),
     FILE_UNSUPPORTED_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "F002", "지원하지 않는 파일 형식입니다."),

--- a/src/main/java/com/example/mate/domain/constant/Rating.java
+++ b/src/main/java/com/example/mate/domain/constant/Rating.java
@@ -25,6 +25,6 @@ public enum Rating {
             if (rate.value.equals(value))
                 return rate;
         }
-        throw new CustomException(ErrorCode.INVALID_AGE_VALUE);
+        throw new CustomException(ErrorCode.INVALID_RATING_VALUE);
     }
 }

--- a/src/main/java/com/example/mate/domain/constant/Rating.java
+++ b/src/main/java/com/example/mate/domain/constant/Rating.java
@@ -1,5 +1,9 @@
 package com.example.mate.domain.constant;
 
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 @Getter
@@ -8,9 +12,19 @@ public enum Rating {
     GOOD("좋아요!"),
     GREAT("최고예요!");
 
+    @JsonValue
     private final String value;
 
     Rating(String value) {
         this.value = value;
+    }
+
+    @JsonCreator
+    public static Rating from(String value) {
+        for (Rating rate : Rating.values()) {
+            if (rate.value.equals(value))
+                return rate;
+        }
+        throw new CustomException(ErrorCode.INVALID_AGE_VALUE);
     }
 }

--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -15,8 +15,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -107,13 +105,16 @@ public class MateController {
         return ResponseEntity.noContent().build();
     }
 
+    // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
     // 직관 후기 작성
-    @PostMapping("/{postId}/reviews")
-    public ResponseEntity<MateReviewCreateResponse> createMateReview(
+    @PostMapping("/{memberId}/{postId}/reviews")
+    public ResponseEntity<ApiResponse<MateReviewCreateResponse>> createMateReview(
+            @PathVariable Long memberId,
             @PathVariable Long postId,
-            @AuthenticationPrincipal UserDetails userDetails,
-            @RequestBody MateReviewRequest request
+            @RequestBody MateReviewCreateRequest request
     ) {
-        return ResponseEntity.ok(MateReviewCreateResponse.builder().id(1L).build());
+
+        MateReviewCreateResponse response = mateService.createReview(postId, memberId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -111,7 +111,7 @@ public class MateController {
     public ResponseEntity<ApiResponse<MateReviewCreateResponse>> createMateReview(
             @PathVariable Long memberId,
             @PathVariable Long postId,
-            @RequestBody MateReviewCreateRequest request
+            @Valid @RequestBody MateReviewCreateRequest request
     ) {
 
         MateReviewCreateResponse response = mateService.createReview(postId, memberId, request);

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MateReviewCreateRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MateReviewCreateRequest.java
@@ -1,0 +1,26 @@
+package com.example.mate.domain.mate.dto.request;
+
+import com.example.mate.common.utils.validator.ValidEnum;
+import com.example.mate.domain.constant.Rating;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MateReviewCreateRequest {
+
+    @NotNull(message = "리뷰 대상자 ID는 필수입니다.")
+    private Long revieweeId;
+
+    @ValidEnum(message = "유효하지 않은 평가입니다.", enumClass = Rating.class)
+    private Rating rating;
+
+    @Size(max = 100, message = "리뷰 내용은 100자를 초과할 수 없습니다.")
+    private String content;
+}

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MateReviewRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MateReviewRequest.java
@@ -1,9 +1,0 @@
-package com.example.mate.domain.mate.dto.request;
-
-import com.example.mate.domain.constant.Rating;
-
-public class MateReviewRequest {
-    private Long revieweeId;
-    private Rating rating;
-    private String content;
-}

--- a/src/main/java/com/example/mate/domain/mate/dto/response/MateReviewCreateResponse.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/response/MateReviewCreateResponse.java
@@ -1,10 +1,27 @@
 package com.example.mate.domain.mate.dto.response;
 
+import com.example.mate.domain.mate.entity.MateReview;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class MateReviewCreateResponse {
-    private Long id;
+    private Long reviewId;
+    private Long reviewerId;
+    private Long revieweeId;
+    private String revieweeName;
+    private String content;
+    private String rating;
+
+    public static MateReviewCreateResponse from(MateReview review) {
+        return MateReviewCreateResponse.builder()
+                .reviewId(review.getId())
+                .reviewerId(review.getReviewer().getId())
+                .revieweeId(review.getReviewee().getId())
+                .revieweeName(review.getReviewee().getName())
+                .content(review.getReviewContent())
+                .rating(review.getRating().getValue())
+                .build();
+    }
 }

--- a/src/main/java/com/example/mate/domain/mate/dto/response/MateReviewCreateResponse.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/response/MateReviewCreateResponse.java
@@ -10,7 +10,7 @@ public class MateReviewCreateResponse {
     private Long reviewId;
     private Long reviewerId;
     private Long revieweeId;
-    private String revieweeName;
+    private String revieweeNickName;
     private String content;
     private String rating;
 
@@ -19,7 +19,7 @@ public class MateReviewCreateResponse {
                 .reviewId(review.getId())
                 .reviewerId(review.getReviewer().getId())
                 .revieweeId(review.getReviewee().getId())
-                .revieweeName(review.getReviewee().getName())
+                .revieweeNickName(review.getReviewee().getNickname())
                 .content(review.getReviewContent())
                 .rating(review.getRating().getValue())
                 .build();

--- a/src/main/java/com/example/mate/domain/mate/entity/Age.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/Age.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 public enum Age {
-    ALL("상관 없음"),
+    ALL("상관없음"),
     TEENS("10대"),
     TWENTIES("20대"),
     THIRTIES("30대"),

--- a/src/main/java/com/example/mate/domain/mate/entity/MateReview.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/MateReview.java
@@ -1,11 +1,10 @@
 package com.example.mate.domain.mate.entity;
 
-import com.example.mate.domain.member.entity.Member;
+import com.example.mate.common.BaseTimeEntity;
 import com.example.mate.domain.constant.Rating;
+import com.example.mate.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "mate_review")
@@ -13,7 +12,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class MateReview {
+public class MateReview extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -37,15 +36,5 @@ public class MateReview {
     @Enumerated(EnumType.STRING)
     @Column(name = "rating", nullable = false)
     private Rating rating;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    // 후기 내용 수정
-    public void updateReview(String content, Rating rating) {
-        this.reviewContent = content;
-        this.rating = rating;
-    }
-
 }
 

--- a/src/main/java/com/example/mate/domain/mate/entity/Visit.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/Visit.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.mate.entity;
 
+import com.example.mate.domain.mate.dto.request.MateReviewCreateRequest;
 import com.example.mate.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -50,5 +51,18 @@ public class Visit {
         });
 
         return visit;
+    }
+
+    public MateReview createReview(Member reviewer, Member reviewee, MateReviewCreateRequest request) {
+        MateReview newMateReview = MateReview.builder()
+                .visit(this)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .reviewContent(request.getContent())
+                .rating(request.getRating())
+                .build();
+
+        reviews.add(newMateReview);
+        return newMateReview;
     }
 }

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -5,17 +5,14 @@ import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
-import com.example.mate.domain.mate.dto.request.MatePostCompleteRequest;
-import com.example.mate.domain.mate.dto.request.MatePostCreateRequest;
-import com.example.mate.domain.mate.dto.request.MatePostSearchRequest;
-import com.example.mate.domain.mate.dto.request.MatePostStatusRequest;
-import com.example.mate.domain.mate.dto.response.MatePostCompleteResponse;
-import com.example.mate.domain.mate.dto.response.MatePostDetailResponse;
-import com.example.mate.domain.mate.dto.response.MatePostResponse;
-import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
+import com.example.mate.domain.mate.dto.request.*;
+import com.example.mate.domain.mate.dto.response.*;
 import com.example.mate.domain.mate.entity.MatePost;
+import com.example.mate.domain.mate.entity.MateReview;
 import com.example.mate.domain.mate.entity.Status;
+import com.example.mate.domain.mate.entity.Visit;
 import com.example.mate.domain.mate.repository.MateRepository;
+import com.example.mate.domain.mate.repository.MateReviewRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
@@ -28,7 +25,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.example.mate.common.error.ErrorCode.*;
 
@@ -40,10 +36,10 @@ public class MateService {
     private final MateRepository mateRepository;
     private final MatchRepository matchRepository;
     private final MemberRepository memberRepository;
+    private final MateReviewRepository mateReviewRepository;
 
     public MatePostResponse createMatePost(MatePostCreateRequest request, MultipartFile file) {
-        Member author = memberRepository.findById(request.getMemberId())
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND_BY_ID));
+        Member author = findMemberById(request.getMemberId());
 
 
         Match match = matchRepository.findById(request.getMatchId())
@@ -87,7 +83,7 @@ public class MateService {
 
         return mainPagePosts.stream()
                 .map(MatePostSummaryResponse::from)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public PageResponse<MatePostSummaryResponse> getMatePagePosts(MatePostSearchRequest request, Pageable pageable) {
@@ -140,17 +136,6 @@ public class MateService {
     }
 
 
-    private MatePost findMatePostById(Long postId) {
-        return mateRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND_BY_ID));
-    }
-
-    private void validateAuthorization(MatePost matePost, Long memberId) {
-        if (!matePost.getAuthor().getId().equals(memberId)) {
-            throw new CustomException(MATE_POST_UPDATE_NOT_ALLOWED);
-        }
-    }
-
     private void validateCompletionTime(MatePost matePost) {
         if (matePost.getMatch().getMatchTime().isAfter(LocalDateTime.now())) {
             throw new CustomException(MATE_POST_COMPLETE_TIME_NOT_ALLOWED);
@@ -194,5 +179,68 @@ public class MateService {
         }
 
         mateRepository.delete(matePost);
+    }
+
+    public MateReviewCreateResponse createReview(Long postId, Long reviewerId, MateReviewCreateRequest request) {
+        MatePost matePost = findMatePostById(postId);
+        Member reviewer = findMemberById(reviewerId);
+        Member reviewee = findMemberById(request.getRevieweeId());
+
+        validateReviewEligibility(matePost, reviewer, reviewee);
+
+        MateReview review = matePost.getVisit().createReview(reviewer, reviewee, request);
+        MateReview savedReview = mateReviewRepository.save(review);
+
+        return MateReviewCreateResponse.from(savedReview);
+    }
+
+    private void validateReviewEligibility(MatePost matePost, Member reviewer, Member reviewee) {
+        // 리뷰어와 리뷰 대상자 모두 참여자(또는 방장) 여부 검증
+        validateParticipant(matePost, reviewer);
+        validateParticipant(matePost, reviewee);
+
+        // 자기 자신 리뷰 검증
+        validateSelfReview(reviewer, reviewee);
+    }
+
+    private void validateParticipant(MatePost matePost, Member member) {
+        boolean isParticipant = isAuthor(matePost, member) ||
+                isVisitParticipant(matePost.getVisit(), member);
+
+        if (!isParticipant) {
+            throw new CustomException(NOT_PARTICIPANT_OR_AUTHOR);
+        }
+    }
+
+    private boolean isAuthor(MatePost matePost, Member member) {
+        return matePost.getAuthor().equals(member);
+    }
+
+    private boolean isVisitParticipant(Visit visit, Member member) {
+        return visit.getParticipants().stream()
+                .anyMatch(part -> part.getMember().equals(member));
+    }
+
+    private void validateSelfReview(Member reviewer, Member reviewee) {
+        if (reviewer.equals(reviewee)) {
+            throw new CustomException(SELF_REVIEW_NOT_ALLOWED);
+        }
+    }
+
+    private Member findMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND_BY_ID));
+    }
+
+    private MatePost findMatePostById(Long postId) {
+        return mateRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND_BY_ID));
+    }
+
+
+    private void validateAuthorization(MatePost matePost, Long memberId) {
+        if (!matePost.getAuthor().getId().equals(memberId)) {
+            throw new CustomException(MATE_POST_UPDATE_NOT_ALLOWED);
+        }
     }
 }

--- a/src/test/java/com/example/mate/domain/mate/controller/MateReviewControllerTest.java
+++ b/src/test/java/com/example/mate/domain/mate/controller/MateReviewControllerTest.java
@@ -1,6 +1,5 @@
 package com.example.mate.domain.mate.controller;
 
-import com.example.mate.common.error.CustomException;
 import com.example.mate.domain.constant.Rating;
 import com.example.mate.domain.mate.dto.request.MateReviewCreateRequest;
 import com.example.mate.domain.mate.dto.response.MateReviewCreateResponse;
@@ -17,7 +16,6 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static com.example.mate.common.error.ErrorCode.NOT_PARTICIPANT_OR_AUTHOR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;

--- a/src/test/java/com/example/mate/domain/mate/controller/MateReviewControllerTest.java
+++ b/src/test/java/com/example/mate/domain/mate/controller/MateReviewControllerTest.java
@@ -1,0 +1,139 @@
+package com.example.mate.domain.mate.controller;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.domain.constant.Rating;
+import com.example.mate.domain.mate.dto.request.MateReviewCreateRequest;
+import com.example.mate.domain.mate.dto.response.MateReviewCreateResponse;
+import com.example.mate.domain.mate.service.MateService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.example.mate.common.error.ErrorCode.NOT_PARTICIPANT_OR_AUTHOR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MateController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MateReviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MateService mateService;
+
+    @Nested
+    @DisplayName("메이트 직관 후기 작성")
+    class CreateMateReview {
+
+        private MateReviewCreateRequest createMateReviewRequest() {
+            return MateReviewCreateRequest.builder()
+                    .revieweeId(2L)
+                    .rating(Rating.GOOD)
+                    .content("함께해서 즐거웠어요!")
+                    .build();
+        }
+
+        private MateReviewCreateResponse createMateReviewResponse() {
+            return MateReviewCreateResponse.builder()
+                    .reviewId(1L)
+                    .reviewerId(1L)
+                    .revieweeId(2L)
+                    .revieweeNickName("테스트닉네임")
+                    .content("함께해서 즐거웠어요!")
+                    .rating("좋아요!")
+                    .build();
+        }
+
+        @Test
+        @DisplayName("메이트 직관 후기 작성 성공")
+        void createMateReview_success() throws Exception {
+            // given
+            Long memberId = 1L;
+            Long postId = 1L;
+            MateReviewCreateRequest request = createMateReviewRequest();
+            MateReviewCreateResponse response = createMateReviewResponse();
+
+            given(mateService.createReview(any(), any(), any()))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/mates/{memberId}/{postId}/reviews", memberId, postId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.reviewId").value(1L))
+                    .andExpect(jsonPath("$.data.reviewerId").value(1L))
+                    .andExpect(jsonPath("$.data.revieweeId").value(2L))
+                    .andExpect(jsonPath("$.data.revieweeNickName").value("테스트닉네임"))
+                    .andExpect(jsonPath("$.data.content").value("함께해서 즐거웠어요!"))
+                    .andExpect(jsonPath("$.data.rating").value("좋아요!"))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("메이트 직관 후기 작성 실패 - 리뷰 대상자 ID 누락")
+        void createMateReview_failWithoutRevieweeId() throws Exception {
+            // given
+            Long memberId = 1L;
+            Long postId = 1L;
+            MateReviewCreateRequest request = MateReviewCreateRequest.builder()
+                    .rating(Rating.GOOD)
+                    .content("함께해서 즐거웠어요!")
+                    .build();
+
+            // when & then
+            mockMvc.perform(post("/api/mates/{memberId}/{postId}/reviews", memberId, postId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value("revieweeId: 리뷰 대상자 ID는 필수입니다."))
+                    .andExpect(jsonPath("$.code").value(400));
+        }
+
+        @Test
+        @DisplayName("메이트 직관 후기 작성 실패 - 리뷰 내용 길이 초과")
+        void createMateReview_failWithLongContent() throws Exception {
+            // given
+            Long memberId = 1L;
+            Long postId = 1L;
+            String longContent = "a".repeat(101);
+            MateReviewCreateRequest request = MateReviewCreateRequest.builder()
+                    .revieweeId(2L)
+                    .rating(Rating.GOOD)
+                    .content(longContent)
+                    .build();
+
+            // when & then
+            mockMvc.perform(post("/api/mates/{memberId}/{postId}/reviews", memberId, postId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.message").value("content: 리뷰 내용은 100자를 초과할 수 없습니다."))
+                    .andExpect(jsonPath("$.code").value(400));
+        }
+    }
+}

--- a/src/test/java/com/example/mate/domain/mate/service/MateReviewServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateReviewServiceTest.java
@@ -1,0 +1,261 @@
+package com.example.mate.domain.mate.service;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.constant.Rating;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.mate.dto.request.MateReviewCreateRequest;
+import com.example.mate.domain.mate.dto.response.MateReviewCreateResponse;
+import com.example.mate.domain.mate.entity.*;
+import com.example.mate.domain.mate.repository.MateRepository;
+import com.example.mate.domain.mate.repository.MateReviewRepository;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.mate.common.error.ErrorCode.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MateReviewServiceTest {
+
+    @InjectMocks
+    private MateService mateService;
+
+    @Mock
+    private MateRepository mateRepository;
+
+    @Mock
+    private MateReviewRepository mateReviewRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private static final Long TEST_POST_ID = 1L;
+    private static final Long TEST_REVIEWER_ID = 1L;
+    private static final Long TEST_REVIEWEE_ID = 2L;
+
+    private Member createReviewer() {
+        return Member.builder()
+                .id(TEST_REVIEWER_ID)
+                .name("리뷰어")
+                .email("reviewer@test.com")
+                .nickname("리뷰어닉네임")
+                .imageUrl("reviewer.jpg")
+                .build();
+    }
+
+    private Member createReviewee() {
+        return Member.builder()
+                .id(TEST_REVIEWEE_ID)
+                .name("리뷰대상자")
+                .email("reviewee@test.com")
+                .nickname("리뷰대상자닉네임")
+                .imageUrl("reviewee.jpg")
+                .build();
+    }
+
+    private MatePost createMatePost(Member author) {
+        return MatePost.builder()
+                .id(TEST_POST_ID)
+                .author(author)
+                .teamId(1L)
+                .match(Match.builder().build())
+                .title("테스트 제목")
+                .content("테스트 내용")
+                .status(Status.VISIT_COMPLETE)
+                .maxParticipants(4)
+                .currentParticipants(2)
+                .age(Age.TWENTIES)
+                .gender(Gender.ANY)
+                .transport(TransportType.PUBLIC)
+                .build();
+    }
+
+    private Visit createVisit(MatePost post, List<Member> participants) {
+        return Visit.createForComplete(post, participants);
+    }
+
+    private MateReviewCreateRequest createRequest() {
+        return MateReviewCreateRequest.builder()
+                .revieweeId(TEST_REVIEWEE_ID)
+                .rating(Rating.GOOD)
+                .content("좋은 메이트였습니다!")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("메이트 후기 작성")
+    class CreateMateReview {
+
+        @Test
+        @DisplayName("메이트 후기 작성 성공")
+        void createMateReview_Success() {
+            // given
+            Member reviewer = createReviewer();
+            Member reviewee = createReviewee();
+            MatePost matePost = createMatePost(reviewer);
+            List<Member> participants = List.of(reviewer, reviewee);
+            Visit visit = createVisit(matePost, participants);
+            matePost.complete(participants);
+
+            MateReviewCreateRequest request = createRequest();
+
+            MateReview mateReview = MateReview.builder()
+                    .id(1L)
+                    .visit(visit)
+                    .reviewer(reviewer)
+                    .reviewee(reviewee)
+                    .reviewContent(request.getContent())
+                    .rating(request.getRating())
+                    .build();
+
+            given(mateRepository.findById(TEST_POST_ID))
+                    .willReturn(Optional.of(matePost));
+            given(memberRepository.findById(TEST_REVIEWER_ID))
+                    .willReturn(Optional.of(reviewer));
+            given(memberRepository.findById(TEST_REVIEWEE_ID))
+                    .willReturn(Optional.of(reviewee));
+            given(mateReviewRepository.save(any(MateReview.class)))
+                    .willReturn(mateReview);
+
+            // when
+            MateReviewCreateResponse response = mateService.createReview(
+                    TEST_POST_ID,
+                    TEST_REVIEWER_ID,
+                    request
+            );
+
+            // then
+            assertThat(response.getReviewerId()).isEqualTo(TEST_REVIEWER_ID);
+            assertThat(response.getRevieweeId()).isEqualTo(TEST_REVIEWEE_ID);
+            assertThat(response.getRating()).isEqualTo(Rating.GOOD.getValue());
+            verify(mateRepository).findById(TEST_POST_ID);
+            verify(memberRepository).findById(TEST_REVIEWER_ID);
+            verify(memberRepository).findById(TEST_REVIEWEE_ID);
+            verify(mateReviewRepository).save(any(MateReview.class));
+        }
+
+        @Test
+        @DisplayName("메이트 후기 작성 실패 - 존재하지 않는 게시글")
+        void createMateReview_FailWithInvalidPost() {
+            // given
+            MateReviewCreateRequest request = createRequest();
+
+            given(mateRepository.findById(TEST_POST_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                    () -> mateService.createReview(TEST_POST_ID, TEST_REVIEWER_ID, request)
+            )
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MATE_POST_NOT_FOUND_BY_ID);
+
+            verify(mateRepository).findById(TEST_POST_ID);
+            verify(memberRepository, never()).findById(any());
+            verify(mateReviewRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("메이트 후기 작성 실패 - 존재하지 않는 리뷰어")
+        void createMateReview_FailWithInvalidReviewer() {
+            // given
+            Member reviewee = createReviewee();
+            MatePost matePost = createMatePost(reviewee);
+            MateReviewCreateRequest request = createRequest();
+
+            given(mateRepository.findById(TEST_POST_ID))
+                    .willReturn(Optional.of(matePost));
+            given(memberRepository.findById(TEST_REVIEWER_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                    () -> mateService.createReview(TEST_POST_ID, TEST_REVIEWER_ID, request)
+            )
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MEMBER_NOT_FOUND_BY_ID);
+
+            verify(mateRepository).findById(TEST_POST_ID);
+            verify(memberRepository).findById(TEST_REVIEWER_ID);
+            verify(mateReviewRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("메이트 후기 작성 실패 - 존재하지 않는 리뷰 대상자")
+        void createMateReview_FailWithInvalidReviewee() {
+            // given
+            Member reviewer = createReviewer();
+            MatePost matePost = createMatePost(reviewer);
+            MateReviewCreateRequest request = createRequest();
+
+            given(mateRepository.findById(TEST_POST_ID))
+                    .willReturn(Optional.of(matePost));
+            given(memberRepository.findById(TEST_REVIEWER_ID))
+                    .willReturn(Optional.of(reviewer));
+            given(memberRepository.findById(TEST_REVIEWEE_ID))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                    () -> mateService.createReview(TEST_POST_ID, TEST_REVIEWER_ID, request)
+            )
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MEMBER_NOT_FOUND_BY_ID);
+
+            verify(mateRepository).findById(TEST_POST_ID);
+            verify(memberRepository).findById(TEST_REVIEWER_ID);
+            verify(memberRepository).findById(TEST_REVIEWEE_ID);
+            verify(mateReviewRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("메이트 후기 작성 실패 - 참여하지 않은 사용자")
+        void createMateReview_FailWithNonParticipant() {
+            // given
+            Member reviewer = createReviewer();
+            Member reviewee = createReviewee();
+            Member author = Member.builder().id(3L).build();
+
+            MatePost matePost = createMatePost(author);
+            List<Member> participants = List.of(author, reviewee); // reviewer는 참여자 목록에 없음
+            matePost.complete(participants);
+
+            MateReviewCreateRequest request = createRequest();
+
+            given(mateRepository.findById(TEST_POST_ID))
+                    .willReturn(Optional.of(matePost));
+            given(memberRepository.findById(TEST_REVIEWER_ID))
+                    .willReturn(Optional.of(reviewer));
+            given(memberRepository.findById(TEST_REVIEWEE_ID))
+                    .willReturn(Optional.of(reviewee));
+
+            // when & then
+            assertThatThrownBy(
+                    () -> mateService.createReview(TEST_POST_ID, TEST_REVIEWER_ID, request)
+            )
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", NOT_PARTICIPANT_OR_AUTHOR);
+
+            verify(mateRepository).findById(TEST_POST_ID);
+            verify(memberRepository).findById(TEST_REVIEWER_ID);
+            verify(memberRepository).findById(TEST_REVIEWEE_ID);
+            verify(mateReviewRepository, never()).save(any());
+        }
+    }
+}

--- a/src/test/java/com/example/mate/domain/mate/service/MateStatusServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateStatusServiceTest.java
@@ -34,7 +34,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-
 @ExtendWith(MockitoExtension.class)
 class MateStatusServiceTest {
 

--- a/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
@@ -231,7 +231,6 @@ class MemberIntegrationTest {
                 .reviewee(reviewee)
                 .reviewContent("매칭 후기입니다. 아주 즐거웠어요!")
                 .rating(Rating.GOOD)
-                .createdAt(LocalDateTime.now())
                 .build());
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 메이트 직관 후기 작성 API 개발
- [x] 직관 후기 도메인 엔티티 및 검증 로직 구현
- [x] 직관 후기 테스트 작성 (통합 테스트는 미구현)

## 💡 자세한 설명

### 도메인 규칙
   
![image](https://github.com/user-attachments/assets/de49f695-1027-492b-a52d-2c5dbb659d3e)



### 기술적 특이사항
- Visit 엔티티와 MateReview 엔티티 간 1:N 관계 설정
- 검증 로직은 도메인 서비스 계층에서 처리
- 생성 및 연관관계 매핑 로직은 도메인 계층에서 처리

## 📗 참고 자료

## 📢 리뷰 요구 사항

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?