### PR TITLE
MATE-41 : [FEAT] : 회원 메이트 후기 페이징 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepositoryCustom.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.mate.domain.mate.repository;
+
+import com.example.mate.domain.member.dto.response.MyReviewResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MateReviewRepositoryCustom {
+
+    Page<MyReviewResponse> findMateReviewsByRevieweeId(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepositoryImpl.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.example.mate.domain.mate.repository;
+
+import com.example.mate.domain.mate.entity.QMatePost;
+import com.example.mate.domain.mate.entity.QMateReview;
+import com.example.mate.domain.member.dto.response.MyReviewResponse;
+import com.example.mate.domain.member.entity.QMember;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class MateReviewRepositoryImpl implements MateReviewRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<MyReviewResponse> findMateReviewsByRevieweeId(Long revieweeId, Pageable pageable) {
+        QMateReview mateReview = QMateReview.mateReview;
+        QMatePost matePost = QMatePost.matePost;
+        QMember reviewer = QMember.member;
+
+        // 'created_at' 기준 내림차순으로 고정된 정렬
+        OrderSpecifier<LocalDateTime> desc = mateReview.createdAt.desc();
+
+        // 페이징 처리된 데이터 조회
+        List<MyReviewResponse> results = queryFactory
+                .select(Projections.constructor(
+                        MyReviewResponse.class,
+                        matePost.id.as("postId"),
+                        matePost.title.as("title"),
+                        reviewer.nickname.as("nickname"),
+                        mateReview.rating.stringValue().as("rating"),
+                        mateReview.reviewContent.as("content"),
+                        mateReview.createdAt.as("createdAt")
+                ))
+                .from(mateReview)
+                .join(mateReview.visit.post, matePost)
+                .join(mateReview.reviewer, reviewer)
+                .where(mateReview.reviewee.id.eq(revieweeId))
+                .orderBy(desc)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 데이터 개수 조회 (null 체크 추가)
+        Long total = queryFactory
+                .select(mateReview.count())
+                .from(mateReview)
+                .where(mateReview.reviewee.id.eq(revieweeId))
+                .fetchOne();
+
+        // total이 null일 경우 0으로 처리
+        long totalElements = total != null ? total : 0;
+
+        // Page 객체 생성
+        return new PageImpl<>(results, pageable, totalElements);
+    }
+}

--- a/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
@@ -57,15 +57,13 @@ public class ProfileController {
     3. 페이징 처리 후 반환
     */
     @GetMapping("{memberId}/review/mate")
-    public ResponseEntity<Page<MyReviewResponse>> getMateReviews(
-            @PathVariable Long memberId,
-            @PageableDefault(size = 10) Pageable pageable
+    public ResponseEntity<ApiResponse<PageResponse<MyReviewResponse>>> getMateReviews(
+            @Parameter(description = "회원 ID") @PathVariable Long memberId,
+            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
     ) {
-        MyReviewResponse myReviewResponse = MyReviewResponse.mateFrom();
-        List<MyReviewResponse> responses = Collections.nCopies(10, myReviewResponse);
-        Page<MyReviewResponse> page = new PageImpl<>(responses, pageable, responses.size());
-
-        return ResponseEntity.ok(page);
+        validatePageable(pageable);
+        PageResponse<MyReviewResponse> response = profileService.getMateReviewPage(memberId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /*

--- a/src/main/java/com/example/mate/domain/member/dto/response/MyReviewResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MyReviewResponse.java
@@ -1,21 +1,20 @@
 package com.example.mate.domain.member.dto.response;
 
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor // access = AccessLevel.PRIVATE 으로 설정 시, queryDSL의 Projection 과정에서 문제
 public class MyReviewResponse {
     private Long postId;
     private String title;
     private String nickname;
     private String rating;
     private String content;
-    private LocalDateTime created_at;
+    private LocalDateTime createdAt;
 
     public static MyReviewResponse goodsFrom() {
         return MyReviewResponse.builder()
@@ -24,7 +23,7 @@ public class MyReviewResponse {
                 .nickname("볼빨간사촌형")
                 .rating("좋았어요!")
                 .content("물건 너무 이쁘고 보존 상태가 좋아요!")
-                .created_at(LocalDateTime.now().minusDays(3))
+                .createdAt(LocalDateTime.now().minusDays(3))
                 .build();
     }
 
@@ -35,7 +34,7 @@ public class MyReviewResponse {
                 .nickname("서대문박병호")
                 .rating("좋았어요!")
                 .content("야구 지식이 풍부하시고 젠틀하십니다!")
-                .created_at(LocalDateTime.now().minusDays(3))
+                .createdAt(LocalDateTime.now().minusDays(3))
                 .build();
     }
 }

--- a/src/main/java/com/example/mate/domain/member/dto/response/MyVisitResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MyVisitResponse.java
@@ -1,6 +1,5 @@
 package com.example.mate.domain.member.dto.response;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -23,7 +22,7 @@ public class MyVisitResponse {
     private Long postId;
     private String imageUrl;
     private String title;
-    
+
     // 리뷰 정보
     private List<MateReviewResponse> reviews;
 

--- a/src/main/java/com/example/mate/domain/member/service/ProfileService.java
+++ b/src/main/java/com/example/mate/domain/member/service/ProfileService.java
@@ -7,7 +7,10 @@ import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.GoodsPostImage;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.mate.repository.MateReviewRepository;
+import com.example.mate.domain.mate.repository.MateReviewRepositoryCustom;
 import com.example.mate.domain.member.dto.response.MyGoodsRecordResponse;
+import com.example.mate.domain.member.dto.response.MyReviewResponse;
 import com.example.mate.domain.member.repository.MemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +26,8 @@ public class ProfileService {
 
     private final MemberRepository memberRepository;
     private final GoodsPostRepository goodsPostRepository;
+    private final MateReviewRepository mateReviewRepository;
+    private final MateReviewRepositoryCustom mateReviewRepositoryCustom;
 
     // 굿즈 판매기록 페이징 조회
     @Transactional(readOnly = true)
@@ -82,5 +87,22 @@ public class ProfileService {
                 .findFirst()
                 .map(GoodsPostImage::getImageUrl)
                 .orElse("upload/default.jpg");
+    }
+
+    // 메이트 후기 페이징 조회
+    public PageResponse<MyReviewResponse> getMateReviewPage(Long memberId, Pageable pageable) {
+        validateMemberId(memberId);
+
+        Page<MyReviewResponse> mateReviewPage = mateReviewRepositoryCustom.findMateReviewsByRevieweeId(
+                memberId, pageable);
+
+        return PageResponse.<MyReviewResponse>builder()
+                .content(mateReviewPage.getContent())
+                .totalPages(mateReviewPage.getTotalPages())
+                .totalElements(mateReviewPage.getTotalElements())
+                .hasNext(mateReviewPage.hasNext())
+                .pageNumber(mateReviewPage.getNumber())
+                .pageSize(mateReviewPage.getSize())
+                .build();
     }
 }

--- a/src/test/java/com/example/mate/domain/member/controller/ProfileControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/ProfileControllerTest.java
@@ -13,6 +13,7 @@ import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.member.dto.response.MyGoodsRecordResponse;
+import com.example.mate.domain.member.dto.response.MyReviewResponse;
 import com.example.mate.domain.member.service.ProfileService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
@@ -184,6 +185,81 @@ class ProfileControllerTest {
                     .andExpect(jsonPath("$.message").value(ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage()));
 
             verify(profileService, times(1)).getBoughtGoodsPage(memberId, pageable);
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 프로필 메이트 후기 페이징 조회")
+    class ProfileMateReviewPage {
+
+        @Test
+        @DisplayName("회원 프로필 메이트 후기 페이징 조회 성공")
+        void get_mate_review_page_success() throws Exception {
+            // given
+            Long memberId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            MyReviewResponse reviewResponse = MyReviewResponse.builder()
+                    .postId(1L)
+                    .title("Title 1")
+                    .nickname("tester1")
+                    .rating("GOOD")
+                    .content("Great!")
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            List<MyReviewResponse> content = List.of(reviewResponse);
+            PageImpl<MyReviewResponse> mateReviewPage = new PageImpl<>(content);
+
+            PageResponse<MyReviewResponse> response = PageResponse.<MyReviewResponse>builder()
+                    .content(content)
+                    .totalPages(mateReviewPage.getTotalPages())
+                    .totalElements(mateReviewPage.getTotalElements())
+                    .hasNext(mateReviewPage.hasNext())
+                    .pageNumber(mateReviewPage.getNumber())
+                    .pageSize(mateReviewPage.getSize())
+                    .build();
+
+            given(profileService.getMateReviewPage(memberId, pageable)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/review/mate", memberId)
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageSize())))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content.size()").value(content.size()))
+                    .andExpect(jsonPath("$.data.content[0].postId").value(reviewResponse.getPostId()))
+                    .andExpect(jsonPath("$.data.content[0].title").value(reviewResponse.getTitle()))
+                    .andExpect(jsonPath("$.data.content[0].content").value(reviewResponse.getContent()))
+                    .andExpect(jsonPath("$.data.totalPages").value(response.getTotalPages()))
+                    .andExpect(jsonPath("$.data.totalElements").value(response.getTotalElements()))
+                    .andExpect(jsonPath("$.data.pageNumber").value(response.getPageNumber()))
+                    .andExpect(jsonPath("$.data.pageSize").value(response.getPageSize()))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("회원 프로필 메이트 후기 페이징 조회 실패 - 유효하지 않은 회원 아이디로 조회")
+        void get_mate_review_page_fail_invalid_member_id() throws Exception {
+            // given
+            Long memberId = 999L; // 존재 하지 않는 아이디
+            Pageable pageable = PageRequest.of(0, 10);
+
+            willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID))
+                    .given(profileService).getMateReviewPage(memberId, pageable);
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/review/mate", memberId)
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageSize())))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage()));
+
+            verify(profileService, times(1)).getMateReviewPage(memberId, pageable);
         }
     }
 }

--- a/src/test/java/com/example/mate/domain/member/integration/ProfileIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/ProfileIntegrationTest.java
@@ -1,11 +1,13 @@
 package com.example.mate.domain.member.integration;
 
+import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.constant.Rating;
 import com.example.mate.domain.goods.dto.LocationInfo;
 import com.example.mate.domain.goods.entity.Category;
 import com.example.mate.domain.goods.entity.GoodsPost;
@@ -13,10 +15,23 @@ import com.example.mate.domain.goods.entity.GoodsPostImage;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostImageRepository;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.match.repository.MatchRepository;
+import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.domain.mate.entity.MatePost;
+import com.example.mate.domain.mate.entity.MateReview;
+import com.example.mate.domain.mate.entity.TransportType;
+import com.example.mate.domain.mate.entity.Visit;
+import com.example.mate.domain.mate.entity.VisitPart;
+import com.example.mate.domain.mate.repository.MateRepository;
+import com.example.mate.domain.mate.repository.MateReviewRepository;
+import com.example.mate.domain.mate.repository.VisitPartRepository;
+import com.example.mate.domain.mate.repository.VisitRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,8 +40,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
@@ -36,31 +51,82 @@ public class ProfileIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
+
     @Autowired
     private MemberRepository memberRepository;
+
     @Autowired
     private GoodsPostRepository goodsPostRepository;
+
     @Autowired
     private GoodsPostImageRepository imageRepository;
+
+    @Autowired
+    private MatchRepository matchRepository;
+
+    @Autowired
+    private MateRepository mateRepository;
+
+    @Autowired
+    private VisitRepository visitRepository;
+
+    @Autowired
+    private VisitPartRepository visitPartRepository;
+
+    @Autowired
+    private MateReviewRepository mateReviewRepository;
+
     @Autowired
     private ObjectMapper objectMapper;
 
-    private Member member;
+    private Member member1;
+    private Member member2;
+    private Member member3;
 
     private GoodsPost goodsPost;
+
+    private Match match;
+
+    private MatePost matePost;
+
+    private Visit visit;
 
     @BeforeEach
     void setUp() {
         createMember();
         createGoodsPost();
         createGoodsPostImage();
+        createMatch(LocalDateTime.now().minusDays(7));
+        createMatePost();
+        createVisit(matePost, List.of(member1, member2, member3));
+        createVisitPart();
+        createMateReview(member2, member1);
+        createMateReview(member3, member1);
     }
 
     private void createMember() {
-        member = memberRepository.save(Member.builder()
+        member1 = memberRepository.save(Member.builder()
                 .name("홍길동")
                 .email("test@gmail.com")
                 .nickname("테스터")
+                .imageUrl("upload/test.jpg")
+                .gender(Gender.FEMALE)
+                .age(25)
+                .manner(0.3f)
+                .build());
+        member2 = memberRepository.save(Member.builder()
+                .name("김철수")
+                .email("test2@gmail.com")
+                .nickname("테스터2")
+                .imageUrl("upload/test.jpg")
+                .gender(Gender.FEMALE)
+                .age(25)
+                .manner(0.3f)
+                .build());
+        member3 = memberRepository.save(Member.builder()
+                .name("김영희")
+                .email("test3@gmail.com")
+                .nickname("테스터3")
                 .imageUrl("upload/test.jpg")
                 .gender(Gender.FEMALE)
                 .age(25)
@@ -70,7 +136,7 @@ public class ProfileIntegrationTest {
 
     private void createGoodsPost() {
         goodsPost = goodsPostRepository.save(GoodsPost.builder()
-                .seller(member)
+                .seller(member1)
                 .teamId(1L)
                 .title("test title")
                 .content("test content")
@@ -90,21 +156,66 @@ public class ProfileIntegrationTest {
         goodsPostRepository.save(goodsPost);
     }
 
-    private MockMultipartFile createFile() {
-        return new MockMultipartFile(
-                "files",
-                "test_photo.jpg",
-                MediaType.IMAGE_JPEG_VALUE,
-                "content".getBytes()
-        );
-    }
-
     private LocationInfo createLocationInfo() {
         return LocationInfo.builder()
                 .placeName("Stadium Plaza")
                 .longitude("127.12345")
                 .latitude("37.56789")
                 .build();
+    }
+
+    private void createMatch(LocalDateTime matchTime) {
+        match = matchRepository.save(Match.builder()
+                .homeTeamId(1L)
+                .awayTeamId(2L)
+                .stadiumId(1L)
+                .status(SCHEDULED)
+                .matchTime(matchTime)
+                .build());
+    }
+
+    private void createMatePost() {
+        matePost = mateRepository.save(MatePost.builder()
+                .author(member1)
+                .teamId(1L)
+                .match(match)
+                .title("테스트 제목")
+                .content("테스트 내용")
+                .status(com.example.mate.domain.mate.entity.Status.CLOSED)
+                .maxParticipants(3)
+                .age(Age.TWENTIES)
+                .gender(Gender.FEMALE)
+                .transport(TransportType.PUBLIC)
+                .build());
+    }
+
+    private void createVisit(MatePost post, List<Member> participants) {
+        visit = visitRepository.save(Visit.createForComplete(post, participants));
+    }
+
+    private void createVisitPart() {
+        visitPartRepository.save(VisitPart.builder()
+                .member(member1)
+                .visit(visit)
+                .build());
+        visitPartRepository.save(VisitPart.builder()
+                .member(member2)
+                .visit(visit)
+                .build());
+        visitPartRepository.save(VisitPart.builder()
+                .member(member3)
+                .visit(visit)
+                .build());
+    }
+
+    private void createMateReview(Member reviewer, Member reviewee) {
+        mateReviewRepository.save(MateReview.builder()
+                .visit(visit)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .reviewContent("good")
+                .rating(Rating.GOOD)
+                .build());
     }
 
     @Nested
@@ -115,7 +226,7 @@ public class ProfileIntegrationTest {
         @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회 성공")
         void get_sold_goods_page_success() throws Exception {
             // given
-            Long memberId = member.getId();
+            Long memberId = member1.getId();
             int page = 0;
             int size = 10;
 
@@ -124,7 +235,7 @@ public class ProfileIntegrationTest {
 
             for (int i = 1; i <= 3; i++) {
                 GoodsPost post = GoodsPost.builder()
-                        .seller(member)
+                        .seller(member1)
                         .teamId(10L)
                         .title("Test Title " + i)
                         .content("Test Content " + i)
@@ -159,7 +270,7 @@ public class ProfileIntegrationTest {
         @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회 실패 - 유효하지 않은 회원 아이디로 조회")
         void get_sold_goods_page_invalid_member_id() throws Exception {
             // given
-            Long invalidMemberId = member.getId() + 999L; // 존재하지 않는 회원 ID
+            Long invalidMemberId = member1.getId() + 999L; // 존재하지 않는 회원 ID
             int page = 0;
             int size = 10;
 
@@ -184,9 +295,9 @@ public class ProfileIntegrationTest {
         void get_bought_goods_page_success() throws Exception {
             // given
             Member buyer = memberRepository.save(Member.builder()
-                    .name("김철수")
-                    .email("test2@gmail.com")
-                    .nickname("테스터2")
+                    .name("김희민")
+                    .email("test4@gmail.com")
+                    .nickname("테스터4")
                     .imageUrl("upload/test.jpg")
                     .gender(Gender.MALE)
                     .age(25)
@@ -200,7 +311,7 @@ public class ProfileIntegrationTest {
 
             for (int i = 1; i <= 3; i++) {
                 GoodsPost post = GoodsPost.builder()
-                        .seller(member)
+                        .seller(member1)
                         .buyer(buyer)
                         .teamId(10L)
                         .title("Test Title " + i)
@@ -236,7 +347,7 @@ public class ProfileIntegrationTest {
         @DisplayName("회원 프로필 굿즈 구매기록 페이징 조회 실패 - 유효하지 않은 회원 아이디로 조회")
         void get_bought_goods_page_invalid_member_id() throws Exception {
             // given
-            Long invalidMemberId = member.getId() + 999L; // 존재하지 않는 회원 ID
+            Long invalidMemberId = member1.getId() + 999L; // 존재하지 않는 회원 ID
             int page = 0;
             int size = 10;
 
@@ -249,6 +360,48 @@ public class ProfileIntegrationTest {
                     .andExpect(jsonPath("$.status").value("ERROR"))
                     .andExpect(jsonPath("$.code").value(404))
                     .andExpect(jsonPath("$.message").value("해당 ID의 회원 정보를 찾을 수 없습니다")); // 커스텀 에러 메시지
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 프로필 메이트 후기 페이징 조회")
+    class ProfileMateReviewPage {
+
+        @Test
+        @DisplayName("회원 프로필 메이트 후기 페이징 조회 성공")
+        void get_mate_review_page_success() throws Exception {
+            // given
+            Long memberId = member1.getId();
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/review/mate", memberId)
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageSize())))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(2))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("회원 프로필 메이트 후기 페이징 조회 실패 - 유효하지 않은 회원 아이디로 조회")
+        void get_mate_review_page_fail_invalid_member_id() throws Exception {
+            // given
+            Long invalidMemberId = member1.getId() + 999L; // 존재 하지 않는 아이디
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when & then
+            mockMvc.perform(get("/api/profile/{memberId}/review/mate", invalidMemberId)
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageNumber())))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andExpect(jsonPath("$.message").value("해당 ID의 회원 정보를 찾을 수 없습니다"));
         }
     }
 }

--- a/src/test/java/com/example/mate/domain/member/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/ProfileServiceTest.java
@@ -9,15 +9,20 @@ import static org.mockito.Mockito.verify;
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.constant.Rating;
 import com.example.mate.domain.goods.dto.LocationInfo;
 import com.example.mate.domain.goods.entity.Category;
 import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.GoodsPostImage;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.mate.entity.MateReview;
+import com.example.mate.domain.mate.repository.MateReviewRepositoryCustom;
 import com.example.mate.domain.member.dto.response.MyGoodsRecordResponse;
+import com.example.mate.domain.member.dto.response.MyReviewResponse;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -44,20 +50,25 @@ class ProfileServiceTest {
     @Mock
     private GoodsPostRepository goodsPostRepository;
 
-    private Member seller;
-    private Member buyer;
+    @Mock
+    private MateReviewRepositoryCustom mateReviewRepositoryCustom;
+
+    private Member member1;
+    private Member member2;
     private GoodsPost goodsPost;
     private GoodsPostImage goodsPostImage;
+    private MateReview mateReview;
 
     @BeforeEach
     void setUp() {
         createTestMember();
         createGoodsPost();
         createGoodsPostImage(goodsPost);
+        createMateReview();
     }
 
     private void createTestMember() {
-        seller = Member.builder()
+        member1 = Member.builder()
                 .id(1L)
                 .name("홍길동")
                 .nickname("tester1")
@@ -66,7 +77,7 @@ class ProfileServiceTest {
                 .gender(Gender.MALE)
                 .teamId(1L)
                 .build();
-        buyer = Member.builder()
+        member2 = Member.builder()
                 .id(2L)
                 .name("김영희")
                 .nickname("tester2")
@@ -80,8 +91,8 @@ class ProfileServiceTest {
     private void createGoodsPost() {
         goodsPost = GoodsPost.builder()
                 .id(1L)
-                .seller(seller)
-                .buyer(buyer)
+                .seller(member1)
+                .buyer(member2)
                 .teamId(1L)
                 .title("test title")
                 .content("test content")
@@ -109,6 +120,16 @@ class ProfileServiceTest {
         goodsPost.changeImages(List.of(goodsPostImage));
     }
 
+    private void createMateReview() {
+        mateReview = MateReview.builder()
+                .id(1L)
+                .reviewer(member2)
+                .reviewee(member1)
+                .reviewContent("good")
+                .rating(Rating.GOOD)
+                .build();
+    }
+
     @Nested
     @DisplayName("회원 프로필 굿즈 판매기록 페이징 조회")
     class ProfileSoldGoodsPage {
@@ -122,7 +143,7 @@ class ProfileServiceTest {
             PageImpl<GoodsPost> soldGoodsPage = new PageImpl<>(List.of(goodsPost));
             Pageable pageable = PageRequest.of(0, 10);
 
-            given(memberRepository.findById(memberId)).willReturn(Optional.of(seller));
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member1));
             given(goodsPostRepository.findGoodsPostsBySellerId(memberId, Status.CLOSED, pageable))
                     .willReturn(soldGoodsPage);
 
@@ -174,7 +195,7 @@ class ProfileServiceTest {
             PageImpl<GoodsPost> boughtGoodsPage = new PageImpl<>(List.of(goodsPost));
             Pageable pageable = PageRequest.of(0, 10);
 
-            given(memberRepository.findById(memberId)).willReturn(Optional.of(seller));
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member1));
             given(goodsPostRepository.findGoodsPostsByBuyerId(memberId, Status.CLOSED, pageable))
                     .willReturn(boughtGoodsPage);
 
@@ -210,6 +231,64 @@ class ProfileServiceTest {
                     .hasFieldOrPropertyWithValue("errorCode", MEMBER_NOT_FOUND_BY_ID);
 
             verify(memberRepository).findById(invalidMemberId);
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 프로필 메이트 후기 페이징 조회")
+    class ProfileMateReviewPage {
+
+        @Test
+        @DisplayName("회원 프로필 메이트 후기 페이징 조회 성공")
+        void get_mate_review_page_success() {
+            // given
+            Long memberId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            List<MyReviewResponse> myReviewResponseList = List.of(
+                    new MyReviewResponse(1L, "Title 1", "tester1", "GOOD", "Great!", LocalDateTime.now()),
+                    new MyReviewResponse(2L, "Title 2", "tester2", "GOOD", "Nice!", LocalDateTime.now())
+            );
+
+            Page<MyReviewResponse> mateReviewPage = new PageImpl<>(myReviewResponseList, pageable,
+                    myReviewResponseList.size());
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member1));
+            given(mateReviewRepositoryCustom.findMateReviewsByRevieweeId(memberId, pageable))
+                    .willReturn(mateReviewPage);
+
+            // when
+            PageResponse<MyReviewResponse> response = profileService.getMateReviewPage(memberId, pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).isNotEmpty();
+            assertThat(response.getTotalElements()).isEqualTo(mateReviewPage.getTotalElements());
+            assertThat(response.getContent().size()).isEqualTo(mateReviewPage.getContent().size());
+
+            MyReviewResponse reviewResponse = response.getContent().get(0);
+            assertThat(reviewResponse.getTitle()).isEqualTo(myReviewResponseList.get(0).getTitle());
+            assertThat(reviewResponse.getContent()).isEqualTo(myReviewResponseList.get(0).getContent());
+
+            verify(mateReviewRepositoryCustom).findMateReviewsByRevieweeId(memberId, pageable);
+        }
+
+        @Test
+        @DisplayName("회원 프로필 메이트 후기 페이징 조회 실패 - 유효하지 않은 회원 아이디로 조회")
+        void get_mate_review_page_fail_invalid_member_id() {
+            // given
+            Long invalidMemberId = 999L; // 존재하지 않는 회원 ID
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(memberRepository.findById(invalidMemberId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> profileService.getMateReviewPage(invalidMemberId, pageable))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", MEMBER_NOT_FOUND_BY_ID);
+
+            verify(memberRepository).findById(invalidMemberId);
+
         }
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 회원 프로필에서 메이트 후기 보기 페이징
- [x] QueryDSL을 통해 `mate_review`, `mate_post`, `member` 세 테이블의 필드를 DTO에 바로 매핑

## 💡 자세한 설명

### 메이트 후기 페이징 조회
- 사용자의 최신 정보를 받기 위해 메이트 후기가 남겨긴 최신 순으로, 내림차순으로 조회됩니다.
- 커스텀 인터페이스 `MateReviewRepositoryCustom`과 구현 클래스 `MateReviewRepositoryImpl`을 통해 QueryDSL 사용했습니다.
    - 현재 후기 모아보기 페이지에선, 후기(`MateReview`) 객체와 함께 리뷰어에 대한 정보(`Member.nickname`)와 메이트 구인글(`MatePost`) 정보를 같이 받아와야 합니다.
    - 따라서 쿼리가 테이블을 조인과 동시에 DTO인 `MyReviewResponse`에 해당 필드를 바로 주입하기 용이해보여 사용했습니다.
        - 이 과정에서 QueryDSL에 미숙함이 있어 코드가 지저분합니다.

### 도메인 규칙
- 노션에 메이트 후기 조회에 대한 내용 추가

![스크린샷 2024-12-02 오전 2 41 42](https://github.com/user-attachments/assets/279cadc5-81c9-4054-82be-0b4d54a1d1fa)




## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?