### PR TITLE
MATE-111 : [FEAT] CATCH Mi 로그아웃 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A002", "인증에 실패했습니다. 유효한 토큰을 제공해주세요."),
     AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "A003", "접근 권한이 없습니다. 권한을 확인해주세요."),
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "A004", "인증되지 않은 사용자입니다"),
+    INVALID_AUTH_TOKEN(HttpStatus.BAD_REQUEST, "A005", "잘못된 토큰 형식입니다."),
 
     // Team
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "팀을 찾을 수 없습니다"),

--- a/src/main/java/com/example/mate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.example.mate.domain.member.dto.response.JoinResponse;
 import com.example.mate.domain.member.dto.response.MemberLoginResponse;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
 import com.example.mate.domain.member.dto.response.MyProfileResponse;
+import com.example.mate.domain.member.service.LogoutRedisService;
 import com.example.mate.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -27,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberController {
 
     private final MemberService memberService;
+    private final LogoutRedisService logoutRedisService;
 
     @Operation(summary = "자체 회원가입 기능")
     @PostMapping("/join")
@@ -43,6 +45,15 @@ public class MemberController {
     ) {
         MemberLoginResponse response = memberService.loginByEmail(request);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "CATCH Mi 서비스 로그아웃", description = "캐치미 서비스에 로그아웃합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> catchMiLogout(
+            @Parameter(description = "회원 로그인 토큰 헤더", required = true) @RequestHeader("Authorization") String token
+    ) {
+        logoutRedisService.addTokenToBlacklist(token);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "내 프로필 조회")

--- a/src/main/java/com/example/mate/domain/member/service/LogoutRedisService.java
+++ b/src/main/java/com/example/mate/domain/member/service/LogoutRedisService.java
@@ -1,0 +1,31 @@
+package com.example.mate.domain.member.service;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutRedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // 로그아웃 시 블랙리스트에 토큰 추가
+    public void addTokenToBlacklist(String token) {
+        if (token == null || !token.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.INVALID_AUTH_TOKEN);
+        }
+
+        // TODO : 테스트용 1분 유효를 변경
+        redisTemplate.opsForValue().set("blacklist:" + token.substring(7), "blacklisted", 1, TimeUnit.MINUTES);
+    }
+
+    // 블랙리스트에 토큰 있는지 확인
+    public boolean isTokenBlacklisted(String accessToken) {
+        return redisTemplate.hasKey("blacklist:" + accessToken);
+    }
+}

--- a/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomControllerTest.java
@@ -1,20 +1,12 @@
 package com.example.mate.domain.goodsChat.controller;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.example.mate.common.response.PageResponse;
+import com.example.mate.common.security.filter.JwtCheckFilter;
+import com.example.mate.common.security.util.JwtUtil;
 import com.example.mate.config.WithAuthMember;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatMessageResponse;
-import com.example.mate.common.security.util.JwtUtil;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
 import com.example.mate.domain.goodsChat.service.GoodsChatService;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +17,16 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(GoodsChatRoomController.class)
 @MockBean(JpaMetamodelMappingContext.class)
