### PR TITLE
MATE-74 : [FEAT] WebSocket 설정 및 채팅 인프라 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
     // WebDriverManager
     implementation 'io.github.bonigarcia:webdrivermanager:5.9.2'
 
+    // WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     implementation 'org.hibernate.validator:hibernate-validator'
 }
 

--- a/src/main/java/com/example/mate/common/config/WebSocketConfig.java
+++ b/src/main/java/com/example/mate/common/config/WebSocketConfig.java
@@ -1,0 +1,40 @@
+package com.example.mate.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker  // WebSocket 메시지 브로커 활성화
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 구독 경로 설정 - 클라이언트가 구독할 수 있는 endpoint 설정
+        // 클라이언트는 이 prefix로 시작하는 주제를 구독할 수 있음
+        registry.enableSimpleBroker(
+                "/sub/chat/mate",     // 메이트 채팅 (다대다 채팅)
+                "/sub/chat/goods",    // 굿즈거래 채팅 (1:1)
+                "/sub/chat/dm"        // 일반 DM (1:1)
+        );
+
+        // 발행 경로 설정 - 클라이언트가 메시지를 발행할 때 사용할 prefix
+        // 클라이언트가 메시지를 보낼 때는 이 prefix로 시작하는 endpoint로 메시지를 전송
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // WebSocket 연결 endpoint 설정
+        // 클라이언트는 이 경로로 WebSocket 연결을 맺음
+        registry.addEndpoint("/ws/chat")
+                // CORS 설정 - 허용할 origin 패턴 설정
+                .setAllowedOriginPatterns("*")
+                // SockJS 지원 추가 (WebSocket을 지원하지 않는 브라우저를 위한 fallback)
+                .withSockJS();
+    }
+}

--- a/src/main/java/com/example/mate/domain/mateChat/entity/MateChatMessage.java
+++ b/src/main/java/com/example/mate/domain/mateChat/entity/MateChatMessage.java
@@ -7,7 +7,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "chat_message")
+@Table(name = "mate_chat_message")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/example/mate/domain/mateChat/entity/MateChatMessage.java
+++ b/src/main/java/com/example/mate/domain/mateChat/entity/MateChatMessage.java
@@ -1,0 +1,42 @@
+package com.example.mate.domain.mateChat.entity;
+
+import com.example.mate.common.BaseTimeEntity;
+import com.example.mate.domain.mateChat.message.MessageType;
+import com.example.mate.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "chat_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class MateChatMessage extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private MateChatRoom mateChatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")  // 시스템 메시지는 sender가 null일 수 있음
+    private Member sender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private MessageType type;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    private MateChatMessage(MateChatRoom mateChatRoom, Member sender, MessageType type,
+                        String content) {
+        this.mateChatRoom = mateChatRoom;
+        this.sender = sender;
+        this.type = type;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/mate/domain/mateChat/entity/MateChatRoom.java
+++ b/src/main/java/com/example/mate/domain/mateChat/entity/MateChatRoom.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "chat_room")
+@Table(name = "mate_chat_room")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/example/mate/domain/mateChat/entity/MateChatRoom.java
+++ b/src/main/java/com/example/mate/domain/mateChat/entity/MateChatRoom.java
@@ -31,11 +31,11 @@ public class MateChatRoom extends BaseTimeEntity {
     @Builder.Default
     private Integer currentMembers = 0;
 
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "mateChatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<MateChatRoomMember> members = new ArrayList<>();
 
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "mateChatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<MateChatMessage> messages = new ArrayList<>();
 

--- a/src/main/java/com/example/mate/domain/mateChat/entity/MateChatRoom.java
+++ b/src/main/java/com/example/mate/domain/mateChat/entity/MateChatRoom.java
@@ -1,0 +1,59 @@
+package com.example.mate.domain.mateChat.entity;
+
+import com.example.mate.common.BaseTimeEntity;
+import com.example.mate.domain.mate.entity.MatePost;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "chat_room")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class MateChatRoom extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mate_post_id", nullable = false)
+    private MatePost matePost;
+
+    @Column(name = "active", nullable = false)
+    @Builder.Default
+    private Boolean active = true;
+
+    @Column(name = "current_members", nullable = false)
+    @Builder.Default
+    private Integer currentMembers = 0;
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<MateChatRoomMember> members = new ArrayList<>();
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<MateChatMessage> messages = new ArrayList<>();
+
+    public static MateChatRoom create(MatePost matePost) {
+        return MateChatRoom.builder()
+                .matePost(matePost)
+                .currentMembers(1)
+                .build();
+    }
+
+    public void decrementCurrentMembers() {
+        this.currentMembers--;
+        if (this.currentMembers == 0) {
+            this.active = false;
+        }
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+}

--- a/src/main/java/com/example/mate/domain/mateChat/entity/MateChatRoomMember.java
+++ b/src/main/java/com/example/mate/domain/mateChat/entity/MateChatRoomMember.java
@@ -1,0 +1,39 @@
+package com.example.mate.domain.mateChat.entity;
+
+import com.example.mate.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "chat_room_member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class MateChatRoomMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private MateChatRoom mateChatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private Boolean isActive = true;
+
+    private MateChatRoomMember(MateChatRoom mateChatRoom, Member member) {
+        this.mateChatRoom = mateChatRoom;
+        this.member = member;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+        this.mateChatRoom.decrementCurrentMembers();
+    }
+}

--- a/src/main/java/com/example/mate/domain/mateChat/entity/MateChatRoomMember.java
+++ b/src/main/java/com/example/mate/domain/mateChat/entity/MateChatRoomMember.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "chat_room_member")
+@Table(name = "mate_chat_room_member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/example/mate/domain/mateChat/message/MessageType.java
+++ b/src/main/java/com/example/mate/domain/mateChat/message/MessageType.java
@@ -1,0 +1,20 @@
+package com.example.mate.domain.mateChat.message;
+
+import lombok.Getter;
+
+@Getter
+public enum MessageType {
+    ENTER("입장"),      // 채팅방 입장
+    TALK("대화"),       // 일반 메시지
+    LEAVE("퇴장");      // 채팅방 퇴장
+
+    private final String value;
+
+    MessageType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] WebSocket 의존성 주입 및 WebSocketConfig 클래스 설정
- [x] 메이트 채팅 엔티티 설정

## 💡 자세한 설명
WebSocketConfig 를 초반에 설정해놔야 컨트롤러 구현할 때 용이하기 때문에 구현해봤습니다.
설명은 적어놨으니 나중에 url이나 수정해야할 부분 생기시면 같이 수정하면 될거같습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?