### PR TITLE
MATE-77: [FEAT] 굿즈거래 채팅방 채팅내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -71,6 +71,7 @@ public enum ErrorCode {
     // Goods Chat
     GOODS_CHAT_CLOSED_POST(HttpStatus.BAD_REQUEST, "GC001", "거래완료된 판매글에 채팅을 시작할 수 없습니다."),
     GOODS_CHAT_SELLER_CANNOT_START(HttpStatus.BAD_REQUEST, "GC002", "자신의 판매글에 채팅을 시작할 수 없습니다."),
+    GOODS_CHAT_NOT_FOUND_CHAT_PART(HttpStatus.BAD_REQUEST, "GC003", "요청한 회원은 해당 채팅방에 참여한 회원이 아닙니다."),
 
     // Mate Review
     NOT_PARTICIPANT_OR_AUTHOR(HttpStatus.FORBIDDEN, "R002", "리뷰어와 리뷰 대상자 모두 직관 참여자여야 합니다."),

--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatController.java
@@ -5,7 +5,6 @@ import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
 import com.example.mate.domain.goodsChat.service.GoodsChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,11 +19,11 @@ public class GoodsChatController {
 
     /*
     굿즈거래 상세 페이지 - 채팅방 입장
-    TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
+    TODO: @RequestParam Long memberId -> @AuthenticationPrincipal 로 변경
     "/api/goods/chat" 로 변경 예정
     */
-    @PostMapping("/{buyerId}")
-    public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> createGoodsChatRoom(@PathVariable Long buyerId, @RequestParam Long goodsPostId) {
+    @PostMapping
+    public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> createGoodsChatRoom(@RequestParam Long buyerId, @RequestParam Long goodsPostId) {
         GoodsChatRoomResponse response = goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId);
 
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatController.java
@@ -1,10 +1,16 @@
 package com.example.mate.domain.goodsChat.controller;
 
 import com.example.mate.common.response.ApiResponse;
+import com.example.mate.common.response.PageResponse;
+import com.example.mate.domain.goodsChat.dto.response.GoodsChatMsgResponse;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
 import com.example.mate.domain.goodsChat.service.GoodsChatService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,9 +29,23 @@ public class GoodsChatController {
     "/api/goods/chat" 로 변경 예정
     */
     @PostMapping
-    public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> createGoodsChatRoom(@RequestParam Long buyerId, @RequestParam Long goodsPostId) {
+    public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> createGoodsChatRoom(@RequestParam Long buyerId,
+                                                                                  @RequestParam Long goodsPostId) {
         GoodsChatRoomResponse response = goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
+    /*
+    굿즈거래 채팅방 페이지 - 채팅 내역 조회
+    TODO: @RequestParam Long memberId -> @AuthenticationPrincipal 로 변경
+    */
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<ApiResponse<PageResponse<GoodsChatMsgResponse>>> getGoodsChatRoomMessages(
+            @PathVariable Long chatRoomId,
+            @RequestParam Long memberId,
+            @PageableDefault Pageable pageable
+    ) {
+        PageResponse<GoodsChatMsgResponse> response = goodsChatService.getMessagesForChatRoom(chatRoomId, memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatController.java
@@ -39,7 +39,7 @@ public class GoodsChatController {
     굿즈거래 채팅방 페이지 - 채팅 내역 조회
     TODO: @RequestParam Long memberId -> @AuthenticationPrincipal 로 변경
     */
-    @GetMapping("/{chatRoomId}")
+    @GetMapping("/{chatRoomId}/message")
     public ResponseEntity<ApiResponse<PageResponse<GoodsChatMsgResponse>>> getGoodsChatRoomMessages(
             @PathVariable Long chatRoomId,
             @RequestParam Long memberId,

--- a/src/main/java/com/example/mate/domain/goodsChat/dto/response/GoodsChatMsgResponse.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/dto/response/GoodsChatMsgResponse.java
@@ -1,0 +1,34 @@
+package com.example.mate.domain.goodsChat.dto.response;
+
+import com.example.mate.domain.goodsChat.entity.GoodsChatMessage;
+import com.example.mate.domain.goodsChat.entity.GoodsChatPart;
+import com.example.mate.domain.member.entity.Member;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class GoodsChatMsgResponse {
+
+    private final Long chatMessageId;
+    private final Long authorId;
+    private final String content;
+    private final String authorImageUrl;
+    private final LocalDateTime sentAt;
+
+    public static GoodsChatMsgResponse of(GoodsChatMessage chatMessage) {
+        GoodsChatPart goodsChatPart = chatMessage.getGoodsChatPart();
+        Member author = goodsChatPart.getMember();
+
+        return GoodsChatMsgResponse.builder()
+                .chatMessageId(chatMessage.getId())
+                .authorId(author.getId())
+                .authorImageUrl(author.getImageUrl())
+                .content(chatMessage.getContent())
+                .sentAt(chatMessage.getSentAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepository.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepository.java
@@ -1,0 +1,19 @@
+package com.example.mate.domain.goodsChat.repository;
+
+import com.example.mate.domain.goodsChat.entity.GoodsChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GoodsChatMessageRepository extends JpaRepository<GoodsChatMessage, Long> {
+
+    @Query("""
+            SELECT cm
+            FROM GoodsChatMessage cm
+            WHERE cm.goodsChatPart.goodsChatRoom.id = :chatRoomId
+            ORDER BY cm.sentAt DESC
+            """)
+    Page<GoodsChatMessage> findByChatRoomId(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatPartRepository.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatPartRepository.java
@@ -1,0 +1,9 @@
+package com.example.mate.domain.goodsChat.repository;
+
+import com.example.mate.domain.goodsChat.entity.GoodsChatPart;
+import com.example.mate.domain.goodsChat.entity.GoodsChatPartId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GoodsChatPartRepository extends JpaRepository<GoodsChatPart, GoodsChatPartId> {
+
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
@@ -2,16 +2,25 @@ package com.example.mate.domain.goodsChat.service;
 
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.Role;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
+import com.example.mate.domain.goodsChat.dto.response.GoodsChatMsgResponse;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
+import com.example.mate.domain.goodsChat.entity.GoodsChatMessage;
+import com.example.mate.domain.goodsChat.entity.GoodsChatPartId;
 import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
+import com.example.mate.domain.goodsChat.repository.GoodsChatMessageRepository;
+import com.example.mate.domain.goodsChat.repository.GoodsChatPartRepository;
 import com.example.mate.domain.goodsChat.repository.GoodsChatRoomRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +32,8 @@ public class GoodsChatService {
     private final GoodsPostRepository goodsPostRepository;
     private final MemberRepository memberRepository;
     private final GoodsChatRoomRepository chatRoomRepository;
+    private final GoodsChatPartRepository partRepository;
+    private final GoodsChatMessageRepository messageRepository;
 
     public GoodsChatRoomResponse getOrCreateGoodsChatRoom(Long buyerId, Long goodsPostId) {
         Member buyer = findMemberById(buyerId);
@@ -53,7 +64,6 @@ public class GoodsChatService {
                 .build();
         
         GoodsChatRoom savedChatRoom = chatRoomRepository.save(goodsChatRoom);
-
         savedChatRoom.addChatParticipant(buyer, Role.BUYER);
         savedChatRoom.addChatParticipant(seller, Role.SELLER);
 
@@ -68,5 +78,24 @@ public class GoodsChatService {
     private GoodsPost findGoodsPostById(Long goodsPostId) {
         return goodsPostRepository.findById(goodsPostId).orElseThrow(() ->
                 new CustomException(ErrorCode.GOODS_NOT_FOUND_BY_ID));
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<GoodsChatMsgResponse> getMessagesForChatRoom(Long chatRoomId, Long memberId, Pageable pageable) {
+        validateMemberParticipation(chatRoomId, memberId);
+        Pageable validatePageable = PageResponse.validatePageable(pageable);
+
+        Page<GoodsChatMessage> chatMessagePage = messageRepository.findByChatRoomId(chatRoomId, validatePageable);
+        List<GoodsChatMsgResponse> content = chatMessagePage.getContent().stream()
+                .map(GoodsChatMsgResponse::of)
+                .toList();
+
+        return PageResponse.from(chatMessagePage, content);
+    }
+
+    private void validateMemberParticipation(Long chatRoomId, Long memberId) {
+        if (!partRepository.existsById(new GoodsChatPartId(chatRoomId, memberId))) {
+            throw new CustomException(ErrorCode.GOODS_CHAT_NOT_FOUND_CHAT_PART);
+        }
     }
 }

--- a/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatControllerTest.java
@@ -144,7 +144,7 @@ class GoodsChatControllerTest {
         when(goodsChatService.getMessagesForChatRoom(chatRoomId, memberId, pageable)).thenReturn(pageResponse);
 
         // when & then
-        mockMvc.perform(get("/api/goods/chat/{chatRoomId}", chatRoomId)
+        mockMvc.perform(get("/api/goods/chat/{chatRoomId}/message", chatRoomId)
                         .param("memberId", String.valueOf(memberId))
                         .param("page", "0")
                         .param("size", "10"))

--- a/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatControllerTest.java
@@ -50,7 +50,8 @@ class GoodsChatControllerTest {
                 .thenReturn(existingChatRoomResponse);
 
         // when & then
-        mockMvc.perform(post("/api/goods/chat/{buyerId}", buyerId)
+        mockMvc.perform(post("/api/goods/chat", buyerId)
+                        .param("buyerId", String.valueOf(buyerId))
                         .param("goodsPostId", String.valueOf(goodsPostId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
@@ -89,7 +90,8 @@ class GoodsChatControllerTest {
                 .thenReturn(newChatRoomResponse);
 
         // when & then
-        mockMvc.perform(post("/api/goods/chat/{buyerId}", buyerId)
+        mockMvc.perform(post("/api/goods/chat", buyerId)
+                        .param("buyerId", String.valueOf(buyerId))
                         .param("goodsPostId", String.valueOf(goodsPostId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))

--- a/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatControllerTest.java
@@ -7,14 +7,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.mate.common.response.PageResponse;
+import com.example.mate.domain.goodsChat.dto.response.GoodsChatMsgResponse;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
 import com.example.mate.domain.goodsChat.service.GoodsChatService;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -107,4 +113,51 @@ class GoodsChatControllerTest {
 
         verify(goodsChatService).getOrCreateGoodsChatRoom(buyerId, goodsPostId);
     }
+
+    @Test
+    @DisplayName("채팅 내역 조회 성공 - 회원이 채팅방에 참여한 경우 메시지를 페이지로 반환한다.")
+    void getMessagesForChatRoom_should_return_messages() throws Exception {
+        // given
+        Long chatRoomId = 1L;
+        Long memberId = 2L;
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        GoodsChatMsgResponse firstMessage = GoodsChatMsgResponse.builder()
+                .chatMessageId(1L)
+                .content("first message")
+                .authorId(memberId)
+                .sentAt(LocalDateTime.now().minusMinutes(10))
+                .build();
+
+        GoodsChatMsgResponse secondMessage = GoodsChatMsgResponse.builder()
+                .chatMessageId(2L)
+                .content("second message")
+                .authorId(memberId)
+                .sentAt(LocalDateTime.now())
+                .build();
+
+        PageResponse<GoodsChatMsgResponse> pageResponse = PageResponse.from(
+                new PageImpl<>(List.of(secondMessage, firstMessage), pageable, 2),
+                List.of(secondMessage, firstMessage)
+        );
+
+        when(goodsChatService.getMessagesForChatRoom(chatRoomId, memberId, pageable)).thenReturn(pageResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/goods/chat/{chatRoomId}", chatRoomId)
+                        .param("memberId", String.valueOf(memberId))
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content[0].content").value(secondMessage.getContent()))
+                .andExpect(jsonPath("$.data.content[0].chatMessageId").value(secondMessage.getChatMessageId()))
+                .andExpect(jsonPath("$.data.content[1].content").value(firstMessage.getContent()))
+                .andExpect(jsonPath("$.data.content[1].chatMessageId").value(firstMessage.getChatMessageId()));
+
+        verify(goodsChatService).getMessagesForChatRoom(chatRoomId, memberId, pageable);
+    }
+
 }

--- a/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
@@ -61,7 +61,8 @@ public class GoodsChatIntegrationTest {
         Long goodsPostId = goodsPost.getId();
 
         // when
-        MockHttpServletResponse result = mockMvc.perform(post("/api/goods/chat/{buyerId}", buyerId)
+        MockHttpServletResponse result = mockMvc.perform(post("/api/goods/chat", buyerId)
+                        .param("buyerId", String.valueOf(buyerId))
                         .param("goodsPostId", String.valueOf(goodsPostId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))

--- a/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
@@ -125,7 +125,7 @@ public class GoodsChatIntegrationTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when & then
-        mockMvc.perform(get("/api/goods/chat/{chatRoomId}", chatRoomId)
+        mockMvc.perform(get("/api/goods/chat/{chatRoomId}/message", chatRoomId)
                         .param("memberId", String.valueOf(memberId))
                         .param("page", String.valueOf(pageable.getPageNumber()))
                         .param("size", String.valueOf(pageable.getPageSize())))


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 채팅방 채팅내역 조회 기능 구현
- [x] 굿즈거래 채팅방 채팅내역 조회 테스트 코드 작성

## 💡 자세한 설명
<img width="364" alt="image" src="https://github.com/user-attachments/assets/a2f49b9c-d13f-4b8e-b302-734f30e96d0d">

#### `GET api/goods/chat/{chatRoomId}/message`
- 사용자가 굿즈거래 채팅방에 입장했을 때, 최근 채팅 내역을 조회하는 기능입니다.
- 유효성 검증은 `회원 ID, 채팅방 ID` 를 검사해서 굿즈거래 채팅참여(`GoodsChatPart`) 엔티티가 있는지 확인했습니다.
- 추가된 도메인 규칙은 없습니다.

> 채팅은 보낸시간(`sendAt`)을 기준으로 내림차순 정렬했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?