### PR TITLE
MATE-101 : [TEST] 굿즈거래 채팅 관련 기능들 테스트 코드 작성

### DIFF
--- a/src/main/java/com/example/mate/domain/goodsChat/dto/request/GoodsChatMessageRequest.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/dto/request/GoodsChatMessageRequest.java
@@ -3,9 +3,11 @@ package com.example.mate.domain.goodsChat.dto.request;
 import com.example.mate.domain.constant.MessageType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class GoodsChatMessageRequest {
 
     @NotNull(message = "채팅방 ID는 필수 입력 값입니다.")

--- a/src/main/java/com/example/mate/domain/goodsChat/entity/GoodsChatMessage.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/entity/GoodsChatMessage.java
@@ -20,6 +20,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(name = "goods_chat_message")
@@ -38,6 +40,7 @@ public class GoodsChatMessage {
             @JoinColumn(name = "member_id", referencedColumnName = "member_id"),
             @JoinColumn(name = "chat_room_id", referencedColumnName = "chat_room_id")
     })
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private GoodsChatPart goodsChatPart;
 
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageService.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageService.java
@@ -41,7 +41,7 @@ public class GoodsChatMessageService {
 
         // DB에 메시지 저장
         GoodsChatMessage chatMessage
-                = messageRepository.save(createChatMessage(message.getMessage(), chatPart, MessageType.TALK));
+                = messageRepository.save(createChatMessage(message.getMessage(), chatPart, message.getType()));
         chatRoom.updateLastChat(chatMessage.getContent(), chatMessage.getSentAt());
 
         GoodsChatMessageResponse response = GoodsChatMessageResponse.of(chatMessage);

--- a/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomControllerTest.java
@@ -1,7 +1,9 @@
 package com.example.mate.domain.goodsChat.controller;
 
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -301,5 +303,21 @@ class GoodsChatRoomControllerTest {
                 .andExpect(jsonPath("$.data.content[1].message").value(firstMessage.getMessage()));
 
         verify(goodsChatService).getMessagesForChatRoom(chatRoomId, memberId, pageable);
+    }
+
+    @Test
+    @DisplayName("굿즈거래 채팅방 나가기 성공")
+    void leaveGoodsChatRoom_should_deactivate_chat_part_and_return_no_content() throws Exception {
+        // given
+        Long memberId = 1L;
+        Long chatRoomId = 1L;
+
+        willDoNothing().given(goodsChatService).deactivateGoodsChatPart(memberId, chatRoomId);
+
+        // when & then
+        mockMvc.perform(delete("/api/goods/chat/{chatRoomId}", chatRoomId))
+                .andExpect(status().isNoContent());
+
+        verify(goodsChatService).deactivateGoodsChatPart(memberId, chatRoomId);
     }
 }

--- a/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
@@ -187,6 +187,32 @@ public class GoodsChatIntegrationTest {
         assertThat(image.getImageUrl()).isEqualTo("upload/test_img_url");
     }
 
