### PR TITLE
MATE-65 : [FEAT] 메이트 게시글 수정, 삭제 제약조건 추가

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -48,7 +48,7 @@ public enum ErrorCode {
     MATE_POST_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MP006", "메이트 게시글의 작성자가 아니라면, 게시글을 수정할 수 없습니다"),
     DIRECT_VISIT_COMPLETE_FORBIDDEN(HttpStatus.FORBIDDEN, "MP007", "모집완료 상태가 아니라면 직관 완료 상태로 게시글을 수정할 수 없습니다"),
     MATE_POST_COMPLETE_TIME_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MP008", "경기 시작 이후에만 직관 완료 처리가 가능합니다."),
-    ALREADY_COMPLETED_POST(HttpStatus.FORBIDDEN, "MP009", "이미 직관완료한 게시글은 모집 상태를 변경할 수 없습니다."),
+    ALREADY_COMPLETED_POST(HttpStatus.FORBIDDEN, "MP009", "이미 직관완료한 게시글은 수정하거나 삭제할 수 없습니다."),
     MATE_POST_PARTICIPANTS_NOT_FOUND(HttpStatus.BAD_REQUEST, "MP010", "직관 참여자 목록이 비어있습니다."),
     VISIT_COMPLETE_POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "MP0011", "직관 완료된 게시글은 삭제할 수 없습니다"),
     MATE_POST_MAX_PARTICIPANTS_EXCEEDED(HttpStatus.BAD_REQUEST, "MP0012", "참여자 수가 최대 모집 인원을 초과했습니다"),

