### PR TITLE
MATE-73: [FEAT] 굿즈거래 채팅방 생성 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -68,6 +68,10 @@ public enum ErrorCode {
     GOODS_REVIEW_NOT_ALLOWED_FOR_NON_BUYER(HttpStatus.FORBIDDEN, "GR002", "굿즈거래 후기는 구매자만 작성할 수 있습니다."),
     GOODS_REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "GR003", "굿즈거래 후기는 한 번만 작성할 수 있습니다."),
 
+    // Goods Chat
+    GOODS_CHAT_CLOSED_POST(HttpStatus.BAD_REQUEST, "GC001", "거래완료된 판매글에 채팅을 시작할 수 없습니다."),
+    GOODS_CHAT_SELLER_CANNOT_START(HttpStatus.BAD_REQUEST, "GC002", "자신의 판매글에 채팅을 시작할 수 없습니다."),
+
     // Mate Review
     NOT_PARTICIPANT_OR_AUTHOR(HttpStatus.FORBIDDEN, "R002", "리뷰어와 리뷰 대상자 모두 직관 참여자여야 합니다."),
     SELF_REVIEW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "R004", "자기 자신에 대한 리뷰는 작성할 수 없습니다."),

--- a/src/main/java/com/example/mate/domain/goods/controller/GoodsChatController.java
+++ b/src/main/java/com/example/mate/domain/goods/controller/GoodsChatController.java
@@ -1,9 +1,0 @@
-package com.example.mate.domain.goods.controller;
-
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-@RequestMapping("/api/goods/chat")
-public class GoodsChatController {
-}

