### PR TITLE
MATE-40 : [FEAT] 프로필 굿즈거래 후기 페이징 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsReviewRepositoryCustom.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsReviewRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.mate.domain.goods.repository;
+
+import com.example.mate.domain.member.dto.response.MyReviewResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface GoodsReviewRepositoryCustom {
+
+    Page<MyReviewResponse> findGoodsReviewsByRevieweeId(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsReviewRepositoryImpl.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsReviewRepositoryImpl.java
@@ -1,0 +1,59 @@
+package com.example.mate.domain.goods.repository;
+
+import com.example.mate.domain.goods.entity.QGoodsPost;
+import com.example.mate.domain.goods.entity.QGoodsReview;
+import com.example.mate.domain.member.dto.response.MyReviewResponse;
+import com.example.mate.domain.member.entity.QMember;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class GoodsReviewRepositoryImpl implements GoodsReviewRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MyReviewResponse> findGoodsReviewsByRevieweeId(Long revieweeId, Pageable pageable) {
+        QGoodsReview goodsReview = QGoodsReview.goodsReview;
+        QGoodsPost goodsPost = QGoodsPost.goodsPost;
+        QMember member = QMember.member;
+
+        // 'created_at' 기준 내림차순으로 고정된 정렬
+        OrderSpecifier<LocalDateTime> desc = goodsReview.createdAt.desc();
+
+        // 페이징 처리된 데이터 조회
+        List<MyReviewResponse> results = queryFactory
+                .select(Projections.constructor(
+                        MyReviewResponse.class,
+                        goodsPost.id.as("postId"),
+                        goodsPost.title.as("title"),
+                        member.nickname.as("nickname"),
+                        goodsReview.rating.stringValue().as("rating"),
+                        goodsReview.reviewContent.as("content"),
+                        goodsReview.createdAt.as("createdAt")
+                ))
+                .from(goodsReview)
+                .join(goodsReview.goodsPost, goodsPost)
+                .join(goodsReview.reviewer, member)
+                .where(goodsReview.reviewee.id.eq(revieweeId))
+                .orderBy(desc)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> total = queryFactory
+                .select(goodsReview.count())
+                .from(goodsReview)
+                .where(goodsReview.reviewee.id.eq(revieweeId));
+
+        return PageableExecutionUtils.getPage(results, pageable, total::fetchOne);
+    }
+}

--- a/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
@@ -32,30 +32,18 @@ public class ProfileController {
 
     private final ProfileService profileService;
 
-    /*
-    TODO : 2024/11/24 - 굿즈거래 후기 페이징 조회
-    1. memberId 을 통해 회원 정보 조회
-    2. 회원이 받은 굿즈거래 후기 조회
-    3. 페이징 처리 후 반환
-    */
+    @Operation(summary = "굿즈거래 후기 페이징 조회")
     @GetMapping("/{memberId}/review/goods")
-    public ResponseEntity<Page<MyReviewResponse>> getGoodsReviews(
-            @PathVariable Long memberId,
-            @PageableDefault(size = 10) Pageable pageable
+    public ResponseEntity<ApiResponse<PageResponse<MyReviewResponse>>> getGoodsReviews(
+            @Parameter(description = "회원 ID") @PathVariable Long memberId,
+            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
     ) {
-        MyReviewResponse myReviewResponse = MyReviewResponse.goodsFrom();
-        List<MyReviewResponse> responses = Collections.nCopies(10, myReviewResponse);
-        Page<MyReviewResponse> page = new PageImpl<>(responses, pageable, responses.size());
-
-        return ResponseEntity.ok(page);
+        validatePageable(pageable);
+        PageResponse<MyReviewResponse> response = profileService.getGoodsReviewPage(memberId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /*
-    TODO : 2024/11/24 - 메이트 후기 페이징 조회
-    1. memberId 을 통해 회원 정보 조회
-    2. 회원이 받은 메이트 후기 조회
-    3. 페이징 처리 후 반환
-    */
+    @Operation(summary = "메이트 후기 페이징 조회")
     @GetMapping("{memberId}/review/mate")
     public ResponseEntity<ApiResponse<PageResponse<MyReviewResponse>>> getMateReviews(
             @Parameter(description = "회원 ID") @PathVariable Long memberId,

--- a/src/main/java/com/example/mate/domain/member/service/ProfileService.java
+++ b/src/main/java/com/example/mate/domain/member/service/ProfileService.java
@@ -7,7 +7,7 @@ import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.GoodsPostImage;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
-import com.example.mate.domain.mate.repository.MateReviewRepository;
+import com.example.mate.domain.goods.repository.GoodsReviewRepositoryCustom;
 import com.example.mate.domain.mate.repository.MateReviewRepositoryCustom;
 import com.example.mate.domain.member.dto.response.MyGoodsRecordResponse;
 import com.example.mate.domain.member.dto.response.MyReviewResponse;
@@ -26,8 +26,8 @@ public class ProfileService {
 
     private final MemberRepository memberRepository;
     private final GoodsPostRepository goodsPostRepository;
-    private final MateReviewRepository mateReviewRepository;
     private final MateReviewRepositoryCustom mateReviewRepositoryCustom;
+    private final GoodsReviewRepositoryCustom goodsReviewRepositoryCustom;
 
     // 굿즈 판매기록 페이징 조회
     @Transactional(readOnly = true)
@@ -90,6 +90,7 @@ public class ProfileService {
     }
 
     // 메이트 후기 페이징 조회
+    @Transactional(readOnly = true)
     public PageResponse<MyReviewResponse> getMateReviewPage(Long memberId, Pageable pageable) {
         validateMemberId(memberId);
 
@@ -103,6 +104,24 @@ public class ProfileService {
                 .hasNext(mateReviewPage.hasNext())
                 .pageNumber(mateReviewPage.getNumber())
                 .pageSize(mateReviewPage.getSize())
+                .build();
+    }
+
+    // 굿즈거래 후기 페이징 조회
+    @Transactional(readOnly = true)
+    public PageResponse<MyReviewResponse> getGoodsReviewPage(Long memberId, Pageable pageable) {
+        validateMemberId(memberId);
+
+        Page<MyReviewResponse> goodsReviewPage = goodsReviewRepositoryCustom.findGoodsReviewsByRevieweeId(
+                memberId, pageable);
+
+        return PageResponse.<MyReviewResponse>builder()
+                .content(goodsReviewPage.getContent())
+                .totalPages(goodsReviewPage.getTotalPages())
+                .totalElements(goodsReviewPage.getTotalElements())
+                .hasNext(goodsReviewPage.hasNext())
+                .pageNumber(goodsReviewPage.getNumber())
+                .pageSize(goodsReviewPage.getSize())
                 .build();
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 프로필 굿즈거래 후기 페이징 조회
- [x] QueryDSL을 통해 goods_review, goods_post, member 세 테이블의 필드를 DTO에 바로 매핑
- [x] 테스트 코드

## 💡 자세한 설명

### 굿즈거래 후기 페이징 조회
- 사용자의 최신 정보를 받기 위해 굿즈 후기가 남겨긴 최신 순으로, 내림차순으로 조회됩니다.
- 커스텀 인터페이스 `GoodsReviewRepositoryCustom`과 구현 클래스 `GoodsReviewRepositoryImpl`을 통해 QueryDSL 사용했습니다.
    - 현재 후기 모아보기 페이지에선, 후기(`GoodsReview`) 객체와 함께 리뷰어에 대한 정보(`Member.nickname`)와 메이트 구인글(`GoodsPost`) 정보를 같이 받아와야 합니다.
    - 따라서 쿼리가 테이블을 조인과 동시에 DTO인 `MyReviewResponse`에 해당 필드를 바로 주입하기 용이해보여 사용했습니다.
    - TODO : 추후 Repository 테스트 추가


### 도메인 규칙
- 노션에 굿즈거래 후기 조회에 대한 내용 추가

![스크린샷 2024-12-02 오후 2 41 04](https://github.com/user-attachments/assets/4b413587-61df-492a-97f0-2e7550f2d2fe)



## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?