### PR TITLE
MATE-94 : [REFACTOR] 굿즈거래 채팅방 입장 기능 리팩토링

### DIFF
--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatMessageController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatMessageController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 
 @Controller
 @RequiredArgsConstructor
@@ -14,7 +15,7 @@ public class GoodsChatMessageController {
     private final GoodsChatMessageService goodsChatMessageService;
 
     @MessageMapping("/chat/goods/message")
-    public void handleMessage(@Payload GoodsChatMessageRequest message) {
+    public void handleMessage(@Validated @Payload GoodsChatMessageRequest message) {
         goodsChatMessageService.sendMessage(message);
     }
 }

--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
@@ -29,11 +29,6 @@ public class GoodsChatRoomController {
 
     private final GoodsChatService goodsChatService;
 
-    /*
-    굿즈거래 상세 페이지 - 채팅방 입장
-    TODO: @RequestParam Long memberId -> @AuthenticationPrincipal 로 변경
-    "/api/goods/chat" 로 변경 예정
-    */
     @PostMapping
     public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> createGoodsChatRoom(@AuthenticationPrincipal AuthMember member,
                                                                                   @RequestParam Long goodsPostId) {
@@ -41,10 +36,6 @@ public class GoodsChatRoomController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /*
-    굿즈거래 채팅방 페이지 - 채팅 내역 조회
-    TODO: @RequestParam Long memberId -> @AuthenticationPrincipal 로 변경
-    */
     @GetMapping("/{chatRoomId}/message")
     public ResponseEntity<ApiResponse<PageResponse<GoodsChatMessageResponse>>> getGoodsChatRoomMessages(
             @AuthenticationPrincipal AuthMember member,
@@ -55,10 +46,6 @@ public class GoodsChatRoomController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /*
-    굿즈거래 채팅방 리스트 페이지 - 내가 참여한 채팅방 리스트 조회
-    TODO: @RequestParam Long memberId -> @AuthenticationPrincipal 로 변경
-    */
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<GoodsChatRoomSummaryResponse>>> getGoodsChatRooms(@AuthenticationPrincipal AuthMember member,
                                                                                                      @PageableDefault Pageable pageable) {
@@ -66,7 +53,6 @@ public class GoodsChatRoomController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // 채팅방 나가기
     @DeleteMapping("/{chatRoomId}")
     public ResponseEntity<Void> leaveGoodsChatRoom(@AuthenticationPrincipal AuthMember member, @PathVariable Long chatRoomId) {
         goodsChatService.deactivateGoodsChatPart(member.getMemberId(), chatRoomId);
@@ -74,10 +60,6 @@ public class GoodsChatRoomController {
         return ResponseEntity.noContent().build();
     }
 
-    /*
-    굿즈거래 채팅방 리스트 페이지 - 채팅방 단건 조회
-    TODO: @RequestParam Long memberId -> @AuthenticationPrincipal 로 변경
-    */
     @GetMapping("/{chatRoomId}")
     public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> getGoodsChatRoomInfo(@AuthenticationPrincipal AuthMember member,
                                                                                    @PathVariable Long chatRoomId) {
@@ -85,7 +67,6 @@ public class GoodsChatRoomController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // 채팅방 하단 토글 - 현재 채팅에 참여한 사용자 프로필 조회
     @GetMapping("/{chatRoomId}/members")
     public ResponseEntity<ApiResponse<List<MemberSummaryResponse>>> getGoodsChatRoomMembers(@AuthenticationPrincipal AuthMember member,
                                                                                             @PathVariable Long chatRoomId) {

--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
@@ -47,7 +47,7 @@ public class GoodsChatRoomController {
     public ResponseEntity<ApiResponse<PageResponse<GoodsChatMessageResponse>>> getGoodsChatRoomMessages(
             @PathVariable Long chatRoomId,
             @RequestParam Long memberId,
-            @PageableDefault Pageable pageable
+            @PageableDefault(page = 1, size = 20) Pageable pageable
     ) {
         PageResponse<GoodsChatMessageResponse> response = goodsChatService.getMessagesForChatRoom(chatRoomId, memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
@@ -2,6 +2,7 @@ package com.example.mate.domain.goodsChat.controller;
 
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
+import com.example.mate.common.security.auth.AuthMember;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatMessageResponse;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomSummaryResponse;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,9 +35,9 @@ public class GoodsChatRoomController {
     "/api/goods/chat" 로 변경 예정
     */
     @PostMapping
-    public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> createGoodsChatRoom(@RequestParam Long buyerId,
+    public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> createGoodsChatRoom(@AuthenticationPrincipal AuthMember member,
                                                                                   @RequestParam Long goodsPostId) {
-        GoodsChatRoomResponse response = goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId);
+        GoodsChatRoomResponse response = goodsChatService.getOrCreateGoodsChatRoom(member.getMemberId(), goodsPostId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -45,11 +47,11 @@ public class GoodsChatRoomController {
     */
     @GetMapping("/{chatRoomId}/message")
     public ResponseEntity<ApiResponse<PageResponse<GoodsChatMessageResponse>>> getGoodsChatRoomMessages(
+            @AuthenticationPrincipal AuthMember member,
             @PathVariable Long chatRoomId,
-            @RequestParam Long memberId,
             @PageableDefault(page = 1, size = 20) Pageable pageable
     ) {
-        PageResponse<GoodsChatMessageResponse> response = goodsChatService.getMessagesForChatRoom(chatRoomId, memberId, pageable);
+        PageResponse<GoodsChatMessageResponse> response = goodsChatService.getMessagesForChatRoom(chatRoomId, member.getMemberId(), pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -58,16 +60,16 @@ public class GoodsChatRoomController {
     TODO: @RequestParam Long memberId -> @AuthenticationPrincipal 로 변경
     */
     @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<GoodsChatRoomSummaryResponse>>> getGoodsChatRooms(@RequestParam Long memberId,
+    public ResponseEntity<ApiResponse<PageResponse<GoodsChatRoomSummaryResponse>>> getGoodsChatRooms(@AuthenticationPrincipal AuthMember member,
                                                                                                      @PageableDefault Pageable pageable) {
-        PageResponse<GoodsChatRoomSummaryResponse> response = goodsChatService.getGoodsChatRooms(memberId, pageable);
+        PageResponse<GoodsChatRoomSummaryResponse> response = goodsChatService.getGoodsChatRooms(member.getMemberId(), pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 채팅방 나가기
     @DeleteMapping("/{chatRoomId}")
-    public ResponseEntity<Void> leaveGoodsChatRoom(@RequestParam Long memberId, @PathVariable Long chatRoomId) {
-        goodsChatService.deactivateGoodsChatPart(memberId, chatRoomId);
+    public ResponseEntity<Void> leaveGoodsChatRoom(@AuthenticationPrincipal AuthMember member, @PathVariable Long chatRoomId) {
+        goodsChatService.deactivateGoodsChatPart(member.getMemberId(), chatRoomId);
 
         return ResponseEntity.noContent().build();
     }
@@ -77,17 +79,17 @@ public class GoodsChatRoomController {
     TODO: @RequestParam Long memberId -> @AuthenticationPrincipal 로 변경
     */
     @GetMapping("/{chatRoomId}")
-    public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> getGoodsChatRoomInfo(@RequestParam Long memberId,
+    public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> getGoodsChatRoomInfo(@AuthenticationPrincipal AuthMember member,
                                                                                    @PathVariable Long chatRoomId) {
-        GoodsChatRoomResponse response = goodsChatService.getGoodsChatRoomInfo(memberId, chatRoomId);
+        GoodsChatRoomResponse response = goodsChatService.getGoodsChatRoomInfo(member.getMemberId(), chatRoomId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 채팅방 하단 토글 - 현재 채팅에 참여한 사용자 프로필 조회
     @GetMapping("/{chatRoomId}/members")
-    public ResponseEntity<ApiResponse<List<MemberSummaryResponse>>> getGoodsChatRoomMembers(@RequestParam Long memberId,
+    public ResponseEntity<ApiResponse<List<MemberSummaryResponse>>> getGoodsChatRoomMembers(@AuthenticationPrincipal AuthMember member,
                                                                                             @PathVariable Long chatRoomId) {
-        List<MemberSummaryResponse> responses = goodsChatService.getChatRoomMembers(memberId, chatRoomId);
+        List<MemberSummaryResponse> responses = goodsChatService.getChatRoomMembers(member.getMemberId(), chatRoomId);
         return ResponseEntity.ok(ApiResponse.success(responses));
     }
 }

--- a/src/main/java/com/example/mate/domain/goodsChat/dto/request/GoodsChatMessageRequest.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/dto/request/GoodsChatMessageRequest.java
@@ -1,13 +1,22 @@
 package com.example.mate.domain.goodsChat.dto.request;
 
 import com.example.mate.domain.constant.MessageType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class GoodsChatMessageRequest {
 
+    @NotNull(message = "채팅방 ID는 필수 입력 값입니다.")
     private Long roomId;
+
+    @NotNull(message = "회원 ID는 필수 입력 값입니다.")
     private Long senderId;
+
+    @NotBlank(message = "메시지는 비어있을 수 없습니다.")
     private String message;
+
+    @NotNull(message = "채팅 타입은 필수 입력 값입니다.")
     private MessageType type;
 }

--- a/src/main/java/com/example/mate/domain/goodsChat/dto/response/GoodsChatRoomResponse.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/dto/response/GoodsChatRoomResponse.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.goodsChat.dto.response;
 
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
@@ -22,7 +23,9 @@ public class GoodsChatRoomResponse {
     private final String chatRoomStatus;
     private final String imageUrl;
 
-    public static GoodsChatRoomResponse of(GoodsChatRoom chatRoom) {
+    private final PageResponse<GoodsChatMessageResponse> initialMessages;
+
+    public static GoodsChatRoomResponse of(GoodsChatRoom chatRoom, PageResponse<GoodsChatMessageResponse> initialMessages) {
         GoodsPost goodsPost = chatRoom.getGoodsPost();
         String mainImageUrl = goodsPost.getMainImageUrl();
         String teamName = getTeamName(goodsPost);
@@ -37,6 +40,7 @@ public class GoodsChatRoomResponse {
                 .imageUrl(mainImageUrl)
                 .postStatus(goodsPost.getStatus().getValue())
                 .chatRoomStatus(chatRoom.getIsActive().toString())
+                .initialMessages(initialMessages)
                 .build();
     }
 

--- a/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepository.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepository.java
@@ -10,10 +10,10 @@ import org.springframework.data.repository.query.Param;
 public interface GoodsChatMessageRepository extends JpaRepository<GoodsChatMessage, Long> {
 
     @Query("""
-            SELECT cm
-            FROM GoodsChatMessage cm
-            WHERE cm.goodsChatPart.goodsChatRoom.id = :chatRoomId
-            ORDER BY cm.sentAt DESC
-            """)
-    Page<GoodsChatMessage> findByChatRoomId(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
+        SELECT cm
+        FROM GoodsChatMessage cm
+        WHERE cm.goodsChatPart.goodsChatRoom.id = :chatRoomId
+        ORDER BY cm.sentAt DESC
+        """)
+    Page<GoodsChatMessage> getChatMessages(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
 }

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageService.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageService.java
@@ -31,9 +31,8 @@ public class GoodsChatMessageService {
     private final GoodsChatMessageRepository messageRepository;
     private final SimpMessagingTemplate messagingTemplate;
 
-    private static final String MEMBER_ENTER_MESSAGE = "님이 채팅방에 입장하셨습니다.";
-    private static final String MEMBER_LEAVE_MESSAGE = "님이 채팅방을 떠나셨습니다.";
-
+    private static final String MEMBER_ENTER_MESSAGE = "님이 대화를 시작했습니다.";
+    private static final String MEMBER_LEAVE_MESSAGE = "님이 대화를 떠났습니다.";
 
     public void sendMessage(GoodsChatMessageRequest message) {
         Member sender = findMemberById(message.getSenderId());

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
@@ -8,8 +8,6 @@ import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.Role;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
-import com.example.mate.domain.goodsChat.event.GoodsChatEvent;
-import com.example.mate.domain.goodsChat.event.GoodsChatEventPublisher;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatMessageResponse;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomSummaryResponse;
@@ -17,6 +15,8 @@ import com.example.mate.domain.goodsChat.entity.GoodsChatMessage;
 import com.example.mate.domain.goodsChat.entity.GoodsChatPart;
 import com.example.mate.domain.goodsChat.entity.GoodsChatPartId;
 import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
+import com.example.mate.domain.goodsChat.event.GoodsChatEvent;
+import com.example.mate.domain.goodsChat.event.GoodsChatEventPublisher;
 import com.example.mate.domain.goodsChat.repository.GoodsChatMessageRepository;
 import com.example.mate.domain.goodsChat.repository.GoodsChatPartRepository;
 import com.example.mate.domain.goodsChat.repository.GoodsChatRoomRepository;
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,10 +52,34 @@ public class GoodsChatService {
         validateCreateChatRoom(goodsPost, buyer, seller);
 
         // 구매자가 채팅방이 존재하면 기존 채팅방을 반환하고, 없다면 새로 생성하여 반환
-        GoodsChatRoom goodsChatRoom = chatRoomRepository.findExistingChatRoom(goodsPostId, buyerId, Role.BUYER)
+        return chatRoomRepository.findExistingChatRoom(goodsPostId, buyerId, Role.BUYER)
+                .map(this::buildChatRoomResponse)
                 .orElseGet(() -> createChatRoom(goodsPost, buyer, seller));
+    }
 
-        return GoodsChatRoomResponse.of(goodsChatRoom);
+    // 기존 채팅방 & 채팅 내역 반환 (최신 20개)
+    private GoodsChatRoomResponse buildChatRoomResponse(GoodsChatRoom chatRoom) {
+        Page<GoodsChatMessage> messages = messageRepository.getChatMessages(chatRoom.getId(), PageRequest.of(0, 20));
+        List<GoodsChatMessageResponse> content = messages.getContent().stream()
+                .map(GoodsChatMessageResponse::of)
+                .toList();
+        return GoodsChatRoomResponse.of(chatRoom, PageResponse.from(messages, content));
+    }
+
+    // 새로운 채팅방 반환
+    private GoodsChatRoomResponse createChatRoom(GoodsPost goodsPost, Member buyer, Member seller) {
+        GoodsChatRoom goodsChatRoom = GoodsChatRoom.builder()
+                .goodsPost(goodsPost)
+                .build();
+
+        GoodsChatRoom savedChatRoom = chatRoomRepository.save(goodsChatRoom);
+        savedChatRoom.addChatParticipant(buyer, Role.BUYER);
+        savedChatRoom.addChatParticipant(seller, Role.SELLER);
+
+        // 새로운 채팅방 생성 - 입장 메시지 전송
+        eventPublisher.publish(GoodsChatEvent.from(goodsChatRoom.getId(), buyer, MessageType.ENTER));
+
+        return GoodsChatRoomResponse.of(savedChatRoom, null);
     }
 
     private void validateCreateChatRoom(GoodsPost goodsPost, Member seller, Member buyer) {
@@ -66,41 +91,13 @@ public class GoodsChatService {
         }
     }
 
-    private GoodsChatRoom createChatRoom(GoodsPost goodsPost, Member buyer, Member seller) {
-        GoodsChatRoom goodsChatRoom = GoodsChatRoom.builder()
-                .goodsPost(goodsPost)
-                .build();
-        
-        GoodsChatRoom savedChatRoom = chatRoomRepository.save(goodsChatRoom);
-        savedChatRoom.addChatParticipant(buyer, Role.BUYER);
-        savedChatRoom.addChatParticipant(seller, Role.SELLER);
-
-        // 새로운 채팅방 생성 - 입장 메시지 전송
-        eventPublisher.publish(GoodsChatEvent.from(goodsChatRoom.getId(), buyer, MessageType.ENTER));
-
-        return savedChatRoom;
-    }
-
-    private Member findMemberById(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(()
-                -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
-    }
-
-    private GoodsPost findGoodsPostById(Long goodsPostId) {
-        return goodsPostRepository.findById(goodsPostId).orElseThrow(() ->
-                new CustomException(ErrorCode.GOODS_NOT_FOUND_BY_ID));
-    }
-
     @Transactional(readOnly = true)
     public PageResponse<GoodsChatMessageResponse> getMessagesForChatRoom(Long chatRoomId, Long memberId, Pageable pageable) {
         validateMemberParticipation(memberId, chatRoomId);
-        Pageable validatePageable = PageResponse.validatePageable(pageable);
-
-        Page<GoodsChatMessage> chatMessagePage = messageRepository.findByChatRoomId(chatRoomId, validatePageable);
+        Page<GoodsChatMessage> chatMessagePage = messageRepository.getChatMessages(chatRoomId, pageable);
         List<GoodsChatMessageResponse> content = chatMessagePage.getContent().stream()
                 .map(GoodsChatMessageResponse::of)
                 .toList();
-
         return PageResponse.from(chatMessagePage, content);
     }
 
@@ -113,10 +110,7 @@ public class GoodsChatService {
     @Transactional(readOnly = true)
     public PageResponse<GoodsChatRoomSummaryResponse> getGoodsChatRooms(Long memberId, Pageable pageable) {
         Member member = findMemberById(memberId);
-        Pageable validatePageable = PageResponse.validatePageable(pageable);
-
-        Page<GoodsChatRoom> chatRoomPage = chatRoomRepository.findChatRoomPageByMemberId(memberId, validatePageable);
-
+        Page<GoodsChatRoom> chatRoomPage = chatRoomRepository.findChatRoomPageByMemberId(memberId, pageable);
         List<GoodsChatRoomSummaryResponse> content = chatRoomPage.getContent().stream()
                 .map(chatRoom -> GoodsChatRoomSummaryResponse.of(chatRoom, getOpponentMember(chatRoom, member)))
                 .toList();
@@ -136,10 +130,14 @@ public class GoodsChatService {
     @Transactional(readOnly = true)
     public GoodsChatRoomResponse getGoodsChatRoomInfo(Long memberId, Long chatRoomId) {
         validateMemberParticipation(memberId, chatRoomId);
+        GoodsChatRoom chatRoom = findChatRoomById(chatRoomId);
 
-        GoodsChatRoom goodsChatRoom = chatRoomRepository.findByChatRoomId(chatRoomId)
-                .orElseThrow(() -> new CustomException(ErrorCode.GOODS_CHAT_ROOM_NOT_FOUND));
-        return GoodsChatRoomResponse.of(goodsChatRoom);
+        Page<GoodsChatMessage> messages = messageRepository.getChatMessages(chatRoom.getId(), PageRequest.of(0, 20));
+        List<GoodsChatMessageResponse> content = messages.getContent().stream()
+                .map(GoodsChatMessageResponse::of)
+                .toList();
+
+        return GoodsChatRoomResponse.of(chatRoom, PageResponse.from(messages, content));
     }
 
     @Transactional(readOnly = true)
@@ -164,5 +162,20 @@ public class GoodsChatService {
             // 모두 나갔다면 채팅방, 채팅 참여, 채팅 삭제
             chatRoomRepository.deleteById(chatRoomId);
         }
+    }
+
+    private GoodsChatRoom findChatRoomById(Long chatRoomId) {
+        return chatRoomRepository.findByChatRoomId(chatRoomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.GOODS_CHAT_ROOM_NOT_FOUND));
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(()
+                -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
+    }
+
+    private GoodsPost findGoodsPostById(Long goodsPostId) {
+        return goodsPostRepository.findById(goodsPostId).orElseThrow(() ->
+                new CustomException(ErrorCode.GOODS_NOT_FOUND_BY_ID));
     }
 }

--- a/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.mate.common.response.PageResponse;
+import com.example.mate.config.WithAuthMember;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatMessageResponse;
 import com.example.mate.common.security.util.JwtUtil;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
@@ -41,6 +42,7 @@ class GoodsChatRoomControllerTest {
 
     @Test
     @DisplayName("굿즈거래 채팅방 생성 성공 - 기존 채팅방이 있을 경우 해당 채팅방을 반환한다.")
+    @WithAuthMember(memberId = 1L)
     void returnExistingChatRoom() throws Exception {
         // given
         Long buyerId = 1L;
@@ -81,6 +83,7 @@ class GoodsChatRoomControllerTest {
 
     @Test
     @DisplayName("굿즈거래 채팅방 생성 성공 - 기존 채팅방이 없을 경우 새로운 채팅방을 생성한다.")
+    @WithAuthMember(memberId = 1L)
     void createNewChatRoomIfNoneExists() throws Exception {
         // given
         Long buyerId = 1L;
@@ -101,7 +104,6 @@ class GoodsChatRoomControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/goods/chat", buyerId)
-                        .param("buyerId", String.valueOf(buyerId))
                         .param("goodsPostId", String.valueOf(goodsPostId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
@@ -120,6 +122,7 @@ class GoodsChatRoomControllerTest {
 
     @Test
     @DisplayName("채팅 내역 조회 성공 - 회원이 채팅방에 참여한 경우 메시지를 페이지로 반환한다.")
+    @WithAuthMember(memberId = 2L)
     void getMessagesForChatRoom_should_return_messages() throws Exception {
         // given
         Long chatRoomId = 1L;
@@ -149,7 +152,6 @@ class GoodsChatRoomControllerTest {
 
         // when & then
         mockMvc.perform(get("/api/goods/chat/{chatRoomId}/message", chatRoomId)
-                        .param("memberId", String.valueOf(memberId))
                         .param("page", "0")
                         .param("size", "10"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 채팅방 입장 기능 리팩토링
- [x] 굿즈거래 관련 기능 api path 변경 -> `@AuthenticationPrincipal` 사용
- [x] 테스트 코드 수정

## 💡 자세한 설명

> 현재까지 완성된 채팅방 기능에 대한 설명입니다.
### `POST /api/goods/chat`
- 굿즈 거래 상세 페이지에서 채팅방 입장(생성 또는 기존 채팅방 반환)
- 구매자(`member`)가 굿즈 게시글(`goodsPostId`)에 대해 새로운 채팅방을 생성하거나 기존 채팅방을 반환합니다.
- 새로운 채팅방을 생성하는 경우는 채팅내역을 보내지 않고, 기존 채팅방을 반환하는 경우에 채팅내역을 조회하여 반환합니다.

### `GET /api/goods/chat/{chatRoomId}/message`
- 굿즈 거래 채팅방에서 채팅 내역 조회
- 특정 채팅방의 메시지를 페이징 처리하여 반환합니다.

### `GET /api/goods/chat`
- 내가 참여한 굿즈 거래 채팅방 리스트 조회
- 회원(`member`)이 참여한 모든 채팅방을 페이징 처리하여 반환합니다.

### ` DELETE /api/goods/chat/{chatRoomId}`
- 굿즈 거래 채팅방에서 나가기
- 회원이 채팅방에서 나가거나, 모든 사용자가 나갔다면 채팅방을 삭제합니다.

### `GET /api/goods/chat/{chatRoomId}`
- 채팅방 목록에서 채팅방 입장
- 채팅방의 굿즈거래 판매글 정보와 최신 채팅 메시지(20개)를 반환합니다.

### `GET /api/goods/chat/{chatRoomId}/members`
- 특정 채팅방에 참여 중인 사용자 프로필 조회
- 채팅방 페이지에서 하단 토글을 눌렀을 때 보이는 회원 리스트입니다.

### 추가 채팅 기능 구현 자료
- [메시지 비동기 처리 PR (MATE-77)](https://github.com/prgrms-web-devcourse-final-project/WEB1_2_PitchingMate_BE/pull/77)

### 남은 작업
- `@AuthenticationPrincipal AuthMember member` 를 통해 기존 api path를 수정하고, 테스트 코드 수정
-  노션에 api 명세서 수정
-  채팅 관련 기능들 테스트 코드 작성
-  심화 기능구현

### 도메인 규칙
- 업로드 예정

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?