### PR TITLE
MATE-107 : [FEAT] 메이트 채팅방 목록 조회 시 에러 처리 로직 추가

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     AUTH_BAD_REQUEST(HttpStatus.BAD_REQUEST, "A001", "잘못된 인증 요청입니다. 요청 파라미터를 확인해주세요."),
     AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A002", "인증에 실패했습니다. 유효한 토큰을 제공해주세요."),
     AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "A003", "접근 권한이 없습니다. 권한을 확인해주세요."),
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "A004", "인증되지 않은 사용자입니다"),
 
     // Team
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "팀을 찾을 수 없습니다"),

--- a/src/main/java/com/example/mate/domain/mateChat/controller/MateChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/mateChat/controller/MateChatRoomController.java
@@ -37,7 +37,7 @@ public class MateChatRoomController {
     }
 
     @GetMapping("/me")
-    @Operation(summary = "내 채팅방 목록 조회", description = "사용자의 채팅방 목록을 조회합니다.")
+    @Operation(summary = "채팅방 목록 조회", description = "사용자의 채팅방 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<PageResponse<MateChatRoomListResponse>>> getMyChatRooms(
             @Parameter(description = "페이지 정보") @PageableDefault Pageable pageable,
                                                     @AuthenticationPrincipal AuthMember member
@@ -51,11 +51,11 @@ public class MateChatRoomController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @PostMapping("chat/{chatroomId}/join")
-    @Operation(summary = "내 채팅방 목록 -> 채팅방 입장", description = "채팅 목록 페이지에서 채팅방으로 입장")
+    @PostMapping("/{chatroomId}/join")
+    @Operation(summary = "채팅방 목록 -> 채팅방 입장", description = "채팅 목록 페이지에서 채팅방으로 입장")
     public ResponseEntity<ApiResponse<MateChatRoomResponse>> joinExistingChatRoom(
             @Parameter(description = "채팅방 ID") @PathVariable Long chatroomId,
-                                                    @AuthenticationPrincipal AuthMember member
+            @AuthenticationPrincipal AuthMember member
     ) {
         MateChatRoomResponse response = chatRoomService.joinExistingChatRoom(chatroomId, member.getMemberId());
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/example/mate/domain/mateChat/controller/MateChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/mateChat/controller/MateChatRoomController.java
@@ -1,5 +1,7 @@
 package com.example.mate.domain.mateChat.controller;
 
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.auth.AuthMember;
@@ -41,6 +43,10 @@ public class MateChatRoomController {
                                                     @AuthenticationPrincipal AuthMember member
 
             ) {
+
+        if (member == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_USER);
+        }
         PageResponse<MateChatRoomListResponse> response = chatRoomService.getMyChatRooms(member.getMemberId(), pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/example/mate/domain/mateChat/service/MateChatRoomService.java
+++ b/src/main/java/com/example/mate/domain/mateChat/service/MateChatRoomService.java
@@ -268,6 +268,9 @@ public class MateChatRoomService {
     // 내 채팅방 목록 조회
     @Transactional(readOnly = true)
     public PageResponse<MateChatRoomListResponse> getMyChatRooms(Long memberId, Pageable pageable) {
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
+
         Page<MateChatRoom> chatRooms = chatRoomRepository.findActiveChatRoomsByMemberId(memberId, pageable);
 
         List<MateChatRoomListResponse> responses = chatRooms.getContent().stream()
@@ -299,6 +302,9 @@ public class MateChatRoomService {
     }
 
     private void validateChatRoomAccess(Long roomId, Long memberId) {
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
+
         MateChatRoomMember member = chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND));
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] 메이트 채팅방 목록 조회 시 에러 처리 로직 추가

## 💡 자세한 설명
![image](https://github.com/user-attachments/assets/397d9711-6207-4e03-92df-674abdae6fd9)
            `@AuthenticationPrincipal AuthMember member` 를 사용하게 되어 매핑 url에서 memberId를 제거하였는데, 준희님이 jwt 토큰값을 입력해도 memberId값이 null이라고 에러가 뜬다고 하시길래 일단 예외처리 로직을 추가해봤습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?