### PR TITLE
MATE-86 : [FEAT] 토큰 발급을 위한 CATCH Mi 로그인 기능 구현 및 회원 URI 수정

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     UNSUPPORTED_RESPONSE_TYPE(HttpStatus.BAD_REQUEST, "M002", "회원 프로필 조회에서 지원하지 않는 응답 타입입니다."),
     ALREADY_USED_NICKNAME(HttpStatus.BAD_REQUEST, "M003", "이미 사용 중인 닉네임입니다."),
     MEMBER_NOT_FOUND_BY_EMAIL(HttpStatus.NOT_FOUND, "M004", "해당 이메일의 회원 정보를 찾을 수 없습니다."),
+    MEMBER_UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "M005", "해당 회원의 접근 권한이 없습니다."),
 
     // Follow
     ALREADY_FOLLOWED_MEMBER(HttpStatus.BAD_REQUEST, "F001", "이미 팔로우한 회원입니다."),

--- a/src/main/java/com/example/mate/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/mate/domain/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.example.mate.common.jwt.JwtToken;
 import com.example.mate.domain.auth.dto.response.LoginResponse;
 import com.example.mate.domain.auth.service.NaverAuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
@@ -30,8 +31,9 @@ public class AuthController {
      */
     @Operation(summary = "네이버 소셜 인증 페이지 리다이렉트")
     @GetMapping("/connect/naver")
-    public RedirectView connectNaver() {
-        return new RedirectView(naverAuthService.getAuthUrl());
+    public RedirectView connectNaver(
+            @Parameter(description = "네이버 로그인 요청 state") @RequestParam String state) {
+        return new RedirectView(naverAuthService.getAuthUrl(state));
     }
 
     /**

--- a/src/main/java/com/example/mate/domain/auth/service/NaverAuthService.java
+++ b/src/main/java/com/example/mate/domain/auth/service/NaverAuthService.java
@@ -32,12 +32,12 @@ public class NaverAuthService {
      *
      * @return 네이버 로그인 URL
      */
-    public String getAuthUrl() {
+    public String getAuthUrl(String state) {
         return "https://nid.naver.com/oauth2.0/authorize"
                 + "?client_id=" + oAuthConfig.getNaverClientId()
                 + "&redirect_uri=" + oAuthConfig.getNaverRedirectUri()
                 + "&response_type=code"
-                + "&state=STATE_STRING";
+                + "&state=" + state;
     }
 
     /**

--- a/src/main/java/com/example/mate/domain/crawler/scheduler/CrawlingScheduler.java
+++ b/src/main/java/com/example/mate/domain/crawler/scheduler/CrawlingScheduler.java
@@ -43,19 +43,19 @@ public class CrawlingScheduler {
         }
     }
 
-//    // 매 분 실행 자동화 테스트 (현재 off-season )
-//    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
-//    public void testScheduler() {
-//        log.info("Test Scheduler is running!");
-//        try {
-//            // 현재 경기 크롤링
-//            crawlingService.crawlAllCurrentMatches();
-//            // 팀 순위 크롤링
-//            crawlingService.crawlTeamRankings();
-//        } catch (CustomException e) {
-//            log.error("Evening update failed: {}", e.getErrorCode().getMessage(), e);
-//        } catch (Exception e) {
-//            log.error("Evening update failed with unexpected error", e);
-//        }
-//    }
+    // 매 분 실행 자동화 테스트 (현재 off-season )
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    public void testScheduler() {
+        log.info("Test Scheduler is running!");
+        try {
+            // 현재 경기 크롤링
+            crawlingService.crawlAllCurrentMatches();
+            // 팀 순위 크롤링
+            crawlingService.crawlTeamRankings();
+        } catch (CustomException e) {
+            log.error("Evening update failed: {}", e.getErrorCode().getMessage(), e);
+        } catch (Exception e) {
+            log.error("Evening update failed with unexpected error", e);
+        }
+    }
 }

--- a/src/main/java/com/example/mate/domain/member/controller/FollowController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/FollowController.java
@@ -4,6 +4,7 @@ import static com.example.mate.common.response.PageResponse.validatePageable;
 
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
+import com.example.mate.common.security.auth.AuthMember;
 import com.example.mate.domain.member.dto.response.MemberSummaryResponse;
 import com.example.mate.domain.member.service.FollowService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,12 +14,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,29 +30,21 @@ public class FollowController {
 
     private final FollowService followService;
 
-    /*
-    TODO : 2024/11/29 - 회원 팔로우 기능
-    1. JwtToken 을 통해 사용자 정보 조회 - 현재는 임시로 @RequestParam 사용
-    */
     @Operation(summary = "회원 팔로우 기능")
     @PostMapping("/follow/{memberId}")
     public ResponseEntity<ApiResponse<Void>> followMember(
             @Parameter(description = "팔로우할 회원 ID") @PathVariable Long memberId,
-            @Parameter(description = "팔로우하는 회원 ID") @RequestParam Long followerId) {
-        followService.follow(followerId, memberId);
+            @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember) {
+        followService.follow(authMember.getMemberId(), memberId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
-    /*
-    TODO : 2024/11/29 - 회원 언팔로우 기능
-    1. JwtToken 을 통해 사용자 정보 조회 - 현재는 임시로 @RequestParam 사용
-    */
     @Operation(summary = "회원 언팔로우 기능")
     @DeleteMapping("/follow/{memberId}")
     public ResponseEntity<Void> unfollowMember(
             @Parameter(description = "언팔로우할 회원 ID") @PathVariable Long memberId,
-            @Parameter(description = "언팔로우하는 회원 ID") @RequestParam Long unfollowerId) {
-        followService.unfollow(unfollowerId, memberId);
+            @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember) {
+        followService.unfollow(authMember.getMemberId(), memberId);
         return ResponseEntity.noContent().build();
     }
 
@@ -59,7 +52,7 @@ public class FollowController {
     @GetMapping("{memberId}/followings")
     public ResponseEntity<ApiResponse<PageResponse<MemberSummaryResponse>>> getFollowings(
             @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
-            @PageableDefault Pageable pageable
+            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
     ) {
         pageable = validatePageable(pageable);
         PageResponse<MemberSummaryResponse> response = followService.getFollowingsPage(memberId, pageable);
@@ -70,7 +63,7 @@ public class FollowController {
     @GetMapping("{memberId}/followers")
     public ResponseEntity<ApiResponse<PageResponse<MemberSummaryResponse>>> getFollowers(
             @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
-            @PageableDefault Pageable pageable
+            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
     ) {
         pageable = validatePageable(pageable);
         PageResponse<MemberSummaryResponse> response = followService.getFollowersPage(memberId, pageable);

--- a/src/main/java/com/example/mate/domain/member/dto/request/MemberInfoUpdateRequest.java
+++ b/src/main/java/com/example/mate/domain/member/dto/request/MemberInfoUpdateRequest.java
@@ -6,9 +6,9 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 
-@Getter
+@Data
 @Builder
 public class MemberInfoUpdateRequest {
 

--- a/src/main/java/com/example/mate/domain/member/dto/response/MemberLoginResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MemberLoginResponse.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.member.dto.response;
 
+import com.example.mate.common.jwt.JwtToken;
 import com.example.mate.domain.member.entity.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,13 +17,12 @@ public class MemberLoginResponse {
     private final String accessToken;
     private final String refreshToken;
 
-    // TODO : 파라미터로 JwtToken 추가 및 토큰 매핑
-    public static MemberLoginResponse from(Member member) {
+    public static MemberLoginResponse from(Member member, JwtToken jwtToken) {
         return MemberLoginResponse.builder()
                 .memberId(member.getId())
-                .grantType("Bearer")
-                .accessToken("accessToken")
-                .refreshToken("refreshToken")
+                .grantType(jwtToken.getGrantType())
+                .accessToken(jwtToken.getAccessToken())
+                .refreshToken(jwtToken.getRefreshToken())
                 .build();
     }
 }

--- a/src/main/java/com/example/mate/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/mate/domain/member/service/MemberService.java
@@ -49,13 +49,10 @@ public class MemberService {
         return JoinResponse.from(savedMember);
     }
 
-    // TODO : JWT 토큰 발급
     // 자체 로그인 기능
     public MemberLoginResponse loginByEmail(MemberLoginRequest request) {
         Member member = findByEmail(request.getEmail());
-        // 토큰 발급한 뒤 member와 함께 넘기기
-        JwtToken jwtToken = makeToken(member);
-        return MemberLoginResponse.from(member);
+        return MemberLoginResponse.from(member, makeToken(member));
     }
 
     // JWT 토큰 생성
@@ -75,7 +72,6 @@ public class MemberService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_EMAIL));
     }
 
-    // TODO : JWT 도입 이후 본인만 접근할 수 있도록 수정
     // 내 프로필 조회
     public MyProfileResponse getMyProfile(Long memberId) {
         return getProfile(memberId, MyProfileResponse.class);
@@ -86,7 +82,6 @@ public class MemberService {
         return getProfile(memberId, MemberProfileResponse.class);
     }
 
-    // TODO : JWT 도입 이후 본인만 접근할 수 있도록 수정
     // 회원 정보 수정
     public MyProfileResponse updateMyProfile(MultipartFile image, MemberInfoUpdateRequest request) {
         Member member = findByMemberId(request.getMemberId());
@@ -104,7 +99,6 @@ public class MemberService {
         return MyProfileResponse.from(memberRepository.save(member));
     }
 
-    // TODO : JWT 도입 이후 본인만 접근할 수 있도록 수정
     // 회원 탈퇴
     public void deleteMember(Long memberId) {
         findByMemberId(memberId);

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -25,10 +25,9 @@ springdoc:
 
 
 oauth:
-  naver:
-    client-id: ${NAVER_CLIENT_ID}
-    redirect-uri: ${NAVER_REDIRECT_URI}
-    client-secret: ${NAVER_CLIENT_SECRET}
+  naver_client_id: ${NAVER_CLIENT_ID}
+  naver_redirect_uri: ${NAVER_REDIRECT_URI}
+  naver_client_secret: ${NAVER_CLIENT_SECRET}
 
 jwt:
   secret_key: ${JWT_SECRET_KEY}

--- a/src/test/java/com/example/mate/config/WithAuthMember.java
+++ b/src/test/java/com/example/mate/config/WithAuthMember.java
@@ -1,0 +1,15 @@
+package com.example.mate.config;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithAuthMemberSecurityContextFactory.class)
+public @interface WithAuthMember {
+    String userId() default "testUser";
+
+    long memberId() default 1L;
+
+    String[] roles() default {"USER"};
+}

--- a/src/test/java/com/example/mate/config/WithAuthMemberSecurityContextFactory.java
+++ b/src/test/java/com/example/mate/config/WithAuthMemberSecurityContextFactory.java
@@ -1,0 +1,28 @@
+package com.example.mate.config;
+
+import com.example.mate.common.security.auth.AuthMember;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithAuthMemberSecurityContextFactory implements WithSecurityContextFactory<WithAuthMember> {
+    @Override
+    public SecurityContext createSecurityContext(WithAuthMember annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        AuthMember authMember = new AuthMember(annotation.userId(), annotation.memberId());
+        List<SimpleGrantedAuthority> authorities = Arrays.stream(annotation.roles())
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                .collect(Collectors.toList());
+
+        Authentication auth = new UsernamePasswordAuthenticationToken(authMember, null, authorities);
+        context.setAuthentication(auth);
+        return context;
+    }
+}

--- a/src/test/java/com/example/mate/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/mate/domain/auth/controller/AuthControllerTest.java
@@ -39,10 +39,11 @@ public class AuthControllerTest {
     void connectNaver_Success() throws Exception {
         // given
         String expectedAuthUrl = "https://nid.naver.com/oauth2.0/authorize?client_id=testClientId&redirect_uri=testRedirectUri&response_type=code&state=STATE_STRING";
-        when(naverAuthService.getAuthUrl()).thenReturn(expectedAuthUrl);
+        when(naverAuthService.getAuthUrl("state")).thenReturn(expectedAuthUrl);
 
         // when & then
-        mockMvc.perform(get("/api/auth/connect/naver"))
+        mockMvc.perform(get("/api/auth/connect/naver")
+                        .param("state", "state"))
                 .andExpect(status().is3xxRedirection()) // 3xx 리다이렉션 응답 상태
                 .andExpect(redirectedUrl(expectedAuthUrl)); // 리다이렉트 URL 확인
     }

--- a/src/test/java/com/example/mate/domain/auth/integration/NaverAuthIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/auth/integration/NaverAuthIntegrationTest.java
@@ -77,7 +77,8 @@ public class NaverAuthIntegrationTest {
                 + "&state=STATE_STRING";
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/auth/connect/naver"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/auth/connect/naver")
+                        .param("state", "STATE_STRING"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(header().string("Location", is(expectedUrl)));
     }

--- a/src/test/java/com/example/mate/domain/auth/service/NaverAuthServiceTest.java
+++ b/src/test/java/com/example/mate/domain/auth/service/NaverAuthServiceTest.java
@@ -42,7 +42,7 @@ public class NaverAuthServiceTest {
     @DisplayName("네이버 로그인 연결 URL 생성")
     public void getAuthUrl_Success() {
         // when
-        String authUrl = naverAuthService.getAuthUrl();
+        String authUrl = naverAuthService.getAuthUrl("state");
 
         // then
         assertTrue(authUrl.startsWith("https://nid.naver.com/oauth2.0/authorize"));

--- a/src/test/java/com/example/mate/domain/member/controller/FollowControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/FollowControllerTest.java
@@ -19,6 +19,7 @@ import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.filter.JwtCheckFilter;
+import com.example.mate.config.WithAuthMember;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.member.dto.response.MemberSummaryResponse;
 import com.example.mate.domain.member.entity.Follow;
@@ -41,6 +42,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(FollowController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureMockMvc(addFilters = false)
+@WithAuthMember(userId = "customUser", memberId = 1L)
 class FollowControllerTest {
 
     @Autowired
@@ -96,8 +98,7 @@ class FollowControllerTest {
             willDoNothing().given(followService).follow(followerId, followingId);
 
             // when & then
-            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId)
-                            .param("followerId", String.valueOf(followerId)))
+            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId))
                     .andExpect(status().isOk())
                     .andDo(print());
 
@@ -116,8 +117,7 @@ class FollowControllerTest {
                     .given(followService).follow(followerId, followingId);
 
             // when & then
-            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId)
-                            .param("followerId", String.valueOf(followerId)))
+            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId))
                     .andExpect(status().isBadRequest())  // 400 Bad Request
                     .andDo(print());
 
@@ -136,8 +136,7 @@ class FollowControllerTest {
                     .given(followService).follow(followerId, followingId);
 
             // when & then
-            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId)
-                            .param("followerId", String.valueOf(followerId)))
+            mockMvc.perform(post("/api/profile/follow/{memberId}", followingId))
                     .andExpect(status().isNotFound())  // 404 Not Found
                     .andDo(print());
 
@@ -159,8 +158,7 @@ class FollowControllerTest {
             willDoNothing().given(followService).unfollow(unfollowerId, unfollowingId);
 
             // when & then
-            mockMvc.perform(delete("/api/profile/follow/{memberId}", unfollowingId)
-                            .param("unfollowerId", String.valueOf(unfollowerId)))
+            mockMvc.perform(delete("/api/profile/follow/{memberId}", unfollowingId))
                     .andExpect(status().isNoContent())
                     .andDo(print());
 
@@ -179,8 +177,7 @@ class FollowControllerTest {
                     .given(followService).unfollow(unfollowerId, unfollowingId);
 
             // when & then
-            mockMvc.perform(delete("/api/profile/follow/{memberId}", unfollowingId)
-                            .param("unfollowerId", String.valueOf(unfollowerId)))
+            mockMvc.perform(delete("/api/profile/follow/{memberId}", unfollowingId))
                     .andExpect(status().isBadRequest())
                     .andDo(print());
 
@@ -199,8 +196,7 @@ class FollowControllerTest {
                     .given(followService).unfollow(unfollowerId, unfollowingId);
 
             // when & then
-            mockMvc.perform(delete("/api/profile/follow/{memberId}", unfollowingId)
-                            .param("unfollowerId", String.valueOf(unfollowerId)))
+            mockMvc.perform(delete("/api/profile/follow/{memberId}", unfollowingId))
                     .andExpect(status().isNotFound())
                     .andDo(print());
 

--- a/src/test/java/com/example/mate/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/MemberControllerTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.security.filter.JwtCheckFilter;
+import com.example.mate.config.WithAuthMember;
 import com.example.mate.domain.member.dto.request.JoinRequest;
 import com.example.mate.domain.member.dto.request.MemberInfoUpdateRequest;
 import com.example.mate.domain.member.dto.response.JoinResponse;
@@ -39,6 +40,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(MemberController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureMockMvc(addFilters = false)
+@WithAuthMember(userId = "customUser", memberId = 1L)
 class MemberControllerTest {
 
     @Autowired
@@ -207,8 +209,7 @@ class MemberControllerTest {
             given(memberService.getMyProfile(memberId)).willReturn(response);
 
             // when & then
-            mockMvc.perform(get("/api/members/me")
-                            .param("memberId", memberId.toString()))
+            mockMvc.perform(get("/api/members/me"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value("SUCCESS"))
                     .andExpect(jsonPath("$.data.nickname").value("tester"))
@@ -229,32 +230,16 @@ class MemberControllerTest {
         @DisplayName("내 프로필 조회 실패 - 회원이 존재하지 않는 경우")
         void get_my_profile_member_not_found() throws Exception {
             // given
-            Long memberId = 999L;
+            Long memberId = 1L;
 
             given(memberService.getMyProfile(memberId)).willThrow(
                     new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
 
             // when & then
-            mockMvc.perform(get("/api/members/me")
-                            .param("memberId", memberId.toString()))
+            mockMvc.perform(get("/api/members/me"))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.status").value("ERROR"))
                     .andExpect(jsonPath("$.message").value("해당 ID의 회원 정보를 찾을 수 없습니다"))
-                    .andDo(print());
-        }
-
-        @Test
-        @DisplayName("내 프로필 조회 실패 - 잘못된 memberId 형식")
-        void get_my_profile_invalid_member_id() throws Exception {
-            // given
-            String invalidMemberId = "invalid";  // 숫자가 아닌 잘못된 ID
-
-            // when & then
-            mockMvc.perform(get("/api/members/me")
-                            .param("memberId", invalidMemberId))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.status").value("ERROR"))
-                    .andExpect(jsonPath("$.message").value("잘못된 입력 형식입니다. 'invalid' 타입이 'Long'로 변환될 수 없습니다."))
                     .andDo(print());
         }
     }
@@ -371,8 +356,7 @@ class MemberControllerTest {
             willDoNothing().given(memberService).deleteMember(memberId);
 
             // when & then
-            mockMvc.perform(delete("/api/members/me")
-                            .param("memberId", memberId.toString()))
+            mockMvc.perform(delete("/api/members/me"))
                     .andDo(print())
                     .andExpect(status().isNoContent());
 
@@ -383,14 +367,13 @@ class MemberControllerTest {
         @DisplayName("회원 탈퇴 실패 - 존재하지 않는 회원")
         void delete_member_fail_not_exists_member() throws Exception {
             // given
-            Long memberId = 999L;
+            Long memberId = 1L;
 
             willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID))
                     .given(memberService).deleteMember(memberId);
 
             // when & then
-            mockMvc.perform(delete("/api/members/me")
-                            .param("memberId", memberId.toString()))
+            mockMvc.perform(delete("/api/members/me"))
                     .andDo(print())
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.status").value("ERROR"))


### PR DESCRIPTION
## 💡 작업 내용

- [x] 소셜 로그인 후 토큰 발급을 위한 로그인 기능
- [x] AuthMember를 활용해 회원 도메인 URI 전부 수정
- [x] 테스트 통과
- [x] application-common.yml의 네이버 value 필드명 수정
- [x] 팀 순위 1분 스케쥴러 주석 해제

## 💡 자세한 설명

#### 소셜 로그인 후 토큰을 발급받는 로그인 구현

- 해당 기능은 accessToken, refreshToken, memberId를 응답합니다.

#### 도메인 규칙

![스크린샷 2024-12-07 오후 9 36 11](https://github.com/user-attachments/assets/04eff60f-4cba-424b-949f-89ebd9e63cce)


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?