--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -103,6 +103,7 @@ public class MateController {
     // 메이트 게시글 삭제
     @DeleteMapping("/{memberId}/{postId}")
     public ResponseEntity<Void> deleteMatePost(@PathVariable Long memberId, @PathVariable Long postId) {
+
         mateService.deleteMatePost(memberId, postId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MatePostStatusRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MatePostStatusRequest.java
@@ -2,10 +2,14 @@ package com.example.mate.domain.mate.dto.request;
 
 import com.example.mate.common.utils.validator.ValidEnum;
 import com.example.mate.domain.mate.entity.Status;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -14,4 +18,9 @@ import lombok.NoArgsConstructor;
 public class MatePostStatusRequest {
     @ValidEnum(message = "모집 상태의 입력 값이 잘못되었습니다.", enumClass = Status.class)
     private Status status;
+
+    @NotNull(message = "참여자 목록은 필수입니다")
+    @Size(min = 1, message = "최소 1명 이상의 참여자가 필요합니다")
+    @Size(max = 9, message = "방장 포함 최대 10명까지만 참여할 수 있습니다")
+    private List<Long> participantIds;
 }

--- a/src/main/java/com/example/mate/domain/mate/entity/Visit.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/Visit.java
@@ -32,10 +32,6 @@ public class Visit {
     @Builder.Default
     private List<MateReview> reviews = new ArrayList<>();
 
-    public void detachPost() {
-        this.post = null;
-    }
-
     public static Visit createForComplete(MatePost post, List<Member> participants) {
         Visit visit = Visit.builder()
                 .post(post)

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -161,6 +161,10 @@ public class MateService {
 
         validateAuthorization(matePost, memberId);
         validatePostStatus(matePost.getStatus());
+
+        if(request.getStatus() == Status.CLOSED) {
+            findAndValidateParticipants(request.getParticipantIds(), matePost.getMaxParticipants());
+        }
         matePost.changeStatus(request.getStatus());
 
         return MatePostResponse.from(matePost);

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -128,12 +128,6 @@ public class MateService {
         return MatePostResponse.from(matePost);
     }
 
-    private void validatePostStatus(Status status) {
-        if (status == Status.VISIT_COMPLETE) {
-            throw new CustomException(ALREADY_COMPLETED_POST);
-        }
-    }
-
     private void validateTeamId(Long teamId) {
         if (!TeamInfo.existById(teamId)) {
             throw new CustomException(TEAM_NOT_FOUND);
@@ -166,22 +160,25 @@ public class MateService {
         MatePost matePost = findMatePostById(postId);
 
         validateAuthorization(matePost, memberId);
+        validatePostStatus(matePost.getStatus());
         matePost.changeStatus(request.getStatus());
 
         return MatePostResponse.from(matePost);
     }
 
     public void deleteMatePost(Long memberId, Long postId) {
-        MatePost matePost = mateRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(MATE_POST_NOT_FOUND_BY_ID));
+        MatePost matePost = findMatePostById(postId);
 
         validateAuthorization(matePost, memberId);
-
-        if (matePost.getStatus() == Status.VISIT_COMPLETE) {
-            matePost.getVisit().detachPost();
-        }
+        validatePostStatus(matePost.getStatus());
 
         mateRepository.delete(matePost);
+    }
+
+    private void validatePostStatus(Status status) {
+        if (status == Status.VISIT_COMPLETE) {
+            throw new CustomException(ALREADY_COMPLETED_POST);
+        }
     }
 
     public MatePostCompleteResponse completeVisit(Long memberId, Long postId, MatePostCompleteRequest request) {

--- a/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
+++ b/src/test/java/com/example/mate/domain/mate/controller/MateControllerTest.java
@@ -637,7 +637,7 @@ class MateControllerTest {
                     .andDo(print())
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.status").value("ERROR"))
-                    .andExpect(jsonPath("$.message").value("이미 직관완료한 게시글은 모집 상태를 변경할 수 없습니다."));
+                    .andExpect(jsonPath("$.message").value(ALREADY_COMPLETED_POST.getMessage()));
         }
     }
 

--- a/src/test/java/com/example/mate/domain/mate/integration/MateStatusIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/mate/integration/MateStatusIntegrationTest.java
@@ -159,7 +159,7 @@ public class MateStatusIntegrationTest {
         @DisplayName("모집완료에서 모집중으로 상태 변경 성공")
         void updateMatePostStatus_ClosedToOpen_Success() throws Exception {
             // given
-            List<Long> participantIds = Arrays.asList(participant1.getId());  // 최소 1명의 참여자 필요
+            List<Long> participantIds = Collections.singletonList(participant1.getId());  // 최소 1명의 참여자 필요
             MatePostStatusRequest request = new MatePostStatusRequest(Status.OPEN, participantIds);
 
             // when & then
@@ -204,7 +204,7 @@ public class MateStatusIntegrationTest {
         @DisplayName("이미 직관완료된 게시글 상태 변경 시도시 실패")
         void updateMatePostStatus_AlreadyCompleted_Failure() throws Exception {
             // given
-            List<Long> participantIds = Arrays.asList(participant1.getId());  // 최소 1명의 참여자 필요
+            List<Long> participantIds = Collections.singletonList(participant1.getId());  // 최소 1명의 참여자 필요
             MatePostStatusRequest request = new MatePostStatusRequest(Status.OPEN, participantIds);
 
             // when & then

--- a/src/test/java/com/example/mate/domain/mate/service/MateServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateServiceTest.java
@@ -911,7 +911,7 @@ class MateServiceTest {
                     .match(testMatch)
                     .title("테스트 제목")
                     .content("테스트 내용")
-                    .status(Status.VISIT_COMPLETE)
+                    .status(Status.OPEN)
                     .maxParticipants(4)
                     .age(Age.TWENTIES)
                     .gender(Gender.ANY)

--- a/src/test/java/com/example/mate/domain/mate/service/MateStatusServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateStatusServiceTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -261,7 +262,7 @@ class MateStatusServiceTest {
                     .build();
 
             List<Long> participantIds = Arrays.asList(2L, 3L);
-            List<Member> participants = Arrays.asList(Member.builder().id(2L).build()); // 하나만 존재
+            List<Member> participants = Collections.singletonList(Member.builder().id(2L).build()); // 하나만 존재
 
             MatePostStatusRequest request = new MatePostStatusRequest(Status.CLOSED, participantIds);
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 메이트 게시글 수정, 삭제 제약 조건 추가
- [x] 제약 조건 추가에 따른 테스트 코드 수정
- [x] 메이트 게시글 상태 변경 시 참여자 수 제한 제약조건 추가
- [x] 테스트코드 변경

## 💡 자세한 설명
메이트 게시글 수정 시, 직관완료한 상태라면 수정 불가 조건 추가
메이트 게시글 삭제 시, 직관완료한 상태라면 삭제 불가 조건 추가
메이트 게시글 상태 변경 시 참여인원 10명 초과 불가 조건 추가

![image](https://github.com/user-attachments/assets/b93e0fac-8239-4098-b81d-8ae35cf0d51d)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?