### PR TITLE
MATE-72 : [FEAT] 경기 전적 조회 기능 수정

### DIFF
--- a/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
@@ -15,9 +15,16 @@ import java.util.Optional;
 public interface MatchRepository extends JpaRepository<Match, Long> {
     List<Match> findTop5ByOrderByMatchTimeDesc();
     List<Match> findTop3ByHomeTeamIdOrAwayTeamIdOrderByMatchTimeDesc(Long homeTeamId, Long awayTeamId);
-    List<Match> findByStatusAndHomeTeamIdOrStatusAndAwayTeamIdOrderByMatchTimeDesc(
-            MatchStatus status1, Long homeTeamId,
-            MatchStatus status2, Long awayTeamId
+    @Query("SELECT m FROM Match m " +
+            "WHERE (m.status = :status1 AND m.homeTeamId = :homeTeamId) " +
+            "OR (m.status = :status2 AND m.awayTeamId = :awayTeamId) " +
+            "ORDER BY m.matchTime DESC " +
+            "LIMIT 6")
+    List<Match> findRecentCompletedMatches(
+            @Param("status1") MatchStatus status1,
+            @Param("homeTeamId") Long homeTeamId,
+            @Param("status2") MatchStatus status2,
+            @Param("awayTeamId") Long awayTeamId
     );
     @Query("SELECT m FROM Match m WHERE (m.homeTeamId = :teamId OR m.awayTeamId = :teamId) " +
             "AND m.matchTime BETWEEN :startDate AND :endDate " +

--- a/src/main/java/com/example/mate/domain/match/service/MatchService.java
+++ b/src/main/java/com/example/mate/domain/match/service/MatchService.java
@@ -14,8 +14,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.TemporalAdjusters;
-import java.time.temporal.WeekFields;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -48,7 +46,7 @@ public class MatchService {
     public List<MatchResponse> getTeamCompletedMatches(Long teamId) {
         TeamInfo.getById(teamId);
 
-        return matchRepository.findByStatusAndHomeTeamIdOrStatusAndAwayTeamIdOrderByMatchTimeDesc(
+        return matchRepository.findRecentCompletedMatches(
                         MatchStatus.COMPLETED, teamId,
                         MatchStatus.COMPLETED, teamId)
                 .stream()

--- a/src/main/java/com/example/mate/domain/match/service/WeatherService.java
+++ b/src/main/java/com/example/mate/domain/match/service/WeatherService.java
@@ -21,7 +21,7 @@ public class WeatherService {
     private final MatchRepository matchRepository;
     private final WeatherApiClient weatherApiClient;
 
-    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void updateWeatherForUpcomingMatches() {
         LocalDateTime now = LocalDateTime.now();

--- a/src/test/java/com/example/mate/domain/match/controller/MatchControllerTest.java
+++ b/src/test/java/com/example/mate/domain/match/controller/MatchControllerTest.java
@@ -171,18 +171,62 @@ class MatchControllerTest {
                                 .awayScore(3)
                                 .isCanceled(false)
                                 .build(),
-                        teamId),
+                        TeamInfo.LG.id),
                 MatchResponse.from(Match.builder()
-                                .homeTeamId(TeamInfo.KIA.id)
+                                .homeTeamId(TeamInfo.DOOSAN.id)
                                 .awayTeamId(TeamInfo.LG.id)
-                                .stadiumId(StadiumInfo.GWANGJU.id)
+                                .stadiumId(StadiumInfo.JAMSIL.id)
                                 .matchTime(LocalDateTime.now().minusDays(2))
                                 .status(MatchStatus.COMPLETED)
                                 .homeScore(2)
+                                .awayScore(6)
+                                .isCanceled(false)
+                                .build(),
+                        TeamInfo.LG.id),
+                MatchResponse.from(Match.builder()
+                                .homeTeamId(TeamInfo.LG.id)
+                                .awayTeamId(TeamInfo.SAMSUNG.id)
+                                .stadiumId(StadiumInfo.JAMSIL.id)
+                                .matchTime(LocalDateTime.now().minusDays(3))
+                                .status(MatchStatus.COMPLETED)
+                                .homeScore(8)
+                                .awayScore(4)
+                                .isCanceled(false)
+                                .build(),
+                        TeamInfo.LG.id),
+                MatchResponse.from(Match.builder()
+                                .homeTeamId(TeamInfo.KIWOOM.id)
+                                .awayTeamId(TeamInfo.LG.id)
+                                .stadiumId(StadiumInfo.GOCHEOK.id)
+                                .matchTime(LocalDateTime.now().minusDays(4))
+                                .status(MatchStatus.COMPLETED)
+                                .homeScore(1)
                                 .awayScore(7)
                                 .isCanceled(false)
                                 .build(),
-                        teamId)
+                        TeamInfo.LG.id),
+                MatchResponse.from(Match.builder()
+                                .homeTeamId(TeamInfo.LG.id)
+                                .awayTeamId(TeamInfo.NC.id)
+                                .stadiumId(StadiumInfo.JAMSIL.id)
+                                .matchTime(LocalDateTime.now().minusDays(5))
+                                .status(MatchStatus.COMPLETED)
+                                .homeScore(3)
+                                .awayScore(3)
+                                .isCanceled(false)
+                                .build(),
+                        TeamInfo.LG.id),
+                MatchResponse.from(Match.builder()
+                                .homeTeamId(TeamInfo.HANWHA.id)
+                                .awayTeamId(TeamInfo.LG.id)
+                                .stadiumId(StadiumInfo.DAEJEON.id)
+                                .matchTime(LocalDateTime.now().minusDays(6))
+                                .status(MatchStatus.COMPLETED)
+                                .homeScore(4)
+                                .awayScore(9)
+                                .isCanceled(false)
+                                .build(),
+                        TeamInfo.LG.id)
         );
         when(matchService.getTeamCompletedMatches(teamId)).thenReturn(mockResponses);
 
@@ -191,12 +235,8 @@ class MatchControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data", hasSize(2)))
-                .andExpect(jsonPath("$.data[0].status").value("COMPLETED"))
-                .andExpect(jsonPath("$.data[0].homeScore").value(5))
-                .andExpect(jsonPath("$.data[1].awayScore").value(7));
+                .andExpect(jsonPath("$.data", hasSize(mockResponses.size())));  // 동적으로 크기 체크
     }
 
     @Test

--- a/src/test/java/com/example/mate/domain/match/integration/MatchIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/match/integration/MatchIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -135,14 +136,20 @@ class MatchIntegrationTest {
     @DisplayName("팀별 완료된 경기 조회 - 성공")
     void getTeamCompletedMatches_Success() throws Exception {
         // given
-        LocalDateTime pastTime1 = LocalDateTime.now().minusDays(1);
-        LocalDateTime pastTime2 = LocalDateTime.now().minusDays(2);
-
-        Match completedMatch1 = createCompletedMatch(TeamInfo.LG.id, TeamInfo.KT.id, StadiumInfo.JAMSIL.id, pastTime1, 5, 3);
-        Match completedMatch2 = createCompletedMatch(TeamInfo.KIA.id, TeamInfo.LG.id, StadiumInfo.GWANGJU.id, pastTime2, 2, 7);
-        Match scheduledMatch = createMatch(TeamInfo.LG.id, TeamInfo.NC.id, StadiumInfo.JAMSIL.id, LocalDateTime.now().plusDays(1));
-
-        matchRepository.saveAll(Arrays.asList(completedMatch1, completedMatch2, scheduledMatch));
+        LocalDateTime now = LocalDateTime.now();
+        List<Match> matches = new ArrayList<>();
+        // 7개의 완료된 경기 생성
+        for (int i = 1; i <= 7; i++) {
+            matches.add(createCompletedMatch(
+                    TeamInfo.LG.id,
+                    TeamInfo.KT.id,
+                    StadiumInfo.JAMSIL.id,
+                    now.minusDays(i),
+                    5 + i,
+                    3 + i
+            ));
+        }
+        matchRepository.saveAll(matches);
 
         // when
         ResultActions result = mockMvc.perform(get("/api/matches/team/{teamId}/completed", TeamInfo.LG.id)
@@ -152,12 +159,8 @@ class MatchIntegrationTest {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].status").value("COMPLETED"))
-                .andExpect(jsonPath("$.data[0].homeTeam.id").value(TeamInfo.LG.id))
-                .andExpect(jsonPath("$.data[0].homeScore").value(5))
-                .andExpect(jsonPath("$.data[1].awayTeam.id").value(TeamInfo.LG.id))
-                .andExpect(jsonPath("$.data[1].awayScore").value(7));
+                .andExpect(jsonPath("$.data.length()").value(6))  // 최대 6개만 조회되는지 확인
+                .andExpect(jsonPath("$.data[0].status").value("COMPLETED"));
     }
 
     private Match createCompletedMatch(Long homeTeamId, Long awayTeamId, Long stadiumId,


### PR DESCRIPTION
## 💡 작업 내용

- [x] 경기 전적 조회를 최대 6개만 가능하도록 변경

## 💡 자세한 설명
이전 경기 전적 조회는 개수 제한없이 조회가 가능하였는데 이를 최대 6개로 제한

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?