### PR TITLE
MATE-108 : [FIX] 웹소켓 인증 오류 해결

### DIFF
--- a/src/main/java/com/example/mate/common/security/filter/JwtCheckFilter.java
+++ b/src/main/java/com/example/mate/common/security/filter/JwtCheckFilter.java
@@ -3,7 +3,6 @@ package com.example.mate.common.security.filter;
 import com.example.mate.common.security.auth.AuthMember;
 import com.example.mate.common.security.util.JwtUtil;
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -25,28 +24,18 @@ public class JwtCheckFilter extends OncePerRequestFilter {
 
     // 필터링 적용하지 않을 URI 체크
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-
+    protected boolean shouldNotFilter(HttpServletRequest request) {
         // TODO : 2024/11/28 - 각 도메인별로 인증이 필요없는 경로 추가
-
         // 사용자 로그인, 회원가입 경로 인증 제외 (토큰 발급 경로)
-        if (isAuthExcludedPath(request)) {
-            return true;
-        }
-
-        // 메인 페이지 인증 제외
-        if (isMainPagePath(request)) {
-            return true;
-        }
-
-        return false;
+        String requestURI = request.getRequestURI();
+        return isExcludedPath(requestURI) || isMainPagePath(requestURI);
     }
 
     // 필터링 적용 - 액세스 토큰 확인
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+                                    FilterChain filterChain) throws IOException {
         String headerAuth = request.getHeader("Authorization");
 
         // 액세스 토큰 유효성 검사
@@ -67,21 +56,17 @@ public class JwtCheckFilter extends OncePerRequestFilter {
     }
 
     // 사용자 로그인 또는 회원가입 경로인지 확인
-    private boolean isAuthExcludedPath(HttpServletRequest request) {
-        String requestURI = request.getRequestURI();
-        String method = request.getMethod();
-
+    private boolean isExcludedPath(String requestURI) {
         // 소셜 로그인/회원 가입 경로, mate 서비스 로그인/회원 가입 경로 인증 제외
-        return requestURI.startsWith("/api/auth") ||
+        return requestURI.startsWith("/ws/chat") ||
+                requestURI.startsWith("/api/auth") ||
                 requestURI.startsWith("/api/members/join") ||
                 requestURI.startsWith("/swagger-ui") ||
                 requestURI.startsWith("/api/members/login");
     }
 
     // 메인 페이지의 인증 필요없는 메서드인지 확인
-    private boolean isMainPagePath(HttpServletRequest request) {
-        String requestURI = request.getRequestURI();
-
+    private boolean isMainPagePath(String requestURI) {
         // 메인 페이지와 관련된 경로
         return requestURI.startsWith("/api/matches/main") ||
                 requestURI.startsWith("/api/mates/main") ||


### PR DESCRIPTION
## 💡 작업 내용

- [x] JwtCheckFilter 필터링 제외 URI에 웹소켓 엔드포인트 추가

## 💡 자세한 설명
프론트에서 웹소켓 연결 시 403 에러가 발생하는 문제가 생겨서 우선 체크필터에 해당 경로를 무시하도록 추가했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?