+    @Test
+    @DisplayName("굿즈거래 채팅방 목록 조회 성공 통합 테스트")
+    @WithAuthMember(memberId = 2L)
+    void getGoodsChatRooms_should_return_chat_room_list_integration_test() throws Exception {
+        // given
+        Long memberId = buyer.getId();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when & then
+        mockMvc.perform(get("/api/goods/chat")
+                        .param("page", String.valueOf(pageable.getPageNumber()))
+                        .param("size", String.valueOf(pageable.getPageSize())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content[0].chatRoomId").value(chatRoom.getId()))
+                .andExpect(jsonPath("$.data.content[0].opponentNickname").value(seller.getNickname()))
+                .andExpect(jsonPath("$.data.content[0].lastChatContent").value(chatRoom.getLastChatContent()))
+                .andExpect(jsonPath("$.data.content[0].placeName").value(goodsPost.getLocation().getPlaceName()))
+                .andExpect(jsonPath("$.data.content[0].goodsMainImageUrl").value(goodsPost.getMainImageUrl()))
+                .andExpect(jsonPath("$.data.content[0].opponentImageUrl").value(seller.getImageUrl()))
+                .andReturn()
+                .getResponse();
+    }
+
 
     private Member createMember(String name, String nickname, String email) {
         return memberRepository.save(Member.builder()

--- a/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageServiceTest.java
@@ -1,0 +1,311 @@
+package com.example.mate.domain.goodsChat.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import com.example.mate.domain.constant.MessageType;
+import com.example.mate.domain.goodsChat.dto.request.GoodsChatMessageRequest;
+import com.example.mate.domain.goodsChat.dto.response.GoodsChatMessageResponse;
+import com.example.mate.domain.goodsChat.entity.GoodsChatMessage;
+import com.example.mate.domain.goodsChat.entity.GoodsChatPart;
+import com.example.mate.domain.goodsChat.entity.GoodsChatPartId;
+import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
+import com.example.mate.domain.goodsChat.event.GoodsChatEvent;
+import com.example.mate.domain.goodsChat.repository.GoodsChatMessageRepository;
+import com.example.mate.domain.goodsChat.repository.GoodsChatPartRepository;
+import com.example.mate.domain.goodsChat.repository.GoodsChatRoomRepository;
+import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class GoodsChatMessageServiceTest {
+
+    @InjectMocks
+    private GoodsChatMessageService goodsChatMessageService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private GoodsChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private GoodsChatPartRepository chatPartRepository;
+
+    @Mock
+    private GoodsChatMessageRepository messageRepository;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    private Member createMember(Long id, String name, String nickname) {
+        return Member.builder()
+                .id(id)
+                .name(name)
+                .nickname(nickname)
+                .build();
+    }
+
+    private GoodsChatRoom createGoodsChatRoom(Long id) {
+        return GoodsChatRoom.builder()
+                .id(id)
+                .build();
+    }
+
+    private GoodsChatPart createGoodsChatPart(Member member, GoodsChatRoom chatRoom) {
+        return GoodsChatPart.builder()
+                .member(member)
+                .goodsChatRoom(chatRoom)
+                .build();
+    }
+
+    private GoodsChatMessage createGoodsChatMessage(String message, GoodsChatPart chatPart, MessageType type) {
+        return GoodsChatMessage.builder()
+                .content(message)
+                .goodsChatPart(chatPart)
+                .messageType(type)
+                .sentAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Nested
+    @DisplayName("굿즈거래 채팅 전송 테스트")
+    class SendChatMessageTest {
+
+        @Test
+        @DisplayName("메시지 전송 성공")
+        void sendMessage_should_save_message_and_send_to_subscribers() {
+            // given
+            Long memberId = 1L;
+            Long chatRoomId = 1L;
+            GoodsChatMessageRequest request = new GoodsChatMessageRequest(chatRoomId, memberId, "Hello World", MessageType.TALK);
+
+            Member member = createMember(memberId, "Test User", "test_user");
+            GoodsChatRoom chatRoom = createGoodsChatRoom(chatRoomId);
+            GoodsChatPart chatPart = createGoodsChatPart(member, chatRoom);
+            GoodsChatMessage chatMessage = createGoodsChatMessage(request.getMessage(), chatPart, MessageType.TALK);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(chatRoom));
+            when(chatPartRepository.findById(new GoodsChatPartId(memberId, chatRoomId))).thenReturn(Optional.of(chatPart));
+            when(messageRepository.save(any(GoodsChatMessage.class))).thenReturn(chatMessage);
+
+            // when
+            goodsChatMessageService.sendMessage(request);
+
+            // then
+            verify(memberRepository).findById(memberId);
+            verify(chatRoomRepository).findById(chatRoomId);
+            verify(chatPartRepository).findById(new GoodsChatPartId(memberId, chatRoomId));
+            verify(messageRepository).save(any(GoodsChatMessage.class));
+            verify(messagingTemplate).convertAndSend(eq("/sub/chat/goods/" + chatRoomId), any(GoodsChatMessageResponse.class));
+        }
+
+        @Test
+        @DisplayName("메시지 전송 실패 - 유효하지 않은 회원")
+        void sendMessage_should_throw_custom_exception_for_invalid_member() {
+            // given
+            Long memberId = 1L;
+            Long chatRoomId = 1L;
+            GoodsChatMessageRequest request = new GoodsChatMessageRequest(chatRoomId, memberId, "Hello World", MessageType.TALK);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+            // when
+            assertThatThrownBy(() -> goodsChatMessageService.sendMessage(request))
+                    .isExactlyInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage());
+
+            // then
+            verify(memberRepository).findById(memberId);
+            verify(chatRoomRepository, never()).findById(chatRoomId);
+            verify(chatPartRepository, never()).findById(new GoodsChatPartId(memberId, chatRoomId));
+            verify(messageRepository, never()).save(any(GoodsChatMessage.class));
+            verify(messagingTemplate, never()).convertAndSend(eq("/sub/chat/goods/" + chatRoomId), any(GoodsChatMessageResponse.class));
+        }
+
+        @Test
+        @DisplayName("메시지 전송 실패 - 유효하지 않은 채팅방")
+        void sendMessage_should_throw_custom_exception_for_invalid_chatroom() {
+            // given
+            Long memberId = 1L;
+            Long chatRoomId = 1L;
+            GoodsChatMessageRequest request = new GoodsChatMessageRequest(chatRoomId, memberId, "Hello World", MessageType.TALK);
+
+            Member member = createMember(memberId, "Test User", "test_user");
+            GoodsChatRoom chatRoom = createGoodsChatRoom(chatRoomId);
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(chatRoom));
+            when(chatPartRepository.findById(new GoodsChatPartId(memberId, chatRoomId))).thenReturn(Optional.empty());
+
+            // when
+            assertThatThrownBy(() -> goodsChatMessageService.sendMessage(request))
+                    .isExactlyInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.GOODS_CHAT_NOT_FOUND_CHAT_PART.getMessage());
+
+            // then
+            verify(memberRepository).findById(memberId);
+            verify(chatRoomRepository).findById(chatRoomId);
+            verify(chatPartRepository).findById(new GoodsChatPartId(memberId, chatRoomId));
+            verify(messageRepository, never()).save(any(GoodsChatMessage.class));
+            verify(messagingTemplate, never()).convertAndSend(eq("/sub/chat/goods/" + chatRoomId), any(GoodsChatMessageResponse.class));
+        }
+
+        @Test
+        @DisplayName("메시지 전송 실패 - 해당 채팅방에 참가한 회원이 아닌 경우")
+        void sendMessage_should_throw_custom_exception_for_non_participant() {
+            // given
+            Long memberId = 1L;
+            Long chatRoomId = 1L;
+            GoodsChatMessageRequest request = new GoodsChatMessageRequest(chatRoomId, memberId, "Hello World", MessageType.TALK);
+            Member member = createMember(memberId, "Test User", "test_user");
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.empty());
+
+            // when
+            assertThatThrownBy(() -> goodsChatMessageService.sendMessage(request))
+                    .isExactlyInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.GOODS_CHAT_ROOM_NOT_FOUND.getMessage());
+
+            // then
+            verify(memberRepository).findById(memberId);
+            verify(chatRoomRepository).findById(chatRoomId);
+            verify(chatPartRepository, never()).findById(new GoodsChatPartId(memberId, chatRoomId));
+            verify(messageRepository, never()).save(any(GoodsChatMessage.class));
+            verify(messagingTemplate, never()).convertAndSend(eq("/sub/chat/goods/" + chatRoomId), any(GoodsChatMessageResponse.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("굿즈거래 입장 및 퇴장 메시지 전송 테스트")
+    class SendChatSystemMessageTest {
+
+        @Test
+        @DisplayName("채팅방 입장 메시지 전송 성공")
+        void sendChatEventMessage_should_send_enter_message() {
+            // given
+            Long memberId = 1L;
+            Long chatRoomId = 1L;
+
+            Member member = createMember(memberId, "Test User", "test_user");
+            GoodsChatEvent event = new GoodsChatEvent(chatRoomId, member, MessageType.ENTER);
+
+            GoodsChatRoom chatRoom = createGoodsChatRoom(event.chatRoomId());
+            GoodsChatPart chatPart = createGoodsChatPart(event.member(), chatRoom);
+
+            GoodsChatMessage chatMessage
+                    = createGoodsChatMessage(member.getNickname() + "님이 대화를 시작했습니다.", chatPart, event.type());
+
+            when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(chatRoom));
+            when(chatPartRepository.findById(new GoodsChatPartId(memberId, chatRoomId))).thenReturn(Optional.of(chatPart));
+            when(messageRepository.save(any(GoodsChatMessage.class))).thenReturn(chatMessage);
+
+            // when
+            goodsChatMessageService.sendChatEventMessage(event);
+
+            // then
+            verify(chatRoomRepository).findById(chatRoomId);
+            verify(chatPartRepository).findById(new GoodsChatPartId(memberId, chatRoomId));
+            verify(messageRepository).save(any(GoodsChatMessage.class));
+            verify(messagingTemplate).convertAndSend(eq("/sub/chat/goods/" + chatRoomId), any(GoodsChatMessageResponse.class));
+        }
+
+        @Test
+        @DisplayName("채팅방 퇴장 메시지 전송 성공")
+        void sendChatEventMessage_should_send_leave_message() {
+            // given
+            Long memberId = 1L;
+            Long chatRoomId = 1L;
+
+            Member member = createMember(memberId, "Test User", "test_user");
+            GoodsChatEvent event = new GoodsChatEvent(chatRoomId, member, MessageType.LEAVE);
+
+            GoodsChatRoom chatRoom = createGoodsChatRoom(event.chatRoomId());
+            GoodsChatPart chatPart = createGoodsChatPart(event.member(), chatRoom);
+
+            GoodsChatMessage chatMessage
+                    = createGoodsChatMessage(member.getNickname() + "님이 대화를 떠났습니다.", chatPart, event.type());
+
+            when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(chatRoom));
+            when(chatPartRepository.findById(new GoodsChatPartId(memberId, chatRoomId))).thenReturn(Optional.of(chatPart));
+            when(messageRepository.save(any(GoodsChatMessage.class))).thenReturn(chatMessage);
+
+            // when
+            goodsChatMessageService.sendChatEventMessage(event);
+
+            // then
+            verify(chatRoomRepository).findById(chatRoomId);
+            verify(chatPartRepository).findById(new GoodsChatPartId(memberId, chatRoomId));
+            verify(messageRepository).save(any(GoodsChatMessage.class));
+            verify(messagingTemplate).convertAndSend(eq("/sub/chat/goods/" + chatRoomId), any(GoodsChatMessageResponse.class));
+        }
+
+        @Test
+        @DisplayName("시스템 메시지 전송 실패 - 유효하지 않은 채팅방")
+        void sendChatEventMessage_should_throw_custom_exception_for_invalid_chatroom() {
+            // given
+            Long memberId = 1L;
+            Long chatRoomId = 1L;
+
+            Member member = createMember(memberId, "Test User", "test_user");
+            GoodsChatEvent event = new GoodsChatEvent(chatRoomId, member, MessageType.LEAVE);
+
+            when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.empty());
+
+            // when
+            assertThatThrownBy(() -> goodsChatMessageService.sendChatEventMessage(event))
+                    .isExactlyInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.GOODS_CHAT_ROOM_NOT_FOUND.getMessage());
+
+            // then
+            verify(chatRoomRepository).findById(chatRoomId);
+            verify(chatPartRepository, never()).findById(new GoodsChatPartId(memberId, chatRoomId));
+            verify(messageRepository, never()).save(any(GoodsChatMessage.class));
+            verify(messagingTemplate, never()).convertAndSend(eq("/sub/chat/goods/" + chatRoomId), any(GoodsChatMessageResponse.class));
+        }
+
+        @Test
+        @DisplayName("시스템 메시지 전송 실패 - 해당 채팅방에 참가한 회원이 아닌 경우")
+        void sendChatEventMessage_should_throw_custom_exception_for_non_participant() {
+            // given
+            Long memberId = 1L;
+            Long chatRoomId = 1L;
+
+            Member member = createMember(memberId, "Test User", "test_user");
+            GoodsChatEvent event = new GoodsChatEvent(chatRoomId, member, MessageType.LEAVE);
+            GoodsChatRoom chatRoom = createGoodsChatRoom(event.chatRoomId());
+
+            when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(chatRoom));
+            when(chatPartRepository.findById(new GoodsChatPartId(memberId, chatRoomId))).thenReturn(Optional.empty());
+
+            // when
+            assertThatThrownBy(() -> goodsChatMessageService.sendChatEventMessage(event))
+                    .isExactlyInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.GOODS_CHAT_NOT_FOUND_CHAT_PART.getMessage());
+
+            // then
+            verify(chatRoomRepository).findById(chatRoomId);
+            verify(chatPartRepository).findById(new GoodsChatPartId(memberId, chatRoomId));
+            verify(messageRepository, never()).save(any(GoodsChatMessage.class));
+            verify(messagingTemplate, never()).convertAndSend(eq("/sub/chat/goods/" + chatRoomId), any(GoodsChatMessageResponse.class));
+        }
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈거래 채팅방 상세 조회 테스트 코드 작성
- [x] 굿즈거래 내 채팅방 목록 조회 테스트 코드 작성
- [x] 굿즈거래 채팅방 채팅내역 조회 테스트 코드 작성
- [x] 굿즈거래 채팅방 나가기 및 삭제 기능 테스트 코드 작성
- [x] 굿즈거래 채팅방 인원 조회 테스트 코드 작성
- [x] 굿즈거래 채팅 전송 기능 테스트 코드 작성

## 💡 자세한 설명
굿즈거래 채팅 전송 기능을 제외한 모든 기능들의 단위 테스트 및 통합 테스트를 작성했습니다.
채팅 전송 기능은 service 테스트만 작성하였고, 심화 기능이 추가되면 통합 테스트를 시도해볼 예정입니다.

- 주말동안 남은 할 일
  - 굿즈거래 채팅 관련 도메인 규칙 정리
  - 코드 리팩토링 및 분리

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?