### PR TITLE
MATE-42 : [FEAT] 프로필 직관 타임라인 페이징 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/goods/repository/GoodsReviewRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/goods/repository/GoodsReviewRepositoryCustomImpl.java
@@ -14,9 +14,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
 
+@Repository
 @RequiredArgsConstructor
-public class GoodsReviewRepositoryImpl implements GoodsReviewRepositoryCustom {
+public class GoodsReviewRepositoryCustomImpl implements GoodsReviewRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/com/example/mate/domain/mate/repository/MateRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateRepository.java
@@ -1,23 +1,27 @@
 package com.example.mate.domain.mate.repository;
 
+import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.mate.entity.MatePost;
 import com.example.mate.domain.mate.entity.Status;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Repository
 public interface MateRepository extends JpaRepository<MatePost, Long>, MateRepositoryCustom {
     @Query("""
-            SELECT mp FROM MatePost mp JOIN FETCH mp.match mt
-            WHERE (:teamId IS NULL OR mp.teamId = :teamId)
-            And mt.matchTime > :now AND mp.status IN :statuses
-            ORDER BY mt.matchTime ASC
-           """)
-    List<MatePost> findMainPagePosts(@Param("teamId") Long teamId, @Param("now") LocalDateTime now, @Param("statuses") List<Status> statuses, Pageable pageable);
+             SELECT mp FROM MatePost mp JOIN FETCH mp.match mt
+             WHERE (:teamId IS NULL OR mp.teamId = :teamId)
+             And mt.matchTime > :now AND mp.status IN :statuses
+             ORDER BY mt.matchTime ASC
+            """)
+    List<MatePost> findMainPagePosts(@Param("teamId") Long teamId, @Param("now") LocalDateTime now,
+                                     @Param("statuses") List<Status> statuses, Pageable pageable);
+
+    @Query("SELECT m.match FROM MatePost m WHERE m.id = :matePostId")
+    Match findMatchByMatePostId(@Param("matePostId") Long matePostId);
 }

--- a/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepository.java
@@ -1,9 +1,13 @@
 package com.example.mate.domain.mate.repository;
 
 import com.example.mate.domain.mate.entity.MateReview;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MateReviewRepository extends JpaRepository<MateReview, Long> {
 
     int countByRevieweeId(Long revieweeId);
+
+    Optional<MateReview> findMateReviewByVisitIdAndReviewerIdAndRevieweeId(Long visitId, Long reviewerId,
+                                                                           Long revieweeId);
 }

--- a/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepositoryCustomImpl.java
@@ -13,9 +13,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
 
+@Repository
 @RequiredArgsConstructor
-public class MateReviewRepositoryImpl implements MateReviewRepositoryCustom {
+public class MateReviewRepositoryCustomImpl implements MateReviewRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/com/example/mate/domain/mate/repository/VisitPartRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/VisitPartRepository.java
@@ -3,9 +3,20 @@ package com.example.mate.domain.mate.repository;
 import com.example.mate.domain.mate.entity.VisitPart;
 import com.example.mate.domain.mate.entity.VisitPartId;
 import com.example.mate.domain.member.entity.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface VisitPartRepository extends JpaRepository<VisitPart, VisitPartId> {
 
     int countByMember(Member member);
+
+    @Query("""
+            SELECT vp.member
+            FROM VisitPart vp
+            WHERE vp.visit.id = :visitId
+            AND vp.member.id != :memberId
+            """)
+    List<Member> findMembersByVisitIdExcludeMember(@Param("visitId") Long visitId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
@@ -11,11 +11,7 @@ import com.example.mate.domain.member.service.ProfileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.Collections;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -54,19 +50,16 @@ public class ProfileController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /*
-    TODO : 2024/11/24 - 직관 타임라인 페이징 조회
-    1. JwtToken 을 통해 회원 정보 조회
-    2. 회원이 다녀온 직관 기록, 같이 본 사용자 정보, 메이트 후기 조회
-    3. 페이징 처리 후 반환
-    */
-    @GetMapping("/timeline")
-    public ResponseEntity<Page<MyVisitResponse>> getMyVisits(@PageableDefault(size = 10) Pageable pageable) {
-        MyVisitResponse myVisitResponse = MyVisitResponse.from();
-        List<MyVisitResponse> responses = Collections.nCopies(10, myVisitResponse);
-        Page<MyVisitResponse> page = new PageImpl<>(responses, pageable, responses.size());
-
-        return ResponseEntity.ok(page);
+    // TODO : 본인만 접근할 수 있도록 @AuthenticationPrincipal Long memberId
+    @Operation(summary = "직관 타임라인 페이징 조회")
+    @GetMapping("/timeline/{memberId}")
+    public ResponseEntity<ApiResponse<PageResponse<MyVisitResponse>>> getMyVisits(
+            @Parameter(description = "회원 ID") @PathVariable Long memberId,
+            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
+    ) {
+        validatePageable(pageable);
+        PageResponse<MyVisitResponse> response = profileService.getMyVisitPage(memberId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Operation(summary = "굿즈 판매기록 페이징 조회")

--- a/src/main/java/com/example/mate/domain/member/dto/response/MyTimelineResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MyTimelineResponse.java
@@ -1,0 +1,15 @@
+package com.example.mate.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MyTimelineResponse {
+
+    private Long visitId;
+    private Long matePostId;
+    private Long memberId;
+}

--- a/src/main/java/com/example/mate/domain/member/dto/response/MyVisitResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MyVisitResponse.java
@@ -1,7 +1,11 @@
 package com.example.mate.domain.member.dto.response;
 
+import com.example.mate.domain.constant.TeamInfo;
+import com.example.mate.domain.match.entity.Match;
+import com.example.mate.domain.mate.entity.MateReview;
+import com.example.mate.domain.member.entity.Member;
 import java.time.LocalDateTime;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,13 +22,9 @@ public class MyVisitResponse {
     private String location;
     private LocalDateTime matchTime;
 
-    // 구인글 정보
-    private Long postId;
-    private String imageUrl;
-    private String title;
-
     // 리뷰 정보
-    private List<MateReviewResponse> reviews;
+    @Builder.Default
+    private List<MateReviewResponse> reviews = new ArrayList<>();
 
     @Getter
     @Builder
@@ -35,26 +35,32 @@ public class MyVisitResponse {
         private String rating;
         private String content;
 
-        private static MateReviewResponse from() {
+        public static MateReviewResponse from(MateReview mateReview) {
             return MateReviewResponse.builder()
-                    .memberId(1L)
-                    .nickname("김아무개")
-                    .rating("좋았어요!")
-                    .content("정말 재미있는 직관이었어요. 함께해서 즐거웠습니다.")
+                    .memberId(mateReview.getReviewee().getId())
+                    .nickname(mateReview.getReviewee().getNickname())
+                    .rating(mateReview.getRating().getValue())
+                    .content(mateReview.getReviewContent())
+                    .build();
+        }
+
+        public static MateReviewResponse from(Member member) {
+            return MateReviewResponse.builder()
+                    .memberId(member.getId())
+                    .nickname(member.getNickname())
+                    .rating(null)
+                    .content(null)
                     .build();
         }
     }
 
-    public static MyVisitResponse from() {
+    public static MyVisitResponse of(Match match, List<MateReviewResponse> reviews) {
         return MyVisitResponse.builder()
-                .homeTeamName("삼성")
-                .awayTeamName("KT")
-                .location("대구 라이온스 파크")
-                .matchTime(LocalDateTime.now().minusDays(10))
-                .postId(1L)
-                .imageUrl("upload/default.jpg")
-                .title("구인 게시글 제목!")
-                .reviews(Collections.nCopies(3, MateReviewResponse.from()))
+                .homeTeamName(TeamInfo.getById(match.getHomeTeamId()).shortName)
+                .awayTeamName(TeamInfo.getById(match.getAwayTeamId()).shortName)
+                .location(match.getStadium().name)
+                .matchTime(match.getMatchTime())
+                .reviews(reviews)
                 .build();
     }
 }

--- a/src/main/java/com/example/mate/domain/member/repository/TimelineRepositoryCustom.java
+++ b/src/main/java/com/example/mate/domain/member/repository/TimelineRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.mate.domain.member.repository;
+
+import com.example.mate.domain.member.dto.response.MyTimelineResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface TimelineRepositoryCustom {
+
+    Page<MyTimelineResponse> findVisitsById(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/example/mate/domain/member/repository/TimelineRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/member/repository/TimelineRepositoryCustomImpl.java
@@ -1,0 +1,51 @@
+package com.example.mate.domain.member.repository;
+
+import static com.example.mate.domain.mate.entity.QVisit.visit;
+import static com.example.mate.domain.mate.entity.QVisitPart.visitPart;
+import static com.example.mate.domain.member.entity.QMember.member;
+
+import com.example.mate.domain.member.dto.response.MyTimelineResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TimelineRepositoryCustomImpl implements TimelineRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<MyTimelineResponse> findVisitsById(Long memberId, Pageable pageable) {
+        List<MyTimelineResponse> results = queryFactory
+                .select(Projections.constructor(
+                        MyTimelineResponse.class,
+                        visit.id.as("visitId"),
+                        visit.post.id.as("matePostId"),
+                        visitPart.member.id.as("memberId")
+                ))
+                .from(visit)
+                .join(visit.participants, visitPart) // Visit -> VisitPart 조인
+                .join(visitPart.member, member) // VisitPart -> Member 조인
+                .where(member.id.eq(memberId))
+                .orderBy(visit.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> total = queryFactory
+                .select(visit.count())
+                .from(visit)
+                .join(visit.participants, visitPart)
+                .join(visitPart.member, member)
+                .where(member.id.eq(memberId));
+
+        return PageableExecutionUtils.getPage(results, pageable, total::fetchOne);
+    }
+}

--- a/src/test/java/com/example/mate/domain/member/integration/ProfileIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/ProfileIntegrationTest.java
@@ -456,4 +456,46 @@ public class ProfileIntegrationTest {
                     .andExpect(jsonPath("$.message").value("해당 ID의 회원 정보를 찾을 수 없습니다"));
         }
     }
+
+    @Nested
+    @DisplayName("회원 타임라인 페이징 조회")
+    class ProfileTimelinePage {
+
+        @Test
+        @DisplayName("회원 타임라인 페이징 조회 성공")
+        void get_my_visit_page_success() throws Exception {
+            // given
+            Long memberId = member1.getId();
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when & then
+            mockMvc.perform(get("/api/profile/timeline/{memberId}", memberId)
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageSize())))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(1))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("회원 타임라인 페이징 조회 실패 - 유효하지 않은 회원 아이디로 조회")
+        void get_my_visit_page_fail_invalid_member_id() throws Exception {
+            // given
+            Long invalidMemberId = member1.getId() + 999L; // 존재 하지 않는 아이디
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when & then
+            mockMvc.perform(get("/api/profile/timeline/{memberId}", invalidMemberId)
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageNumber())))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value("ERROR"))
+                    .andExpect(jsonPath("$.code").value(404))
+                    .andExpect(jsonPath("$.message").value("해당 ID의 회원 정보를 찾을 수 없습니다"));
+        }
+    }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 타임라인 페이징 조회 구현
- [x] 기존에 사용했던 QueryDSL 레포지토리에 @Repository 추가
- [x] 단일/통합 테스트

## 💡 자세한 설명

### 타임라인 페이징 조회
- 사용자의 최신 정보를 받기 위해 최신 경기 순으로 내림차순 정렬됩니다.
- 커스텀 인터페이스 `TimelineRepositoryCustom`과 구현 클래스 `TimelineRepositoryCustomImpl`을 통해 QueryDSL 사용했습니다.
    - 타임라인 조회를 위해서는 회원(Member), 직관참여(VisitPart), 직관(Visit), 경기정보(Match), 메이트후기(MateReview)까지 총 다섯 개의 테이블에서 데이터를 가져와야 합니다.
        - 처음에는 한번에 가져올 수 있는 테이블을 전부 조인해서 가져오려 했지만, QueryDSL의 사용 미숙으로 매핑 과정에서 오류가 나서 회원, 직관참여, 직관만 QueryDSL로 1차적으로 가져옵니다. (`MyTimelineResponse` DTO 사용) 
        - 그 이후 직관 타임라인 응답 객체 페이지를 생성한 뒤, 페이지의 각 객체(`MyVisitResponse`)에 경기 정보와 사용자 리뷰를 주입하는 방식을 사용했습니다.
        - 한편, 이 과정에서 하나의 경기에 대해 최대 9명의 정보를 가져온 뒤, 9개에 대한 대한 리뷰를 조회하고 응답 DTO에 매핑하는 방식을 사용하고 있다보니 단일 조회에서 약 30개 이상의 쿼리가 나가는 것을 확인할 수 있었습니다.
            - 현재로선 쿼리를 더 효율적으로 짜야하는데, 이 문제는 혼자 해결할 수 없어 멘토링 때 얘기해 볼 예정입니다.
    - TODO : 추후 쿼리 수를 줄이는 작업 필요.

### QueryDSL 레포지토리에 @Repository 추가

- ProfileService 내에 사용한 
```java
    private final MateReviewRepositoryCustom mateReviewRepositoryCustom;
    private final GoodsReviewRepositoryCustom goodsReviewRepositoryCustom;
    private final TimelineRepositoryCustom timelineRepositoryCustom;
```
커스텀 Repository 빈 객체를 컴파일 시 오류는 없지만, 코드 상으로 주입을 인식하지 못하는 문제가 있어,  
해당 인터페이스의 구현 클래스에서 @Repository를 달아주었습니다. 일종의 intellij 버그라고 합니다.

#### 도메인 규칙

![스크린샷 2024-12-07 오후 9 33 44](https://github.com/user-attachments/assets/4df2d89d-d554-48f8-b31f-e07970c298a2)


## 📗 참고 자료 (선택)

https://velog.io/@mooh2jj/Could-not-autowire.-No-beans-of-type-found.-error-문제


## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?