### PR TITLE
MATE-43 : [FEAT] 굿즈 판매기록 페이징 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/response/PageResponse.java
+++ b/src/main/java/com/example/mate/common/response/PageResponse.java
@@ -1,11 +1,12 @@
 package com.example.mate.common.response;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @Getter
 @Builder
@@ -18,4 +19,14 @@ public class PageResponse<T> {
     private boolean hasNext;         // 다음 페이지 존재 여부
     private int pageNumber;          // 현재 페이지 번호
     private int pageSize;           // 페이지 크기
+
+    // Pageable 검증 메서드
+    public static Pageable validatePageable(Pageable pageable) {
+        // pageNumber 검증: 0보다 작은 값은 0으로 처리
+        int pageNumber = Math.max(pageable.getPageNumber(), 0);
+
+        // pageSize 검증: 0 이하이면 기본값 10으로 설정
+        int pageSize = pageable.getPageSize() <= 0 ? 10 : pageable.getPageSize();
+        return PageRequest.of(pageNumber, pageSize, pageable.getSort());
+    }
 }

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsPostRepository.java
@@ -3,6 +3,7 @@ package com.example.mate.domain.goods.repository;
 import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.Status;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,7 +19,7 @@ public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long>, Goo
             ORDER BY gp.createdAt DESC
             """)
     List<GoodsPost> findMainGoodsPosts(@Param("teamId") Long teamId, @Param("status") Status status, Pageable pageable);
-           
+
     @Query("""
             SELECT COUNT(gp)
             FROM GoodsPost gp
