### PR TITLE
MATE-89 : [FIX] KT 팀 이름 변경으로 인한 파싱 에러 해결

### DIFF
--- a/src/main/java/com/example/mate/domain/crawler/controller/CrawlingController.java
+++ b/src/main/java/com/example/mate/domain/crawler/controller/CrawlingController.java
@@ -95,8 +95,8 @@ public class CrawlingController {
     //테스트
     @PostMapping("/matches/custom")
     public ResponseEntity<CrawlingStatusResponse> crawlCustomDateMatches() {
-        // 3월로 가정하고 크롤링
-        LocalDate customDate = LocalDate.of(2024, 3, 1);
+        // 9월로 가정하고 크롤링
+        LocalDate customDate = LocalDate.of(2024, 9, 1);
         return ResponseEntity.ok(crawlingService.crawlMatchesFromCustomDate(customDate));
     }
 

--- a/src/main/java/com/example/mate/domain/crawler/service/CrawlingService.java
+++ b/src/main/java/com/example/mate/domain/crawler/service/CrawlingService.java
@@ -465,7 +465,7 @@ public class CrawlingService {
         String fullTeamName = switch (teamName) {
             case "삼성" -> "삼성 라이온즈";
             case "LG" -> "LG 트윈스";
-            case "KT", "kt" -> "kt wiz";
+            case "KT" -> "KT 위즈";
             case "NC" -> "NC 다이노스";
             case "SSG" -> "SSG 랜더스";
             case "롯데" -> "롯데 자이언츠";


### PR DESCRIPTION
## 💡 작업 내용

- [x] 크롤링 작업 중 KT 팀 이름 파싱 에러

## 💡 자세한 설명
- 1. 크롤링 서비스 중 KT 팀 이름 변경
- 2. custom API 9월로 변경

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?