--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatController.java
@@ -1,0 +1,32 @@
+package com.example.mate.domain.goodsChat.controller;
+
+import com.example.mate.common.response.ApiResponse;
+import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
+import com.example.mate.domain.goodsChat.service.GoodsChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/goods/chat")
+public class GoodsChatController {
+
+    private final GoodsChatService goodsChatService;
+
+    /*
+    굿즈거래 상세 페이지 - 채팅방 입장
+    TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
+    "/api/goods/chat" 로 변경 예정
+    */
+    @PostMapping("/{buyerId}")
+    public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> createGoodsChatRoom(@PathVariable Long buyerId, @RequestParam Long goodsPostId) {
+        GoodsChatRoomResponse response = goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/dto/response/GoodsChatRoomResponse.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/dto/response/GoodsChatRoomResponse.java
@@ -1,0 +1,55 @@
+package com.example.mate.domain.goodsChat.dto.response;
+
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.GoodsPostImage;
+import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class GoodsChatRoomResponse {
+
+    private final Long chatRoomId;
+    private final Long goodsPostId;
+    private final String teamName;
+    private final String title;
+    private final String category;
+    private final Integer price;
+    private final String status;
+    private final String imageUrl;
+
+    private static final String DEFAULT_IMAGE_URL = "upload/default.jpg";
+
+    public static GoodsChatRoomResponse of(GoodsChatRoom chatRoom) {
+        GoodsPost goodsPost = chatRoom.getGoodsPost();
+        String mainImageUrl = getMainImageUrl(goodsPost);
+        String teamName = getTeamName(goodsPost);
+
+        return GoodsChatRoomResponse.builder()
+                .chatRoomId(chatRoom.getId())
+                .goodsPostId(goodsPost.getId())
+                .teamName(teamName)
+                .title(goodsPost.getTitle())
+                .category(goodsPost.getCategory().getValue())
+                .price(goodsPost.getPrice())
+                .imageUrl(mainImageUrl)
+                .status(goodsPost.getStatus().getValue())
+                .build();
+    }
+
+    private static String getMainImageUrl(GoodsPost goodsPost) {
+        return goodsPost.getGoodsPostImages().stream()
+                .filter(GoodsPostImage::getIsMainImage)
+                .findFirst()
+                .map(GoodsPostImage::getImageUrl)
+                .orElse(DEFAULT_IMAGE_URL);
+    }
+
+    private static String getTeamName(GoodsPost goodsPost) {
+        return goodsPost.getTeamId() == null ? null : TeamInfo.getById(goodsPost.getTeamId()).shortName;
+    }
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/entity/GoodsChatMessage.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/entity/GoodsChatMessage.java
@@ -1,0 +1,50 @@
+package com.example.mate.domain.goodsChat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "goods_chat_message")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GoodsChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns({
+            @JoinColumn(name = "member_id", referencedColumnName = "member_id"),
+            @JoinColumn(name = "chat_room_id", referencedColumnName = "chat_room_id")
+    })
+    private GoodsChatPart goodsChatPart;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "sent_at", nullable = false)
+    private LocalDateTime sentAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.sentAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/entity/GoodsChatPart.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/entity/GoodsChatPart.java
@@ -1,0 +1,41 @@
+package com.example.mate.domain.goodsChat.entity;
+
+import com.example.mate.domain.goods.entity.Role;
+import com.example.mate.domain.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@IdClass(GoodsChatPartId.class)
+@Table(name = "goods_chat_part")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GoodsChatPart {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private GoodsChatRoom goodsChatRoom;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/entity/GoodsChatPartId.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/entity/GoodsChatPartId.java
@@ -1,0 +1,15 @@
+package com.example.mate.domain.goodsChat.entity;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoodsChatPartId implements Serializable {
+
+    private Long goodsChatRoom;
+    private Long member;
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/entity/GoodsChatRoom.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/entity/GoodsChatRoom.java
@@ -1,0 +1,61 @@
+package com.example.mate.domain.goodsChat.entity;
+
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.Role;
+import com.example.mate.domain.member.entity.Member;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "goods_chat_room")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GoodsChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private GoodsPost goodsPost;
+
+    @Column(name = "last_chat_content", columnDefinition = "TEXT")
+    private String lastChatContent;
+
+    @Column(name = "last_chat_sent_at")
+    private LocalDateTime lastChatSentAt;
+
+    @OneToMany(mappedBy = "goodsChatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<GoodsChatPart> chatParts = new ArrayList<>();
+
+    public void addChatParticipant(Member member, Role role) {
+        GoodsChatPart chatPart = GoodsChatPart.builder()
+                .goodsChatRoom(this)
+                .member(member)
+                .role(role)
+                .build();
+
+        chatParts.add(chatPart);
+    }
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatRoomRepository.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatRoomRepository.java
@@ -1,0 +1,23 @@
+package com.example.mate.domain.goodsChat.repository;
+
+import com.example.mate.domain.goods.entity.Role;
+import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GoodsChatRoomRepository extends JpaRepository<GoodsChatRoom, Long> {
+
+
+    @Query("""
+            SELECT cr
+            FROM GoodsChatRoom cr
+            JOIN cr.chatParts cp
+            WHERE cr.goodsPost.id = :postId
+            AND cp.member.id = :buyerId
+            AND cp.role = :role
+            """)
+    Optional<GoodsChatRoom> findExistingChatRoom(@Param("postId") Long postId, @Param("buyerId") Long buyerId,
+                                                 @Param("role") Role role);
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
@@ -1,0 +1,71 @@
+package com.example.mate.domain.goodsChat.service;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.Role;
+import com.example.mate.domain.goods.entity.Status;
+import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
+import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
+import com.example.mate.domain.goodsChat.repository.GoodsChatRoomRepository;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GoodsChatService {
+
+    private final GoodsPostRepository goodsPostRepository;
+    private final MemberRepository memberRepository;
+    private final GoodsChatRoomRepository chatRoomRepository;
+
+    public GoodsChatRoomResponse getOrCreateGoodsChatRoom(Long buyerId, Long goodsPostId) {
+        Member buyer = findMemberById(buyerId);
+        GoodsPost goodsPost = findGoodsPostById(goodsPostId);
+        Member seller = goodsPost.getSeller();
+
+        validateCreateChatRoom(goodsPost, buyer, seller);
+
+        // 구매자가 채팅방이 존재하면 기존 채팅방을 반환하고, 없다면 새로 생성하여 반환
+        GoodsChatRoom goodsChatRoom = chatRoomRepository.findExistingChatRoom(goodsPostId, buyerId, Role.BUYER)
+                .orElseGet(() -> createChatRoom(goodsPost, buyer, seller));
+
+        return GoodsChatRoomResponse.of(goodsChatRoom);
+    }
+
+    private void validateCreateChatRoom(GoodsPost goodsPost, Member seller, Member buyer) {
+        if (goodsPost.getStatus() == Status.CLOSED) {
+            throw new CustomException(ErrorCode.GOODS_CHAT_CLOSED_POST);
+        }
+        if (seller == buyer) {
+            throw new CustomException(ErrorCode.GOODS_CHAT_SELLER_CANNOT_START);
+        }
+    }
+
+    private GoodsChatRoom createChatRoom(GoodsPost goodsPost, Member buyer, Member seller) {
+        GoodsChatRoom goodsChatRoom = GoodsChatRoom.builder()
+                .goodsPost(goodsPost)
+                .build();
+        chatRoomRepository.save(goodsChatRoom);
+
+        goodsChatRoom.addChatParticipant(buyer, Role.BUYER);
+        goodsChatRoom.addChatParticipant(seller, Role.SELLER);
+
+        return goodsChatRoom;
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(()
+                -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
+    }
+
+    private GoodsPost findGoodsPostById(Long goodsPostId) {
+        return goodsPostRepository.findById(goodsPostId).orElseThrow(() ->
+                new CustomException(ErrorCode.GOODS_NOT_FOUND_BY_ID));
+    }
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
@@ -51,12 +51,13 @@ public class GoodsChatService {
         GoodsChatRoom goodsChatRoom = GoodsChatRoom.builder()
                 .goodsPost(goodsPost)
                 .build();
-        chatRoomRepository.save(goodsChatRoom);
+        
+        GoodsChatRoom savedChatRoom = chatRoomRepository.save(goodsChatRoom);
 
-        goodsChatRoom.addChatParticipant(buyer, Role.BUYER);
-        goodsChatRoom.addChatParticipant(seller, Role.SELLER);
+        savedChatRoom.addChatParticipant(buyer, Role.BUYER);
+        savedChatRoom.addChatParticipant(seller, Role.SELLER);
 
-        return goodsChatRoom;
+        return savedChatRoom;
     }
 
     private Member findMemberById(Long memberId) {

--- a/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatControllerTest.java
@@ -1,0 +1,108 @@
+package com.example.mate.domain.goodsChat.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
+import com.example.mate.domain.goodsChat.service.GoodsChatService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(GoodsChatController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc(addFilters = false)
+class GoodsChatControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GoodsChatService goodsChatService;
+
+    @Test
+    @DisplayName("굿즈거래 채팅방 생성 성공 - 기존 채팅방이 있을 경우 해당 채팅방을 반환한다.")
+    void returnExistingChatRoom() throws Exception {
+        // given
+        Long buyerId = 1L;
+        Long goodsPostId = 1L;
+        GoodsChatRoomResponse existingChatRoomResponse = GoodsChatRoomResponse.builder()
+                .chatRoomId(1L)
+                .goodsPostId(goodsPostId)
+                .teamName("test team")
+                .title("test title")
+                .category("ACCESSORY")
+                .price(10000)
+                .status("OPEN")
+                .imageUrl("/images/test.jpg")
+                .build();
+
+        when(goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId))
+                .thenReturn(existingChatRoomResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/goods/chat/{buyerId}", buyerId)
+                        .param("goodsPostId", String.valueOf(goodsPostId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.chatRoomId").value(existingChatRoomResponse.getChatRoomId()))
+                .andExpect(jsonPath("$.data.goodsPostId").value(existingChatRoomResponse.getGoodsPostId()))
+                .andExpect(jsonPath("$.data.teamName").value(existingChatRoomResponse.getTeamName()))
+                .andExpect(jsonPath("$.data.title").value(existingChatRoomResponse.getTitle()))
+                .andExpect(jsonPath("$.data.category").value(existingChatRoomResponse.getCategory()))
+                .andExpect(jsonPath("$.data.price").value(existingChatRoomResponse.getPrice()))
+                .andExpect(jsonPath("$.data.status").value(existingChatRoomResponse.getStatus()))
+                .andExpect(jsonPath("$.data.imageUrl").value(existingChatRoomResponse.getImageUrl()));
+
+
+        verify(goodsChatService).getOrCreateGoodsChatRoom(buyerId, goodsPostId);
+    }
+
+    @Test
+    @DisplayName("굿즈거래 채팅방 생성 성공 - 기존 채팅방이 없을 경우 새로운 채팅방을 생성한다.")
+    void createNewChatRoomIfNoneExists() throws Exception {
+        // given
+        Long buyerId = 1L;
+        Long goodsPostId = 1L;
+        GoodsChatRoomResponse newChatRoomResponse = GoodsChatRoomResponse.builder()
+                .chatRoomId(2L)
+                .goodsPostId(goodsPostId)
+                .teamName("test team")
+                .title("test title")
+                .category("ACCESSORY")
+                .price(10000)
+                .status("OPEN")
+                .imageUrl("/images/test.jpg")
+                .build();
+
+        when(goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId))
+                .thenReturn(newChatRoomResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/goods/chat/{buyerId}", buyerId)
+                        .param("goodsPostId", String.valueOf(goodsPostId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.chatRoomId").value(newChatRoomResponse.getChatRoomId()))
+                .andExpect(jsonPath("$.data.goodsPostId").value(newChatRoomResponse.getGoodsPostId()))
+                .andExpect(jsonPath("$.data.teamName").value(newChatRoomResponse.getTeamName()))
+                .andExpect(jsonPath("$.data.title").value(newChatRoomResponse.getTitle()))
+                .andExpect(jsonPath("$.data.category").value(newChatRoomResponse.getCategory()))
+                .andExpect(jsonPath("$.data.price").value(newChatRoomResponse.getPrice()))
+                .andExpect(jsonPath("$.data.status").value(newChatRoomResponse.getStatus()))
+                .andExpect(jsonPath("$.data.imageUrl").value(newChatRoomResponse.getImageUrl()));
+
+        verify(goodsChatService).getOrCreateGoodsChatRoom(buyerId, goodsPostId);
+    }
+}

--- a/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
@@ -1,0 +1,143 @@
+package com.example.mate.domain.goodsChat.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.mate.common.response.ApiResponse;
+import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.goods.dto.LocationInfo;
+import com.example.mate.domain.goods.entity.Category;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.GoodsPostImage;
+import com.example.mate.domain.goods.entity.Status;
+import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
+import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
+import com.example.mate.domain.goodsChat.repository.GoodsChatRoomRepository;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class GoodsChatIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private GoodsPostRepository goodsPostRepository;
+    @Autowired private GoodsChatRoomRepository chatRoomRepository;
+    @Autowired private ObjectMapper objectMapper;
+
+    private Member member;
+    private GoodsPost goodsPost;
+
+    @BeforeEach
+    void setUp() {
+        member = createMember("tester", "tester nickname", "test@gmail.com");
+        goodsPost = createGoodsPost(Status.OPEN, member, null);
+        createGoodsPostImage(goodsPost);
+    }
+
+    @Test
+    @DisplayName("굿즈거래 채팅방 생성 통합 테스트")
+    void get_or_create_goods_chatroom_integration_test() throws Exception {
+        // given
+        Member buyer = createMember("test buyer", "test buyer nickname", "buyer@gmail.com");
+        Long buyerId = buyer.getId();
+        Long goodsPostId = goodsPost.getId();
+
+        // when
+        MockHttpServletResponse result = mockMvc.perform(post("/api/goods/chat/{buyerId}", buyerId)
+                        .param("goodsPostId", String.valueOf(goodsPostId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.goodsPostId").value(goodsPost.getId()))
+                .andExpect(jsonPath("$.data.title").value(goodsPost.getTitle()))
+                .andExpect(jsonPath("$.data.category").value(goodsPost.getCategory().getValue()))
+                .andExpect(jsonPath("$.data.price").value(goodsPost.getPrice()))
+                .andExpect(jsonPath("$.data.status").value(goodsPost.getStatus().getValue()))
+                .andExpect(jsonPath("$.data.imageUrl").value(goodsPost.getGoodsPostImages().get(0).getImageUrl()))
+                .andReturn()
+                .getResponse();
+
+        result.setCharacterEncoding("UTF-8");
+        ApiResponse<GoodsChatRoomResponse> apiResponse = objectMapper.readValue(result.getContentAsString(), new TypeReference<>() {});
+        GoodsChatRoomResponse actualResponse = apiResponse.getData();
+
+        // then
+        GoodsChatRoom actualChatRoom = chatRoomRepository.findById(actualResponse.getChatRoomId()).orElse(null);
+        GoodsPost actualPost = actualChatRoom.getGoodsPost();
+        assertThat(actualPost.getId()).isEqualTo(goodsPost.getId());
+        assertThat(actualPost.getContent()).isEqualTo(goodsPost.getContent());
+        assertThat(actualPost.getTeamId()).isEqualTo(goodsPost.getTeamId());
+        assertThat(actualPost.getTitle()).isEqualTo(goodsPost.getTitle());
+        assertThat(actualPost.getPrice()).isEqualTo(goodsPost.getPrice());
+
+        GoodsPostImage image = actualPost.getGoodsPostImages().get(0);
+        assertThat(image.getImageUrl()).isEqualTo("upload/test_img_url");
+    }
+
+    private Member createMember(String name, String nickname, String email) {
+        return memberRepository.save(Member.builder()
+                .name(name)
+                .nickname(nickname)
+                .email(email)
+                .imageUrl("upload/test.jpg")
+                .gender(Gender.FEMALE)
+                .age(25)
+                .manner(0.3f)
+                .build());
+    }
+
+    private GoodsPost createGoodsPost(Status status, Member seller, Member buyer) {
+        return goodsPostRepository.save(GoodsPost.builder()
+                .teamId(1L)
+                .seller(seller)
+                .buyer(buyer)
+                .title("test title")
+                .content("test content")
+                .price(10_000)
+                .status(status)
+                .category(Category.ACCESSORY)
+                .location(LocationInfo.toEntity(createLocationInfo()))
+                .build());
+    }
+
+    private GoodsChatRoom createGoodsChatRoom(GoodsPost goodsPost) {
+        return chatRoomRepository.save(GoodsChatRoom.builder()
+                .goodsPost(goodsPost)
+                .build());
+    }
+
+    private void createGoodsPostImage(GoodsPost goodsPost) {
+        GoodsPostImage image = GoodsPostImage.builder()
+                .imageUrl("upload/test_img_url")
+                .build();
+
+        goodsPost.changeImages(List.of(image));
+        goodsPostRepository.save(goodsPost);
+    }
+
+    private LocationInfo createLocationInfo() {
+        return LocationInfo.builder()
+                .placeName("Stadium Plaza")
+                .longitude("127.12345")
+                .latitude("37.56789")
+                .build();
+    }
+}

--- a/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatServiceTest.java
@@ -1,0 +1,200 @@
+package com.example.mate.domain.goodsChat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.domain.goods.entity.Category;
+import com.example.mate.domain.goods.entity.GoodsPost;
+import com.example.mate.domain.goods.entity.Role;
+import com.example.mate.domain.goods.entity.Status;
+import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
+import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
+import com.example.mate.domain.goodsChat.repository.GoodsChatRoomRepository;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GoodsChatServiceTest {
+
+    @InjectMocks
+    private GoodsChatService goodsChatService;
+
+    @Mock
+    private GoodsPostRepository goodsPostRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private GoodsChatRoomRepository chatRoomRepository;
+
+    private Member createMember(Long id, String name, String nickname) {
+        return Member.builder()
+                .id(id)
+                .name(name)
+                .nickname(nickname)
+                .build();
+    }
+
+    private GoodsPost createGoodsPost(Long id, Member seller, Member buyer, Status status) {
+        return GoodsPost.builder()
+                .id(id)
+                .seller(seller)
+                .buyer(buyer)
+                .teamId(1L)
+                .title("test title")
+                .content("test content")
+                .price(10_000)
+                .status(status)
+                .category(Category.ACCESSORY)
+                .build();
+    }
+
+    private GoodsChatRoom createGoodsChatRoom(Long id, GoodsPost goodsPost) {
+        return GoodsChatRoom.builder()
+                .id(id)
+                .goodsPost(goodsPost)
+                .build();
+    }
+
+
+    @Nested
+    @DisplayName("굿즈거래 채팅방 생성 테스트")
+    class GoodsChatRoomCreateTest {
+
+        @Test
+        @DisplayName("굿즈거래 채팅방 생성 성공 - 기존 채팅방이 있을 경우 해당 채팅방을 반환한다.")
+        void get_Or_Create_GoodsChatRoom_should_return_existing_chatroom() {
+            // given
+            Member buyer = createMember(1L, "test buyer", "test buyer nickname");
+            Member seller = createMember(2L, "test seller", "test seller nickname");
+
+            Long buyerId = buyer.getId();
+            GoodsPost goodsPost = createGoodsPost(1L, seller, null, Status.OPEN);
+            Long goodsPostId = 1L;
+
+            GoodsChatRoom existingChatRoom = createGoodsChatRoom(1L, goodsPost);
+            existingChatRoom.addChatParticipant(buyer, Role.BUYER);
+            existingChatRoom.addChatParticipant(seller, Role.SELLER);
+
+            when(memberRepository.findById(buyerId)).thenReturn(Optional.of(buyer));
+            when(goodsPostRepository.findById(goodsPostId)).thenReturn(Optional.of(goodsPost));
+            when(chatRoomRepository.findExistingChatRoom(goodsPostId, buyerId, Role.BUYER))
+                    .thenReturn(Optional.of(existingChatRoom));
+
+            // when
+            GoodsChatRoomResponse result = goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId);
+
+            // then
+            assertThat(result.getChatRoomId()).isEqualTo(existingChatRoom.getId());
+            assertThat(result.getGoodsPostId()).isEqualTo(goodsPost.getId());
+            assertThat(result.getStatus()).isEqualTo(goodsPost.getStatus().getValue());
+
+            verify(memberRepository).findById(buyerId);
+            verify(goodsPostRepository).findById(goodsPostId);
+            verify(chatRoomRepository).findExistingChatRoom(goodsPostId, buyerId, Role.BUYER);
+            verify(chatRoomRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("굿즈거래 채팅방 생성 성공 - 기존 채팅방이 없을 경우 새로운 채팅방을 생성한다.")
+        void get_Or_Create_GoodsChatRoom_should_create_new_chatRoom() {
+            // given
+            Member buyer = createMember(1L, "test buyer", "test buyer nickname");
+            Member seller = createMember(2L, "test seller", "test seller nickname");
+
+            Long buyerId = buyer.getId();
+            GoodsPost goodsPost = createGoodsPost(1L, seller, null, Status.OPEN);
+            Long goodsPostId = goodsPost.getId();
+
+            GoodsChatRoom newGoodsChatRoom = createGoodsChatRoom(1L, goodsPost);
+            newGoodsChatRoom.addChatParticipant(buyer, Role.BUYER);
+            newGoodsChatRoom.addChatParticipant(seller, Role.SELLER);
+
+            when(memberRepository.findById(buyerId)).thenReturn(Optional.of(buyer));
+            when(goodsPostRepository.findById(goodsPostId)).thenReturn(Optional.of(goodsPost));
+            when(chatRoomRepository.findExistingChatRoom(goodsPostId, buyerId, Role.BUYER)).thenReturn(Optional.empty());
+            when(chatRoomRepository.save(any(GoodsChatRoom.class))).thenReturn(newGoodsChatRoom);
+
+            // when
+            GoodsChatRoomResponse result = goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId);
+
+            // then
+            assertThat(result.getChatRoomId()).isEqualTo(newGoodsChatRoom.getId());
+            assertThat(result.getGoodsPostId()).isEqualTo(goodsPost.getId());
+            assertThat(result.getStatus()).isEqualTo(goodsPost.getStatus().getValue());
+
+            verify(memberRepository).findById(buyerId);
+            verify(goodsPostRepository).findById(goodsPostId);
+            verify(chatRoomRepository).findExistingChatRoom(goodsPostId, buyerId, Role.BUYER);
+            verify(chatRoomRepository).save(any(GoodsChatRoom.class));
+        }
+
+        @Test
+        @DisplayName("굿즈거래 채팅방 생성 실패 - 거래 완료된 판매글일 경우 예외를 발생시킨다.")
+        void get_Or_Create_GoodsChatRoom_failed_with_closed_post() {
+            // given
+            Member buyer = createMember(1L, "test buyer", "test buyer nickname");
+            Member seller = createMember(2L, "test seller", "test seller nickname");
+
+            Long buyerId = buyer.getId();
+            GoodsPost goodsPost = createGoodsPost(1L, seller, buyer, Status.CLOSED);
+            Long goodsPostId = goodsPost.getId();
+
+            when(memberRepository.findById(buyerId)).thenReturn(Optional.of(buyer));
+            when(goodsPostRepository.findById(goodsPostId)).thenReturn(Optional.of(goodsPost));
+
+            // when
+            assertThatThrownBy(() -> goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.GOODS_CHAT_CLOSED_POST.getMessage());
+
+            // then
+            verify(memberRepository).findById(buyerId);
+            verify(goodsPostRepository).findById(goodsPostId);
+            verify(chatRoomRepository, never()).findExistingChatRoom(anyLong(), anyLong(), any(Role.class));
+            verify(chatRoomRepository, never()).save(any(GoodsChatRoom.class));
+        }
+
+        @Test
+        @DisplayName("굿즈거래 채팅방 생성 실패 - 구매자가 판매글의 판매자라면 예외를 발생시킨다.")
+        void get_Or_Create_GoodsChatRoom_failed_with_seller_as_buyer() {
+            // given
+            Member buyer = createMember(1L, "test buyer", "test buyer nickname");
+            Long buyerId = buyer.getId();
+
+            GoodsPost goodsPost = createGoodsPost(1L, buyer, null, Status.OPEN);
+            Long goodsPostId = goodsPost.getId();
+
+            when(memberRepository.findById(buyerId)).thenReturn(Optional.of(buyer));
+            when(goodsPostRepository.findById(goodsPostId)).thenReturn(Optional.of(goodsPost));
+
+            // when
+            assertThatThrownBy(() -> goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.GOODS_CHAT_SELLER_CANNOT_START.getMessage());
+
+            // then
+            verify(memberRepository).findById(buyerId);
+            verify(goodsPostRepository).findById(goodsPostId);
+            verify(chatRoomRepository, never()).findExistingChatRoom(anyLong(), anyLong(), any(Role.class));
+            verify(chatRoomRepository, never()).save(any(GoodsChatRoom.class));
+        }
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 채팅 관련 엔티티 생성
- [x] 굿즈거래 채팅방 생성 기능 구현
- [x] 굿즈거래 채팅방 생성 기능 테스트 코드 작성

## 💡 자세한 설명
<img width="322" alt="image" src="https://github.com/user-attachments/assets/45527446-78ae-4156-b099-20cbfa5406b0">

#### `POST api/goods/chat/{buyerId}`
- Figma 사진으로 보이는 굿즈거래 상세 페이지에서 `대화 나누기` 버튼을 누르고 나서, 채팅 페이지로 넘어가며 채팅방을 생성하는 기능입니다.
- 사용자의 요청 값으로는 구매자(`buyerId`), 판매글(`goodsPostId`) 를 필요로 합니다.

<img width="1036" alt="image" src="https://github.com/user-attachments/assets/f75c430c-1042-41a5-b1e9-715854f152a8">

- 구매자 ID, 판매글 ID 를 통해 채팅 참여(`GoodsChatPart`) 여부를 조회하고, 기존 채팅방이 있다면 기존 채팅방을 반환합니다.
- 만약 채팅방에서 나갔거나 채팅방을 참여하지 않았다면 새로운 채팅방을 생성하여 반환합니다.
>`Response` DTO 클래스에 기존 채팅 내역을 페이징 처리해서 반환할까 고민을 했었는데, 채팅 내역 조회 기능은 다른 곳에서도 쓰일 수 있기 때문에 프론트에서 추가 요청을 하는 것으로 처리했습니다.

<br>

#### 채팅 관련 엔티티 변경 사항 
- `GoodsChatRoom` 채팅방 제목 삭제
- `GoodsChatRoom` vs `GoodsPost` 엔티티 연관관계 `1:N` 으로 설정
- 채팅참여 엔티티(`GoodsChatPart`) `@IdClass`로 복합키 지정
- 채팅 메시지 엔티티(`GoodsChatMessage`)에서 `@JoinColumns` 를 통해 복합키를 외래키로 저장
- 채팅 메시지 엔티티(`GoodsChatMessage`) 의 `sentAt` 필드를 `@PrePersist` 어노테이션을 통해 생성 시간 저장

<br>

#### 도메인 규칙
<img width="505" alt="image" src="https://github.com/user-attachments/assets/954ada6c-c20a-4dea-8634-3e04ca2ed14d">



## 📗 참고 자료 (선택)

[복합키 매핑 (@JoinColums & @IdClass)](https://velog.io/@ahngj96/JPA-%EB%B3%B5%ED%95%A9%ED%82%A4-%EB%A7%A4%ED%95%91)
[@PrePersist & @PreUpdate](https://blog.naver.com/seek316/223353802740)


## 📢 리뷰 요구 사항 (선택)
굿즈거래와 굿즈거래 채팅의 패키지를 분리했습니다. 테스트 코드 클래스를 새로 작성하느라 시간이 오래 걸렸네요...

엔티티 설계 및 채팅 참여 로직 확인 부탁드립니다 !
> 추후에 구현하면서 엔티티 구조는 변경될 수 있습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?