@@ -34,4 +35,14 @@ public interface GoodsPostRepository extends JpaRepository<GoodsPost, Long>, Goo
             AND gp.status = :status
             """)
     int countGoodsPostsByBuyerIdAndStatus(@Param("memberId") Long memberId, @Param("status") Status status);
+
+    @Query("""
+            SELECT gp
+            FROM GoodsPost gp
+            WHERE gp.seller.id = :memberId
+            AND gp.status = :status
+            ORDER BY gp.createdAt DESC
+            """)
+    Page<GoodsPost> findGoodsPostsBySellerId(@Param("memberId") Long memberId, @Param("status") Status status,
+                                             Pageable pageable);
 }

--- a/src/main/java/com/example/mate/domain/member/controller/FollowController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/FollowController.java
@@ -1,13 +1,15 @@
 package com.example.mate.domain.member.controller;
 
+import static com.example.mate.common.response.PageResponse.validatePageable;
+
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.member.dto.response.MemberSummaryResponse;
 import com.example.mate.domain.member.service.FollowService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/profile")
+@Tag(name = "Follow Controller", description = "회원 팔로우 관련 API")
 public class FollowController {
 
     private final FollowService followService;
@@ -56,7 +59,7 @@ public class FollowController {
     @GetMapping("{memberId}/followings")
     public ResponseEntity<ApiResponse<PageResponse<MemberSummaryResponse>>> getFollowings(
             @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
-            @PageableDefault(size = 10) Pageable pageable
+            @PageableDefault Pageable pageable
     ) {
         pageable = validatePageable(pageable);
         PageResponse<MemberSummaryResponse> response = followService.getFollowingsPage(memberId, pageable);
@@ -67,21 +70,11 @@ public class FollowController {
     @GetMapping("{memberId}/followers")
     public ResponseEntity<ApiResponse<PageResponse<MemberSummaryResponse>>> getFollowers(
             @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
-            @PageableDefault(size = 10) Pageable pageable
+            @PageableDefault Pageable pageable
     ) {
         pageable = validatePageable(pageable);
         PageResponse<MemberSummaryResponse> response = followService.getFollowersPage(memberId, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
-    // Pageable 검증 메서드
-    private Pageable validatePageable(Pageable pageable) {
-        // pageNumber 검증: 0보다 작은 값은 0으로 처리
-        int pageNumber = Math.max(pageable.getPageNumber(), 0);
-
-        // pageSize 검증: 0 이하이면 기본값 10으로 설정
-        int pageSize = pageable.getPageSize() <= 0 ? 10 : pageable.getPageSize();
-        return PageRequest.of(pageNumber, pageSize, pageable.getSort());
     }
 }

--- a/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
@@ -1,10 +1,19 @@
 package com.example.mate.domain.member.controller;
 
+import static com.example.mate.common.response.PageResponse.validatePageable;
+
+import com.example.mate.common.response.ApiResponse;
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.member.dto.response.MyGoodsRecordResponse;
 import com.example.mate.domain.member.dto.response.MyReviewResponse;
 import com.example.mate.domain.member.dto.response.MyVisitResponse;
+import com.example.mate.domain.member.service.ProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Collections;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -16,8 +25,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/profile")
+@Tag(name = "Profile Controller", description = "회원 프로필 관련 API")
 public class ProfileController {
+
+    private final ProfileService profileService;
 
     /*
     TODO : 2024/11/24 - 굿즈거래 후기 페이징 조회
@@ -70,22 +83,15 @@ public class ProfileController {
         return ResponseEntity.ok(page);
     }
 
-    /*
-    TODO : 2024/11/24 - 굿즈 판매기록 페이징 조회
-    1. memberId 을 통해 회원 정보 조회
-    2. 회원이 판매한 굿즈기록 조회
-    3. 페이징 처리 후 반환
-    */
+    @Operation(summary = "굿즈 판매기록 페이징 조회")
     @GetMapping("/{memberId}/goods/sold")
-    public ResponseEntity<Page<MyGoodsRecordResponse>> getSoldGoods(
-            @PathVariable Long memberId,
-            @PageableDefault(size = 10) Pageable pageable
+    public ResponseEntity<ApiResponse<PageResponse<MyGoodsRecordResponse>>> getSoldGoods(
+            @Parameter(description = "회원 ID") @PathVariable Long memberId,
+            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
     ) {
-        MyGoodsRecordResponse myGoodsRecordResponse = MyGoodsRecordResponse.from();
-        List<MyGoodsRecordResponse> responses = Collections.nCopies(10, myGoodsRecordResponse);
-        Page<MyGoodsRecordResponse> page = new PageImpl<>(responses, pageable, responses.size());
-
-        return ResponseEntity.ok(page);
+        pageable = validatePageable(pageable);
+        PageResponse<MyGoodsRecordResponse> response = profileService.getSoldGoodsPage(memberId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /*

--- a/src/main/java/com/example/mate/domain/member/dto/response/MyGoodsRecordResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MyGoodsRecordResponse.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.member.dto.response;
 
+import com.example.mate.domain.goods.entity.GoodsPost;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -25,6 +26,17 @@ public class MyGoodsRecordResponse {
                 .price(50000)
                 .author("이대호가 좋아서")
                 .createdAt(LocalDateTime.now().minusDays(7))
+                .build();
+    }
+
+    public static MyGoodsRecordResponse of(GoodsPost goodsPost, String mainImageUrl) {
+        return MyGoodsRecordResponse.builder()
+                .postId(goodsPost.getId())
+                .title(goodsPost.getTitle())
+                .imageUrl(mainImageUrl)
+                .price(goodsPost.getPrice())
+                .author(goodsPost.getSeller().getNickname())
+                .createdAt(goodsPost.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/example/mate/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/mate/domain/member/service/MemberService.java
@@ -18,11 +18,13 @@ import com.example.mate.domain.member.dto.response.MyProfileResponse;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.FollowRepository;
 import com.example.mate.domain.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MemberService {
 

--- a/src/main/java/com/example/mate/domain/member/service/ProfileService.java
+++ b/src/main/java/com/example/mate/domain/member/service/ProfileService.java
@@ -1,0 +1,64 @@
+package com.example.mate.domain.member.service;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.common.response.PageResponse;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.GoodsPostImage;
+import com.example.mate.domain.goods.entity.Status;
+import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.member.dto.response.MyGoodsRecordResponse;
+import com.example.mate.domain.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ProfileService {
+
+    private final MemberRepository memberRepository;
+    private final GoodsPostRepository goodsPostRepository;
+
+    // 굿즈 판매기록 페이징 조회
+    public PageResponse<MyGoodsRecordResponse> getSoldGoodsPage(Long memberId, Pageable pageable) {
+        validateMemberId(memberId);
+
+        Page<GoodsPost> soldGoodsPage = goodsPostRepository.findGoodsPostsBySellerId(memberId, Status.CLOSED,
+                pageable);
+
+        List<MyGoodsRecordResponse> content = soldGoodsPage.getContent().stream()
+                .map(this::convertToRecordResponse).toList();
+
+        return PageResponse.<MyGoodsRecordResponse>builder()
+                .content(content)
+                .totalPages(soldGoodsPage.getTotalPages())
+                .totalElements(soldGoodsPage.getTotalElements())
+                .hasNext(soldGoodsPage.hasNext())
+                .pageNumber(soldGoodsPage.getNumber())
+                .pageSize(soldGoodsPage.getSize())
+                .build();
+    }
+
+    private void validateMemberId(Long memberId) {
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
+    }
+
+    private MyGoodsRecordResponse convertToRecordResponse(GoodsPost goodsPost) {
+        String mainImageUrl = getMainImageUrl(goodsPost);
+        return MyGoodsRecordResponse.of(goodsPost, mainImageUrl);
+    }
+
+    private String getMainImageUrl(GoodsPost goodsPost) {
+        return goodsPost.getGoodsPostImages().stream()
+                .filter(GoodsPostImage::getIsMainImage)
+                .findFirst()
+                .map(GoodsPostImage::getImageUrl)
+                .orElse("upload/default.jpg");
+    }
+}

--- a/src/test/java/com/example/mate/domain/member/controller/ProfileControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/ProfileControllerTest.java
@@ -1,0 +1,123 @@
+package com.example.mate.domain.member.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.common.response.PageResponse;
+import com.example.mate.domain.member.dto.response.MyGoodsRecordResponse;
+import com.example.mate.domain.member.service.ProfileService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ProfileController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ProfileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ProfileService profileService;
+
+    private MyGoodsRecordResponse createMyGoodsRecordResponse() {
+        return MyGoodsRecordResponse.builder()
+                .postId(1L)
+                .title("test title")
+                .imageUrl("test.png")
+                .price(10000)
+                .author("tester1")
+                .createdAt(LocalDateTime.now().minusDays(7))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회")
+    class ProfileSoldGoodsPage {
+
+        @Test
+        @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회 성공")
+        void get_sold_goods_page_success() throws Exception {
+            // given
+            Long memberId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+            MyGoodsRecordResponse responseDTO = createMyGoodsRecordResponse();
+            List<MyGoodsRecordResponse> content = List.of(responseDTO);
+            PageImpl<MyGoodsRecordResponse> soldGoodsPage = new PageImpl<>(content);
+
+            PageResponse<MyGoodsRecordResponse> response = PageResponse.<MyGoodsRecordResponse>builder()
+                    .content(content)
+                    .totalPages(soldGoodsPage.getTotalPages())
+                    .totalElements(soldGoodsPage.getTotalElements())
+                    .hasNext(soldGoodsPage.hasNext())
+                    .pageNumber(soldGoodsPage.getNumber())
+                    .pageSize(soldGoodsPage.getSize())
+                    .build();
+
+            given(profileService.getSoldGoodsPage(memberId, pageable)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/goods/sold", memberId)
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageSize())))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content.size()").value(content.size()))
+                    .andExpect(jsonPath("$.data.content[0].postId").value(responseDTO.getPostId()))
+                    .andExpect(jsonPath("$.data.content[0].price").value(responseDTO.getPrice()))
+                    .andExpect(jsonPath("$.data.totalPages").value(response.getTotalPages()))
+                    .andExpect(jsonPath("$.data.totalElements").value(response.getTotalElements()))
+                    .andExpect(jsonPath("$.data.pageNumber").value(response.getPageNumber()))
+                    .andExpect(jsonPath("$.data.pageSize").value(response.getPageSize()))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회 실패 - 유효하지 않은 회원 아이디로 조회")
+        void get_sold_goods_page_invalid_member_id() throws Exception {
+            // given
+            Long memberId = 999L; // 존재 하지 않는 아이디
+            Pageable pageable = PageRequest.of(0, 10);
+
+            willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID))
+                    .given(profileService).getSoldGoodsPage(memberId, pageable);
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/goods/sold", memberId)
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageSize())))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage()));
+
+            verify(profileService, times(1)).getSoldGoodsPage(memberId, pageable);
+        }
+    }
+}

--- a/src/test/java/com/example/mate/domain/member/integration/ProfileIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/ProfileIntegrationTest.java
@@ -1,0 +1,177 @@
+package com.example.mate.domain.member.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.goods.dto.LocationInfo;
+import com.example.mate.domain.goods.entity.Category;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.GoodsPostImage;
+import com.example.mate.domain.goods.entity.Status;
+import com.example.mate.domain.goods.repository.GoodsPostImageRepository;
+import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class ProfileIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private GoodsPostRepository goodsPostRepository;
+    @Autowired
+    private GoodsPostImageRepository imageRepository;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Member member;
+
+    private GoodsPost goodsPost;
+
+    @BeforeEach
+    void setUp() {
+        createMember();
+        createGoodsPost();
+        createGoodsPostImage();
+    }
+
+    private void createMember() {
+        member = memberRepository.save(Member.builder()
+                .name("홍길동")
+                .email("test@gmail.com")
+                .nickname("테스터")
+                .imageUrl("upload/test.jpg")
+                .gender(Gender.FEMALE)
+                .age(25)
+                .manner(0.3f)
+                .build());
+    }
+
+    private void createGoodsPost() {
+        goodsPost = goodsPostRepository.save(GoodsPost.builder()
+                .seller(member)
+                .teamId(1L)
+                .title("test title")
+                .content("test content")
+                .price(10_000)
+                .category(Category.ACCESSORY)
+                .location(LocationInfo.toEntity(createLocationInfo()))
+                .status(Status.CLOSED)
+                .build());
+    }
+
+    private void createGoodsPostImage() {
+        GoodsPostImage image = GoodsPostImage.builder()
+                .imageUrl("upload/test_img_url")
+                .build();
+
+        goodsPost.changeImages(List.of(image));
+        goodsPostRepository.save(goodsPost);
+    }
+
+    private MockMultipartFile createFile() {
+        return new MockMultipartFile(
+                "files",
+                "test_photo.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "content".getBytes()
+        );
+    }
+
+    private LocationInfo createLocationInfo() {
+        return LocationInfo.builder()
+                .placeName("Stadium Plaza")
+                .longitude("127.12345")
+                .latitude("37.56789")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회")
+    class ProfileSoldGoodsPage {
+
+        @Test
+        @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회 성공")
+        void get_sold_goods_page_success() throws Exception {
+            // given
+            Long memberId = member.getId();
+            int page = 0;
+            int size = 10;
+
+            goodsPostRepository.deleteAll();
+            imageRepository.deleteAll();
+
+            for (int i = 1; i <= 3; i++) {
+                GoodsPost post = GoodsPost.builder()
+                        .seller(member)
+                        .teamId(10L)
+                        .title("Test Title " + i)
+                        .content("Test Content " + i)
+                        .price(1000 * i)
+                        .category(Category.ACCESSORY)
+                        .location(LocationInfo.toEntity(createLocationInfo()))
+                        .status(Status.CLOSED)
+                        .build();
+
+                GoodsPostImage image = GoodsPostImage.builder()
+                        .imageUrl("upload/test_img_url " + i)
+                        .post(post)
+                        .build();
+
+                post.changeImages(List.of(image));
+                goodsPostRepository.save(post);
+            }
+
+            // when
+            mockMvc.perform(get("/api/profile/{memberId}/goods/sold", memberId)
+                            .param("page", String.valueOf(page))
+                            .param("size", String.valueOf(size)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(3))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회 실패 - 유효하지 않은 회원 아이디로 조회")
+        void get_sold_goods_page_invalid_member_id() throws Exception {
+            // given
+            Long invalidMemberId = member.getId() + 999L; // 존재하지 않는 회원 ID
+            int page = 0;
+            int size = 10;
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/goods/sold", invalidMemberId)
+                            .param("page", String.valueOf(page))
+                            .param("size", String.valueOf(size)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andExpect(jsonPath("$.message").value("해당 ID의 회원 정보를 찾을 수 없습니다")); // 커스텀 에러 메시지
+        }
+    }
+}

--- a/src/test/java/com/example/mate/domain/member/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/ProfileServiceTest.java
@@ -1,0 +1,163 @@
+package com.example.mate.domain.member.service;
+
+import static com.example.mate.common.error.ErrorCode.MEMBER_NOT_FOUND_BY_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.response.PageResponse;
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.goods.dto.LocationInfo;
+import com.example.mate.domain.goods.entity.Category;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.GoodsPostImage;
+import com.example.mate.domain.goods.entity.Status;
+import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.member.dto.response.MyGoodsRecordResponse;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+    @InjectMocks
+    private ProfileService profileService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private GoodsPostRepository goodsPostRepository;
+
+    private Member seller;
+    private Member buyer;
+    private GoodsPost goodsPost;
+    private GoodsPostImage goodsPostImage;
+
+    @BeforeEach
+    void setUp() {
+        createTestMember();
+        createGoodsPost();
+        createGoodsPostImage(goodsPost);
+    }
+
+    private void createTestMember() {
+        seller = Member.builder()
+                .id(1L)
+                .name("홍길동")
+                .nickname("tester1")
+                .email("tester1@example.com")
+                .age(20)
+                .gender(Gender.MALE)
+                .teamId(1L)
+                .build();
+        buyer = Member.builder()
+                .id(2L)
+                .name("김영희")
+                .nickname("tester2")
+                .email("tester2@example.com")
+                .age(20)
+                .gender(Gender.FEMALE)
+                .teamId(2L)
+                .build();
+    }
+
+    private void createGoodsPost() {
+        goodsPost = GoodsPost.builder()
+                .id(1L)
+                .seller(seller)
+                .buyer(buyer)
+                .teamId(1L)
+                .title("test title")
+                .content("test content")
+                .price(10_000)
+                .category(Category.ACCESSORY)
+                .location(LocationInfo.toEntity(createLocationInfo()))
+                .build();
+    }
+
+    private LocationInfo createLocationInfo() {
+        return LocationInfo.builder()
+                .placeName("Stadium Plaza")
+                .longitude("127.12345")
+                .latitude("37.56789")
+                .build();
+    }
+
+    private void createGoodsPostImage(GoodsPost post) {
+        goodsPostImage = GoodsPostImage.builder()
+                .imageUrl("upload/test_img_url")
+                .post(post)
+                .build();
+
+        goodsPostImage.setAsMainImage();
+        goodsPost.changeImages(List.of(goodsPostImage));
+    }
+
+    @Nested
+    @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회")
+    class ProfileSoldGoodsPage {
+
+        @Test
+        @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회 성공")
+        void get_sold_goods_page_success() {
+            // given
+            Long memberId = 1L;
+
+            PageImpl<GoodsPost> soldGoodsPage = new PageImpl<>(List.of(goodsPost));
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(seller));
+            given(goodsPostRepository.findGoodsPostsBySellerId(memberId, Status.CLOSED, pageable))
+                    .willReturn(soldGoodsPage);
+
+            // when
+            PageResponse<MyGoodsRecordResponse> response = profileService.getSoldGoodsPage(memberId, pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).isNotEmpty();
+            assertThat(response.getTotalElements()).isEqualTo(soldGoodsPage.getTotalElements());
+            assertThat(response.getContent().size()).isEqualTo(soldGoodsPage.getContent().size());
+
+            MyGoodsRecordResponse recordResponse = response.getContent().get(0);
+            assertThat(recordResponse.getTitle()).isEqualTo(goodsPost.getTitle());
+            assertThat(recordResponse.getPrice()).isEqualTo(goodsPost.getPrice());
+            assertThat(recordResponse.getImageUrl()).isEqualTo(goodsPostImage.getImageUrl());
+
+            verify(goodsPostRepository).findGoodsPostsBySellerId(memberId, Status.CLOSED, pageable);
+        }
+
+        @Test
+        @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회 실패 - 유효하지 않은 회원 아이디로 조회")
+        void get_sold_goods_page_invalid_member_id() {
+            // given
+            Long invalidMemberId = 999L;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(memberRepository.findById(invalidMemberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> profileService.getSoldGoodsPage(invalidMemberId, pageable))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MEMBER_NOT_FOUND_BY_ID);
+
+            verify(memberRepository).findById(invalidMemberId);
+        }
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈 판매기록 페이징 처리
- [x] 단일, 통합 테스트
- [x] 회원, 팔로우 서비스 누락된 @Transactional 추가

## 💡 자세한 설명

### 프로필의 굿즈 판매기록 조회
- 회원의 프로필 페이지에서 판매기록을 눌렀을 때, 해당 회원이 판매한 목록 페이지입니다.
- `Pageable pageable`에 대한 값의 validation 메서드를 `PageResponse` 내부에 추가했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?