@@ -40,6 +42,9 @@ class GoodsChatRoomControllerTest {
 
     @MockBean
     private JwtUtil jwtUtil;
+
+    @MockBean
+    private JwtCheckFilter jwtCheckFilter;
 
     @Test
     @DisplayName("굿즈거래 채팅방 생성 성공 - 기존 채팅방이 있을 경우 해당 채팅방을 반환한다.")

--- a/src/test/java/com/example/mate/domain/member/service/LogoutRedisServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/LogoutRedisServiceTest.java
@@ -1,0 +1,101 @@
+package com.example.mate.domain.member.service;
+
+import com.example.mate.common.error.CustomException;
+import com.example.mate.common.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutRedisServiceTest {
+
+    @InjectMocks
+    private LogoutRedisService logoutRedisService;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Nested
+    @DisplayName("회원 로그아웃")
+    class LogoutMember {
+
+        @Test
+        @DisplayName("회원 로그아웃 성공 - 블랙리스트에 토큰 추가")
+        void add_token_to_blacklist_success() {
+            // given
+            String token = "Bearer accessToken";
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            doNothing().when(valueOperations).set(
+                    "blacklist:" + token.substring(7), "blacklisted", 1, TimeUnit.MINUTES
+            );
+
+            // when & then
+            assertDoesNotThrow(() -> logoutRedisService.addTokenToBlacklist(token));
+            verify(redisTemplate.opsForValue(), times(1)).set(
+                    "blacklist:accessToken", "blacklisted", 1, TimeUnit.MINUTES
+            );
+        }
+
+        @Test
+        @DisplayName("회원 로그아웃 실패 - 잘못된 토큰으로 블랙리스트 추가 시 CustomException")
+        void add_token_to_blacklist_fail_invalid_token() {
+            // given
+            String invalidToken = "InvalidToken";
+
+            // when & then
+            assertThatThrownBy(() -> logoutRedisService.addTokenToBlacklist(invalidToken))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessage(ErrorCode.INVALID_AUTH_TOKEN.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("블랙리스트에 토큰 여부 확인")
+    class CheckBlacklist {
+
+        @Test
+        @DisplayName("블랙리스트에 토큰 여부 확인 성공")
+        void is_token_blacklisted_success() {
+            // given
+            String accessToken = "accessToken";
+            when(redisTemplate.hasKey("blacklist:" + accessToken)).thenReturn(true);
+
+            // when
+            boolean result = logoutRedisService.isTokenBlacklisted(accessToken);
+
+            // then
+            verify(redisTemplate, times(1)).hasKey("blacklist:accessToken");
+            assert result;
+        }
+
+        @Test
+        @DisplayName("블랙리스트에 토큰 여부 확인 실패 - 블랙리스트에 존재하지 않는 토큰 확인")
+        void is_token_blacklisted_fail_not_exists_token() {
+            // given
+            String accessToken = "accessToken";
+            when(redisTemplate.hasKey("blacklist:" + accessToken)).thenReturn(false);
+
+            // when
+            boolean result = logoutRedisService.isTokenBlacklisted(accessToken);
+
+            // then
+            verify(redisTemplate, times(1)).hasKey("blacklist:accessToken");
+            assert !result;
+        }
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] Redis를 사용해, 로그아웃 기능 구현
- [x] 서비스, 컨트롤러, 통합 테스트

## 💡 자세한 설명

### Redis를 활용해 로그아웃한 토큰을 블랙리스트에 등록

#### 인메모리 방식의 Redis를 통해, 설정한 기간 동안 로그아웃한 토큰은 접근할 수 업도록 처리

- 회원 컨트롤러에서 로그아웃 서비스만을 담당하는 `LogoutRedisService` 서비스 클래스를 주입받아 사용
    - 로그아웃 요청으로 넘겨받은 토큰을 블랙리스트에 등록하는 `addTokenToBlacklist()`
    - JwtCheckFilter에서 모든 요청에 대해 해당 토큰이 블랙리스트에 있는지 검증하는 `isTokenBlacklisted()`
- 현재 테스트 용으로 설정한 블랙리스트 기간은 1분입니다.
    - 로그아웃한 뒤 1분 동안은 해당 토큰으로 모든 인증 불가.

#### 도메인 규칙

![스크린샷 2024-12-07 오후 9 41 14](https://github.com/user-attachments/assets/fc7da883-dfec-419c-a2e5-d8cba7640efe)


## 📗 참고 자료 (선택)

- https://geunzrial.tistory.com/179

- https://www.inflearn.com/community/questions/575213/로그아웃-처리-시-post-를-쓰는-이유가-있을까요?srsltid=AfmBOop8TIHYqDxCk47dGUqR2u1J4aj1utRVVWMWe8yVGpVoOZHnEeGG

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?