### PR TITLE
MATE-102 : [FEAT] 메이트 채팅방 제약 기능 추가

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -130,6 +130,7 @@ public enum ErrorCode {
     ALREADY_JOINED_CHAT_ROOM(HttpStatus.BAD_REQUEST, "CHAT004", "이미 참여 중인 채팅방입니다."),
     CHAT_ROOM_CLOSED(HttpStatus.BAD_REQUEST, "CHAT005", "종료된 채팅방입니다."),
     CHAT_ROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CHAT006", "직관 완료된 채팅방에는 새로운 유저가 입장할 수 없습니다."),
+    CHAT_AUTHOR_JOIN_DENIED(HttpStatus.FORBIDDEN, "CHAT006", "방장은 채팅방 퇴장 시 재입장할 수 없습니다."),
     AUTHOR_LEAVE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "CHAT007", "방장은 직관완료가 안된 채팅방에서 나갈 수 없습니다."),
     CHAT_ROOM_NOT_MESSAGEABLE(HttpStatus.FORBIDDEN, "CHAT008", "메세지 전송이 불가능한 채팅방입니다."),
 

--- a/src/main/java/com/example/mate/domain/mate/repository/VisitPartRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/VisitPartRepository.java
@@ -1,13 +1,13 @@
 package com.example.mate.domain.mate.repository;
 
-import com.example.mate.domain.mate.entity.Visit;
 import com.example.mate.domain.mate.entity.VisitPart;
 import com.example.mate.domain.mate.entity.VisitPartId;
 import com.example.mate.domain.member.entity.Member;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface VisitPartRepository extends JpaRepository<VisitPart, VisitPartId> {
 

--- a/src/main/java/com/example/mate/domain/mate/repository/VisitPartRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/VisitPartRepository.java
@@ -21,5 +21,12 @@ public interface VisitPartRepository extends JpaRepository<VisitPart, VisitPartI
             """)
     List<Member> findMembersByVisitIdExcludeMember(@Param("visitId") Long visitId, @Param("memberId") Long memberId);
 
-    boolean existsByVisitAndMember(Visit visit, Member member);
+    @Query("""
+            SELECT COUNT(vp) > 0
+            FROM VisitPart vp
+            WHERE vp.visit.id = :visitId
+            AND vp.member.id = :memberId
+            """)
+    boolean existsByVisitAndMember(@Param("visitId") Long visitId, @Param("memberId") Long memberId);
+
 }

--- a/src/main/java/com/example/mate/domain/mateChat/service/MateChatRoomService.java
+++ b/src/main/java/com/example/mate/domain/mateChat/service/MateChatRoomService.java
@@ -103,8 +103,11 @@ public class MateChatRoomService {
     }
 
     private void validateChatRoomJoin(MatePost matePost, Member member) {
-        // 방장인 경우 모든 제한을 건너뜀
+        // 방장인 경우, 직관 완료 상태가 아닐 때만 입장 가능
         if (matePost.getAuthor().getId().equals(member.getId())) {
+            if (matePost.getStatus() == Status.VISIT_COMPLETE) {
+                throw new CustomException(ErrorCode.CHAT_AUTHOR_JOIN_DENIED);
+            }
             return;
         }
 
@@ -123,9 +126,8 @@ public class MateChatRoomService {
         if (matePost.getStatus() == Status.VISIT_COMPLETE) {
             boolean isVisitParticipant = visitPartRepository.existsByVisitAndMember(
                     matePost.getVisit(), member);
-            boolean isAuthor = matePost.getAuthor().getId().equals(member.getId());
 
-            if (!isVisitParticipant && !isAuthor) {
+            if (!isVisitParticipant) {
                 throw new CustomException(ErrorCode.CHAT_ROOM_ACCESS_DENIED);
             }
         }

--- a/src/main/java/com/example/mate/domain/mateChat/service/MateChatRoomService.java
+++ b/src/main/java/com/example/mate/domain/mateChat/service/MateChatRoomService.java
@@ -123,9 +123,11 @@ public class MateChatRoomService {
         }
 
         // 3. 직관 완료 상태인 경우 접근 권한 검증
-        if (matePost.getStatus() == Status.VISIT_COMPLETE) {
+        if (matePost.getStatus() == Status.VISIT_COMPLETE && matePost.getVisit() != null) {
             boolean isVisitParticipant = visitPartRepository.existsByVisitAndMember(
-                    matePost.getVisit(), member);
+                    matePost.getVisit().getId(),  // Visit 엔티티 대신 ID 전달
+                    member.getId()                 // Member 엔티티 대신 ID 전달
+            );
 
             if (!isVisitParticipant) {
                 throw new CustomException(ErrorCode.CHAT_ROOM_ACCESS_DENIED);


### PR DESCRIPTION
## 💡 작업 내용

- [x] 메이트 채팅방 제약 기능 추가

## 💡 자세한 설명
9. 만약 "양소희", "안홍제", 방장이 채팅을 나누다가 방장이 채팅방을 퇴장한 경우, 방장은 채팅 목록에서 퇴장한 채팅방을 조회할 수 없다. ✅

   9-1 . "양소희"와 "안홍제"는 채팅 목록에서 방장이 퇴장한 채팅방을 조회할 수 있다. . ✅
   9-2.  "양소희"와 "안홍제"는 방장이 퇴장한 채팅방에 입장할 수 있다. . ✅
   9-3. 그러나 방장이 없는 채팅방 내에서 새로운 메세지를 보내는 건 안된다.✅ 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?