### PR TITLE
MATE-69 : [FEAT] 메이트 게시글 기능 반환값 추가 및 조회 정렬기준 수정 

### DIFF
--- a/src/main/java/com/example/mate/common/utils/file/FileValidator.java
+++ b/src/main/java/com/example/mate/common/utils/file/FileValidator.java
@@ -26,7 +26,6 @@ public class FileValidator {
 
     // 메이트 게시글 이미지 파일 유효성 검사
     public static void validateMatePostImage(MultipartFile file) {
-        validateNotEmpty(file);
         isNotImage(file);
     }
 

--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -89,7 +89,7 @@ public class MateController {
 
 
     // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
-    // 메이트 게시글 모집 상태 변경(모집중, 모집완료)
+    // 메이트 게시글 모집 상태 변경
     @PatchMapping("/{memberId}/{postId}/status")
     public ResponseEntity<ApiResponse<MatePostResponse>> updateMatePostStatus(@PathVariable(value = "memberId") Long memberId,
                                                                               @PathVariable(value = "postId") Long postId,
@@ -100,7 +100,15 @@ public class MateController {
     }
 
     // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
-    // 메이트 게시글 직관 완료로 상태 변경
+    // 메이트 게시글 삭제
+    @DeleteMapping("/{memberId}/{postId}")
+    public ResponseEntity<Void> deleteMatePost(@PathVariable Long memberId, @PathVariable Long postId) {
+        mateService.deleteMatePost(memberId, postId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
+    // 직관 완료 처리
     @PatchMapping("/{memberId}/{postId}/complete")
     public ResponseEntity<ApiResponse<MatePostCompleteResponse>> completeVisit(@PathVariable Long memberId,
                                                                                @PathVariable Long postId,
@@ -108,14 +116,6 @@ public class MateController {
 
         MatePostCompleteResponse response = mateService.completeVisit(memberId, postId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
-    }
-
-    // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
-    // 메이트 게시글 삭제
-    @DeleteMapping("/{memberId}/{postId}")
-    public ResponseEntity<Void> deleteMatePost(@PathVariable Long memberId, @PathVariable Long postId) {
-        mateService.deleteMatePost(memberId, postId);
-        return ResponseEntity.noContent().build();
     }
 
     // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경

--- a/src/main/java/com/example/mate/domain/mate/dto/response/MatePostDetailResponse.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/response/MatePostDetailResponse.java
@@ -18,6 +18,7 @@ public class MatePostDetailResponse {
     private String postImageUrl;
     private String title;
     private Status status;
+    private String myTeamName;
     private String rivalTeamName;
     private LocalDateTime rivalMatchTime;
     private String location;
@@ -32,11 +33,15 @@ public class MatePostDetailResponse {
     private Long postId;
 
     public static MatePostDetailResponse from(MatePost post) {
+        String myTeamName = TeamInfo.getById(post.getTeamId()).shortName;
+        String rivalTeamName = getRivalTeamName(post);
+
         return MatePostDetailResponse.builder()
                 .postImageUrl(post.getImageUrl())
                 .title(post.getTitle())
                 .status(post.getStatus())
-                .rivalTeamName(getRivalTeamName(post))
+                .myTeamName(myTeamName)
+                .rivalTeamName(rivalTeamName)
                 .rivalMatchTime(post.getMatch().getMatchTime())
                 .location(post.getMatch().getStadium().name)
                 .age(post.getAge())
@@ -53,13 +58,11 @@ public class MatePostDetailResponse {
 
     private static String getRivalTeamName(MatePost post) {
         Match match = post.getMatch();
-        Long postTeamId = post.getTeamId(); // 게시글 작성자가 선택한 팀
+        Long postTeamId = post.getTeamId();
 
-        // 게시글 작성자가 선택한 팀이 홈팀인 경우 원정팀이 상대팀
         if (postTeamId.equals(match.getHomeTeamId())) {
             return TeamInfo.getById(match.getAwayTeamId()).shortName;
         }
-        // 게시글 작성자가 선택한 팀이 원정팀인 경우 홈팀이 상대팀
         else {
             return TeamInfo.getById(match.getHomeTeamId()).shortName;
         }

--- a/src/main/java/com/example/mate/domain/mate/dto/response/MatePostSummaryResponse.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/response/MatePostSummaryResponse.java
@@ -27,6 +27,7 @@ public class MatePostSummaryResponse {
     private Age age;
     private Gender gender;
     private TransportType transportType;
+    private Long postId;
 
     public static MatePostSummaryResponse from(MatePost post) {
         // 게시글 작성자의 팀이 myTeam
@@ -45,6 +46,7 @@ public class MatePostSummaryResponse {
                 .age(post.getAge())
                 .gender(post.getGender())
                 .transportType(post.getTransport())
+                .postId(post.getId())
                 .build();
     }
 

--- a/src/main/java/com/example/mate/domain/mate/entity/MatePost.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/MatePost.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.mate.entity;
 
+import com.example.mate.common.BaseTimeEntity;
 import com.example.mate.common.error.CustomException;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.constant.TeamInfo;
@@ -20,7 +21,7 @@ import static com.example.mate.common.error.ErrorCode.DIRECT_VISIT_COMPLETE_FORB
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class MatePost {
+public class MatePost extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")

--- a/src/main/java/com/example/mate/domain/mate/entity/TransportType.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/TransportType.java
@@ -10,9 +10,7 @@ import lombok.Getter;
 public enum TransportType {
     ANY("상관없음"),
     PUBLIC("대중교통"),
-    CAR("자차"),
-    CARPOOL("카풀");
-
+    CAR("자차");
     @JsonValue
     private final String value;
 

--- a/src/main/java/com/example/mate/domain/mate/repository/MateRepositoryImpl.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateRepositoryImpl.java
@@ -84,14 +84,13 @@ public class MateRepositoryImpl implements MateRepositoryCustom{
                                                    QMatch match,
                                                    QMember author) {
         if (sortType == null) {
-            return new OrderSpecifier<>(Order.DESC, matePost.id); // 기본 정렬
+            return new OrderSpecifier<>(Order.DESC, matePost.createdAt); // 기본 정렬
         }
 
         return switch (sortType) {
-            case LATEST -> new OrderSpecifier<>(Order.DESC, matePost.id);
+            case LATEST -> new OrderSpecifier<>(Order.DESC, matePost.createdAt);
             case MATCH_TIME -> new OrderSpecifier<>(Order.ASC, match.matchTime);
             case MANNER -> new OrderSpecifier<>(Order.DESC, author.manner);
-            default -> new OrderSpecifier<>(Order.DESC, matePost.id);
         };
     }
 }

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -17,7 +17,7 @@ import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.mate.repository.MateReviewRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -65,6 +65,7 @@ public class MateService {
         return MatePostResponse.from(savedPost);
     }
 
+    @Transactional(readOnly = true)
     public List<MatePostSummaryResponse> getMainPagePosts(Long teamId) {
         if (teamId != null && !TeamInfo.existById(teamId)) {
             throw new CustomException(TEAM_NOT_FOUND);
@@ -84,6 +85,7 @@ public class MateService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public PageResponse<MatePostSummaryResponse> getMatePagePosts(MatePostSearchRequest request, Pageable pageable) {
         if (request.getTeamId()!= null && !TeamInfo.existById(request.getTeamId())) {
             throw new CustomException(TEAM_NOT_FOUND);
@@ -105,6 +107,7 @@ public class MateService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public MatePostDetailResponse getMatePostDetail(Long postId) {
         MatePost matePost = findMatePostById(postId);
 
@@ -143,15 +146,19 @@ public class MateService {
     }
 
     private String updateImage(String currentImageUrl, MultipartFile newFile) {
-        if (newFile == null) {
+        if (newFile == null || newFile.isEmpty()) {
             return currentImageUrl;
         }
 
+        // 새 파일이 있는 경우에만 유효성 검증 수행
+        FileValidator.validateMatePostImage(newFile);
+
+        // 기존 파일이 있으면 삭제
         if (currentImageUrl != null) {
             FileUploader.deleteFile(currentImageUrl);
         }
 
-        FileValidator.validateMatePostImage(newFile);
+        // 새 파일 업로드
         return FileUploader.uploadFile(newFile);
     }
 

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -17,12 +17,12 @@ import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.mate.repository.MateReviewRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
-import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
@@ -171,6 +171,19 @@ public class MateService {
         return MatePostResponse.from(matePost);
     }
 
+    public void deleteMatePost(Long memberId, Long postId) {
+        MatePost matePost = mateRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND_BY_ID));
+
+        validateAuthorization(matePost, memberId);
+
+        if (matePost.getStatus() == Status.VISIT_COMPLETE) {
+            matePost.getVisit().detachPost();
+        }
+
+        mateRepository.delete(matePost);
+    }
+
     public MatePostCompleteResponse completeVisit(Long memberId, Long postId, MatePostCompleteRequest request) {
         MatePost matePost = findMatePostById(postId);
         validateAuthorization(matePost, memberId);
@@ -184,6 +197,11 @@ public class MateService {
         return MatePostCompleteResponse.from(matePost);
     }
 
+    private void validateAuthorization(MatePost matePost, Long memberId) {
+        if (!matePost.getAuthor().getId().equals(memberId)) {
+            throw new CustomException(MATE_POST_UPDATE_NOT_ALLOWED);
+        }
+    }
 
     private void validateCompletionTime(MatePost matePost) {
         if (matePost.getMatch().getMatchTime().isAfter(LocalDateTime.now())) {
@@ -215,19 +233,6 @@ public class MateService {
         if (totalParticipantCount > maxParticipants) {
             throw new CustomException(MATE_POST_MAX_PARTICIPANTS_EXCEEDED);
         }
-    }
-
-    public void deleteMatePost(Long memberId, Long postId) {
-        MatePost matePost = mateRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND_BY_ID));
-
-        validateAuthorization(matePost, memberId);
-
-        if (matePost.getStatus() == Status.VISIT_COMPLETE) {
-            matePost.getVisit().detachPost();
-        }
-
-        mateRepository.delete(matePost);
     }
 
     public MateReviewCreateResponse createReview(Long postId, Long reviewerId, MateReviewCreateRequest request) {
@@ -284,12 +289,5 @@ public class MateService {
     private MatePost findMatePostById(Long postId) {
         return mateRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND_BY_ID));
-    }
-
-
-    private void validateAuthorization(MatePost matePost, Long memberId) {
-        if (!matePost.getAuthor().getId().equals(memberId)) {
-            throw new CustomException(MATE_POST_UPDATE_NOT_ALLOWED);
-        }
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 메이트 게시글 메인 페이지 조회 반환값에 postId 추가
- [x] 메이트 게시글 필터링 조회 반환값에 postId 추가
- [x] 메이트 게시글 상세조회 반환값에 응원팀 이름 추가
- [x] 메이트 게시글의 Enum클래스인 TransPostType에 CARPOOL("카풀") 필드 제거
- [x] 메이트 게시글 필터링 조회 정렬 기준 수정

## 💡 자세한 설명
반환값에 대한 작업이라 코드는 안보셔도 되고 작업 내용의 글만 보셔도 될 것 같습니다.

MatePost 엔티티에 BaseTimeEntity를 적용 후,  메이트 페이지에서 게시글 조회 시 기본적으로 최신 게시물순으로 정렬되도록 (createdAt 이용)수정했습니다. (원래 postId 순으로 정렬했었습니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?