### PR TITLE
MATE-110 : [FEAT] CATCH Mi 로그인 기능의 응답 DTO에 회원 정보 필드 추가

### DIFF
--- a/src/main/java/com/example/mate/domain/member/dto/response/MemberLoginResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MemberLoginResponse.java
@@ -16,6 +16,10 @@ public class MemberLoginResponse {
     private final String grantType;
     private final String accessToken;
     private final String refreshToken;
+    private final String nickname;
+    private final Long teamId;
+    private final String gender;
+    private final Integer age;
 
     public static MemberLoginResponse from(Member member, JwtToken jwtToken) {
         return MemberLoginResponse.builder()
@@ -23,6 +27,10 @@ public class MemberLoginResponse {
                 .grantType(jwtToken.getGrantType())
                 .accessToken(jwtToken.getAccessToken())
                 .refreshToken(jwtToken.getRefreshToken())
+                .nickname(member.getNickname())
+                .teamId(member.getTeamId())
+                .gender(member.getGender().getValue())
+                .age(member.getAge())
                 .build();
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] CATCH Mi 로그인 시 응답값으로 회원 정보 추가

## 💡 자세한 설명

#### 로그인 시 응답값으로 nickname, teamId, gender, age를 추가합니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?