### PR TITLE
MATE-112 : [FEAT] Pageable 객체 유효성 검증 커스텀 어노테이션 구현

### DIFF
--- a/src/main/java/com/example/mate/common/config/WebMvcConfig.java
+++ b/src/main/java/com/example/mate/common/config/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package com.example.mate.common.config;
+
+import com.example.mate.common.validator.ValidPageableArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final ValidPageableArgumentResolver validPageableArgumentResolver;
+
+    public WebMvcConfig(ValidPageableArgumentResolver validPageableArgumentResolver) {
+        this.validPageableArgumentResolver = validPageableArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(validPageableArgumentResolver);
+    }
+}

--- a/src/main/java/com/example/mate/common/response/PageResponse.java
+++ b/src/main/java/com/example/mate/common/response/PageResponse.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 @Getter
 @Builder
@@ -39,15 +37,5 @@ public class PageResponse<T> {
                 .pageNumber(page.getNumber())
                 .pageSize(page.getSize())
                 .build();
-    }
-
-    // Pageable 검증 메서드
-    public static Pageable validatePageable(Pageable pageable) {
-        // pageNumber 검증: 0보다 작은 값은 0으로 처리
-        int pageNumber = Math.max(pageable.getPageNumber(), 0);
-
-        // pageSize 검증: 0 이하이면 기본값 10으로 설정
-        int pageSize = pageable.getPageSize() <= 0 ? 10 : pageable.getPageSize();
-        return PageRequest.of(pageNumber, pageSize, pageable.getSort());
     }
 }

--- a/src/main/java/com/example/mate/common/response/PageResponse.java
+++ b/src/main/java/com/example/mate/common/response/PageResponse.java
@@ -38,4 +38,22 @@ public class PageResponse<T> {
                 .pageSize(page.getSize())
                 .build();
     }
+
+    /**
+     * Page 객체를 기반으로 PageResponse 를 생성하는 팩토리 메서드
+     *
+     * @param page    Spring Data JPA 의 Page 객체
+     * @param <T>     변환된 데이터 타입
+     * @return PageResponse
+     */
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return PageResponse.<T>builder()
+                .content(page.getContent())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .hasNext(page.hasNext())
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .build();
+    }
 }

--- a/src/main/java/com/example/mate/common/validator/EnumValidator.java
+++ b/src/main/java/com/example/mate/common/validator/EnumValidator.java
@@ -1,4 +1,4 @@
-package com.example.mate.common.utils.validator;
+package com.example.mate.common.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/src/main/java/com/example/mate/common/validator/ValidEnum.java
+++ b/src/main/java/com/example/mate/common/validator/ValidEnum.java
@@ -1,4 +1,4 @@
-package com.example.mate.common.utils.validator;
+package com.example.mate.common.validator;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;

--- a/src/main/java/com/example/mate/common/validator/ValidPageable.java
+++ b/src/main/java/com/example/mate/common/validator/ValidPageable.java
@@ -1,0 +1,27 @@
+package com.example.mate.common.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.data.domain.Sort.Direction;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface ValidPageable {
+
+    @AliasFor("size")
+    int value() default 10;
+
+    @AliasFor("value")
+    int size() default 10;
+
+    int page() default 0;
+
+    String[] sort() default {};
+
+    Direction direction() default Direction.ASC;
+}

--- a/src/main/java/com/example/mate/common/validator/ValidPageableArgumentResolver.java
+++ b/src/main/java/com/example/mate/common/validator/ValidPageableArgumentResolver.java
@@ -1,0 +1,37 @@
+package com.example.mate.common.validator;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * 커스텀 Pageable 리졸버로, {@code @ValidPageable} 어노테이션이 붙은 Pageable 매개변수의 유효성 검사를 수행합니다.
+ */
+@Component
+public class ValidPageableArgumentResolver extends PageableHandlerMethodArgumentResolver {
+
+    @Override
+    public Pageable resolveArgument(MethodParameter methodParameter,
+                                    ModelAndViewContainer mavContainer,
+                                    NativeWebRequest webRequest,
+                                    WebDataBinderFactory binderFactory) {
+
+        // 기본 Pageable 생성
+        Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+
+        // @ValidPageable 어노테이션 확인
+        ValidPageable validPageable = methodParameter.getParameterAnnotation(ValidPageable.class);
+
+        int pageNumber = Math.max(pageable.getPageNumber(), validPageable != null ? validPageable.page() : 0);
+        int pageSize = pageable.getPageSize() > 0
+                ? pageable.getPageSize()
+                : validPageable != null ? validPageable.size() : 10;
+
+        return PageRequest.of(pageNumber, pageSize, pageable.getSort());
+    }
+}

--- a/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
+++ b/src/main/java/com/example/mate/domain/goods/controller/GoodsController.java
@@ -3,6 +3,7 @@ package com.example.mate.domain.goods.controller;
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.auth.AuthMember;
+import com.example.mate.common.validator.ValidPageable;
 import com.example.mate.domain.goods.dto.request.GoodsPostRequest;
 import com.example.mate.domain.goods.dto.request.GoodsReviewRequest;
 import com.example.mate.domain.goods.dto.response.GoodsPostResponse;
@@ -14,7 +15,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -84,7 +84,7 @@ public class GoodsController {
     public ResponseEntity<ApiResponse<PageResponse<GoodsPostSummaryResponse>>> getGoodsPosts(
             @Parameter(description = "팀 ID") @RequestParam(required = false) Long teamId,
             @Parameter(description = "카테고리") @RequestParam(required = false) String category,
-            @Parameter(description = "페이징 정보", required = true) @PageableDefault Pageable pageable
+            @Parameter(description = "페이징 정보", required = true) @ValidPageable Pageable pageable
     ) {
         PageResponse<GoodsPostSummaryResponse> pageGoodsPosts = goodsService.getPageGoodsPosts(teamId, category, pageable);
 

--- a/src/main/java/com/example/mate/domain/goods/dto/request/GoodsPostRequest.java
+++ b/src/main/java/com/example/mate/domain/goods/dto/request/GoodsPostRequest.java
@@ -1,6 +1,6 @@
 package com.example.mate.domain.goods.dto.request;
 
-import com.example.mate.common.utils.validator.ValidEnum;
+import com.example.mate.common.validator.ValidEnum;
 import com.example.mate.domain.goods.dto.LocationInfo;
 import com.example.mate.domain.goods.entity.Category;
 import com.example.mate.domain.goods.entity.GoodsPost;

--- a/src/main/java/com/example/mate/domain/goods/dto/request/GoodsReviewRequest.java
+++ b/src/main/java/com/example/mate/domain/goods/dto/request/GoodsReviewRequest.java
@@ -1,6 +1,6 @@
 package com.example.mate.domain.goods.dto.request;
 
-import com.example.mate.common.utils.validator.ValidEnum;
+import com.example.mate.common.validator.ValidEnum;
 import com.example.mate.domain.constant.Rating;
 import com.example.mate.domain.goods.entity.GoodsPost;
 import com.example.mate.domain.goods.entity.GoodsReview;

--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
@@ -3,6 +3,7 @@ package com.example.mate.domain.goodsChat.controller;
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.auth.AuthMember;
+import com.example.mate.common.validator.ValidPageable;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatMessageResponse;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomResponse;
 import com.example.mate.domain.goodsChat.dto.response.GoodsChatRoomSummaryResponse;
@@ -11,7 +12,6 @@ import com.example.mate.domain.member.dto.response.MemberSummaryResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -40,7 +40,7 @@ public class GoodsChatRoomController {
     public ResponseEntity<ApiResponse<PageResponse<GoodsChatMessageResponse>>> getGoodsChatRoomMessages(
             @AuthenticationPrincipal AuthMember member,
             @PathVariable Long chatRoomId,
-            @PageableDefault(page = 1, size = 20) Pageable pageable
+            @ValidPageable Pageable pageable
     ) {
         PageResponse<GoodsChatMessageResponse> response = goodsChatService.getMessagesForChatRoom(chatRoomId, member.getMemberId(), pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -48,7 +48,7 @@ public class GoodsChatRoomController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<GoodsChatRoomSummaryResponse>>> getGoodsChatRooms(@AuthenticationPrincipal AuthMember member,
-                                                                                                     @PageableDefault Pageable pageable) {
+                                                                                                     @ValidPageable Pageable pageable) {
         PageResponse<GoodsChatRoomSummaryResponse> response = goodsChatService.getGoodsChatRooms(member.getMemberId(), pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/example/mate/domain/mate/controller/MateController.java
+++ b/src/main/java/com/example/mate/domain/mate/controller/MateController.java
@@ -2,6 +2,7 @@ package com.example.mate.domain.mate.controller;
 
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
+import com.example.mate.common.validator.ValidPageable;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.mate.dto.request.*;
 import com.example.mate.domain.mate.dto.response.*;
@@ -15,7 +16,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -33,10 +33,10 @@ public class MateController {
 
     @PostMapping
     @Operation(summary = "메이트 구인글 등록", description = "메이트 구인글 페이지에서 등록합니다.")
-    public ResponseEntity<ApiResponse<MatePostResponse>> createMatePost(@Parameter(description = "구인글 등록 데이터", required = true)
-                                                                        @Valid @RequestPart(value = "data") MatePostCreateRequest request,
-                                                                        @Parameter(description = "구인글 대표사진", required = true)
-                                                                        @RequestPart(value = "file", required = false) MultipartFile file) {
+    public ResponseEntity<ApiResponse<MatePostResponse>> createMatePost(
+            @Parameter(description = "구인글 등록 데이터", required = true) @Valid @RequestPart(value = "data") MatePostCreateRequest request,
+            @Parameter(description = "구인글 대표사진", required = true) @RequestPart(value = "file", required = false) MultipartFile file
+    ) {
         //TODO - member 정보를 request가 아니라  @AuthenticationPrincipal Long memberId로 받도록 변경
         MatePostResponse response = mateService.createMatePost(request, file);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -46,28 +46,21 @@ public class MateController {
     @Operation(summary = "메인페이지 메이트 구인글 조회", description = "메인 페이지에서 메이트 구인글을 요약한 4개의 리스트를 조회합니다.")
     public ResponseEntity<ApiResponse<List<MatePostSummaryResponse>>> getMainPagePosts(@Parameter(description = "팀 ID")
                                                                                        @RequestParam(required = false) Long teamId) {
-
         List<MatePostSummaryResponse> matePostMain = mateService.getMainPagePosts(teamId);
         return ResponseEntity.ok(ApiResponse.success(matePostMain));
     }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "메이트 구인글 페이징 조회", description = "메이트 구인글 페이지에서 팀/카테고리 기준으로 페이징 조회합니다.")
-    public ResponseEntity<ApiResponse<PageResponse<MatePostSummaryResponse>>> getMatePagePosts(@Parameter(description = "팀 ID")
-                                                                                               @RequestParam(required = false) Long teamId,
-                                                                                               @Parameter(description = "정렬 기준")
-                                                                                               @RequestParam(required = false) String sortType,
-                                                                                               @Parameter(description = "연령대 카테고리")
-                                                                                               @RequestParam(required = false) String age,
-                                                                                               @Parameter(description = "성별 카테고리")
-                                                                                               @RequestParam(required = false) String gender,
-                                                                                               @Parameter(description = "모집인원 수")
-                                                                                               @RequestParam(required = false) Integer maxParticipants,
-                                                                                               @Parameter(description = "이동수단 카테고리")
-                                                                                               @RequestParam(required = false) String transportType,
-                                                                                               @Parameter(description = "페이징 정보")
-                                                                                               @PageableDefault Pageable pageable) {
-
+    public ResponseEntity<ApiResponse<PageResponse<MatePostSummaryResponse>>> getMatePagePosts(
+           @Parameter(description = "팀 ID") @RequestParam(required = false) Long teamId,
+           @Parameter(description = "정렬 기준") @RequestParam(required = false) String sortType,
+           @Parameter(description = "연령대 카테고리") @RequestParam(required = false) String age,
+           @Parameter(description = "성별 카테고리") @RequestParam(required = false) String gender,
+           @Parameter(description = "모집인원 수") @RequestParam(required = false) Integer maxParticipants,
+           @Parameter(description = "이동수단 카테고리") @RequestParam(required = false) String transportType,
+           @Parameter(description = "페이징 정보") @ValidPageable Pageable pageable
+    ) {
         MatePostSearchRequest request = MatePostSearchRequest.builder()
                 .teamId(teamId)
                 .sortType(sortType != null ? SortType.from(sortType) : null)
@@ -92,15 +85,12 @@ public class MateController {
 
     @PatchMapping("/{memberId}/{postId}")
     @Operation(summary = "메이트 구인글 수정", description = "메이트 구인글 상세 페이지에서 수정합니다.")
-    public ResponseEntity<ApiResponse<MatePostResponse>> updateMatePost(@Parameter(description = "작성자 ID (삭제 예정)", required = true)
-                                                                        @PathVariable Long memberId,
-                                                                        @Parameter(description = "구인글 ID", required = true)
-                                                                        @PathVariable Long postId,
-                                                                        @Parameter(description = "수정할 구인글 데이터", required = true)
-                                                                        @Valid @RequestPart(value = "data") MatePostUpdateRequest request,
-                                                                        @Parameter(description = "수정할 대표사진 파일 ", required = true)
-                                                                        @RequestPart(value = "file", required = false) MultipartFile file) {
-
+    public ResponseEntity<ApiResponse<MatePostResponse>> updateMatePost(
+            @Parameter(description = "작성자 ID (삭제 예정)", required = true) @PathVariable Long memberId,
+            @Parameter(description = "구인글 ID", required = true) @PathVariable Long postId,
+            @Parameter(description = "수정할 구인글 데이터", required = true) @Valid @RequestPart(value = "data") MatePostUpdateRequest request,
+            @Parameter(description = "수정할 대표사진 파일 ", required = true) @RequestPart(value = "file", required = false) MultipartFile file
+    ) {
         MatePostResponse response = mateService.updateMatePost(memberId, postId, request, file);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -110,13 +100,11 @@ public class MateController {
     // 메이트 게시글 모집 상태 변경
     @PatchMapping("/{memberId}/{postId}/status")
     @Operation(summary = "메이트 구인글 모집상태 변경", description = "메이트 구인글 채팅방에서 모집상태를 변경합니다.")
-    public ResponseEntity<ApiResponse<MatePostResponse>> updateMatePostStatus(@Parameter(description = "작성자 ID (삭제 예정)", required = true)
-                                                                              @PathVariable(value = "memberId") Long memberId,
-                                                                              @Parameter(description = "구인글 ID", required = true)
-                                                                              @PathVariable(value = "postId") Long postId,
-                                                                              @Parameter(description = "변경할 모집상태와 현재 참여자 리스트 ID", required = true)
-                                                                              @Valid @RequestBody MatePostStatusRequest request) {
-
+    public ResponseEntity<ApiResponse<MatePostResponse>> updateMatePostStatus(
+            @Parameter(description = "작성자 ID (삭제 예정)", required = true) @PathVariable(value = "memberId") Long memberId,
+            @Parameter(description = "구인글 ID", required = true) @PathVariable(value = "postId") Long postId,
+            @Parameter(description = "변경할 모집상태와 현재 참여자 리스트 ID", required = true) @Valid @RequestBody MatePostStatusRequest request
+    ) {
         MatePostResponse response = mateService.updateMatePostStatus(memberId, postId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -136,13 +124,11 @@ public class MateController {
     // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
     @PatchMapping("/{memberId}/{postId}/complete")
     @Operation(summary = "직관완료 처리", description = "메이트 구인글 채팅방에서 직관완료 처리를 진행합니다.")
-    public ResponseEntity<ApiResponse<MatePostCompleteResponse>> completeVisit(@Parameter(description = "작성자 ID (삭제 예정)", required = true)
-                                                                               @PathVariable Long memberId,
-                                                                               @Parameter(description = "구인글 ID", required = true)
-                                                                               @PathVariable Long postId,
-                                                                               @Parameter(description = "실제 직관 참여자 리스트 ID", required = true)
-                                                                               @Valid @RequestBody MatePostCompleteRequest request) {
-
+    public ResponseEntity<ApiResponse<MatePostCompleteResponse>> completeVisit(
+            @Parameter(description = "작성자 ID (삭제 예정)", required = true) @PathVariable Long memberId,
+            @Parameter(description = "구인글 ID", required = true) @PathVariable Long postId,
+            @Parameter(description = "실제 직관 참여자 리스트 ID", required = true) @Valid @RequestBody MatePostCompleteRequest request
+    ) {
         MatePostCompleteResponse response = mateService.completeVisit(memberId, postId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -150,14 +136,11 @@ public class MateController {
     // TODO: @PathVariable Long memberId -> @AuthenticationPrincipal 로 변경
     @PostMapping("/{memberId}/{postId}/reviews")
     @Operation(summary = "메이트 직관 후기 등록", description = "직관 타임라인 페이지에서 메이트에 대한 후기를 등록합니다.")
-    public ResponseEntity<ApiResponse<MateReviewCreateResponse>> createMateReview(@Parameter(description = "작성자 ID (삭제 예정)", required = true)
-                                                                                  @PathVariable Long memberId,
-                                                                                  @Parameter(description = "구인글 ID", required = true)
-                                                                                  @PathVariable Long postId,
-                                                                                  @Parameter(description = "리뷰 대상자 ID와 평점 및 코멘트", required = true)
-                                                                                  @Valid @RequestBody MateReviewCreateRequest request
+    public ResponseEntity<ApiResponse<MateReviewCreateResponse>> createMateReview(
+            @Parameter(description = "작성자 ID (삭제 예정)", required = true) @PathVariable Long memberId,
+            @Parameter(description = "구인글 ID", required = true) @PathVariable Long postId,
+            @Parameter(description = "리뷰 대상자 ID와 평점 및 코멘트", required = true) @Valid @RequestBody MateReviewCreateRequest request
     ) {
-
         MateReviewCreateResponse response = mateService.createReview(postId, memberId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MatePostCreateRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MatePostCreateRequest.java
@@ -1,6 +1,6 @@
 package com.example.mate.domain.mate.dto.request;
 
-import com.example.mate.common.utils.validator.ValidEnum;
+import com.example.mate.common.validator.ValidEnum;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.mate.entity.TransportType;

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MatePostSearchRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MatePostSearchRequest.java
@@ -1,6 +1,6 @@
 package com.example.mate.domain.mate.dto.request;
 
-import com.example.mate.common.utils.validator.ValidEnum;
+import com.example.mate.common.validator.ValidEnum;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.mate.entity.SortType;

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MatePostStatusRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MatePostStatusRequest.java
@@ -1,6 +1,6 @@
 package com.example.mate.domain.mate.dto.request;
 
-import com.example.mate.common.utils.validator.ValidEnum;
+import com.example.mate.common.validator.ValidEnum;
 import com.example.mate.domain.mate.entity.Status;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MatePostUpdateRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MatePostUpdateRequest.java
@@ -1,6 +1,6 @@
 package com.example.mate.domain.mate.dto.request;
 
-import com.example.mate.common.utils.validator.ValidEnum;
+import com.example.mate.common.validator.ValidEnum;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.mate.entity.Age;
 import com.example.mate.domain.mate.entity.TransportType;

--- a/src/main/java/com/example/mate/domain/mate/dto/request/MateReviewCreateRequest.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/request/MateReviewCreateRequest.java
@@ -1,6 +1,6 @@
 package com.example.mate.domain.mate.dto.request;
 
-import com.example.mate.common.utils.validator.ValidEnum;
+import com.example.mate.common.validator.ValidEnum;
 import com.example.mate.domain.constant.Rating;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -108,14 +108,7 @@ public class MateService {
                 .map(MatePostSummaryResponse::from)
                 .toList();
 
-        return PageResponse.<MatePostSummaryResponse>builder()
-                .content(content)
-                .totalPages(matePostPage.getTotalPages())
-                .totalElements(matePostPage.getTotalElements())
-                .hasNext(matePostPage.hasNext())
-                .pageNumber(matePostPage.getNumber())
-                .pageSize(matePostPage.getSize())
-                .build();
+        return PageResponse.from(matePostPage, content);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/mate/domain/mateChat/controller/MateChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/mateChat/controller/MateChatRoomController.java
@@ -5,6 +5,7 @@ import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.auth.AuthMember;
+import com.example.mate.common.validator.ValidPageable;
 import com.example.mate.domain.mateChat.dto.response.MateChatMessageResponse;
 import com.example.mate.domain.mateChat.dto.response.MateChatRoomListResponse;
 import com.example.mate.domain.mateChat.dto.response.MateChatRoomResponse;
@@ -14,7 +15,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -30,7 +30,7 @@ public class MateChatRoomController {
     @Operation(summary = "메이트 게시글 -> 채팅방 생성/입장", description = "메이트 게시글 페이지에서 채팅방으로 입장")
     public ResponseEntity<ApiResponse<MateChatRoomResponse>> createOrJoinChatRoomFromPost(
             @Parameter(description = "메이트 게시글 ID") @PathVariable Long matePostId,
-                                                        @AuthenticationPrincipal AuthMember member
+            @AuthenticationPrincipal AuthMember member
     ) {
         MateChatRoomResponse response = chatRoomService.createOrJoinChatRoomFromPost(matePostId, member.getMemberId());
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -39,11 +39,9 @@ public class MateChatRoomController {
     @GetMapping("/me")
     @Operation(summary = "채팅방 목록 조회", description = "사용자의 채팅방 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<PageResponse<MateChatRoomListResponse>>> getMyChatRooms(
-            @Parameter(description = "페이지 정보") @PageableDefault Pageable pageable,
-                                                    @AuthenticationPrincipal AuthMember member
-
-            ) {
-
+            @Parameter(description = "페이지 정보") @ValidPageable Pageable pageable,
+            @AuthenticationPrincipal AuthMember member
+    ) {
         if (member == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER);
         }
@@ -65,8 +63,8 @@ public class MateChatRoomController {
     @Operation(summary = "채팅방 메세지 조회", description = "메시지 내역을 조회합니다.")
     public ResponseEntity<ApiResponse<PageResponse<MateChatMessageResponse>>> getChatMessages(
             @Parameter(description = "채팅방 ID") @PathVariable Long chatroomId,
-                                                    @AuthenticationPrincipal AuthMember member,
-            @Parameter(description = "페이지 정보") @PageableDefault(page = 1, size = 20) Pageable pageable
+            @AuthenticationPrincipal AuthMember member,
+            @Parameter(description = "페이지 정보") @ValidPageable(page = 1, size = 20) Pageable pageable
     ) {
         PageResponse<MateChatMessageResponse> messages = chatRoomService.getChatMessages(chatroomId, member.getMemberId(), pageable);
         return ResponseEntity.ok(ApiResponse.success(messages));
@@ -76,7 +74,7 @@ public class MateChatRoomController {
     @Operation(summary = "채팅방 나가기", description = "채팅방에서 퇴장합니다.")
     public ResponseEntity<Void> leaveChatRoom(
             @Parameter(description = "채팅방 ID") @PathVariable Long chatroomId,
-                                                    @AuthenticationPrincipal AuthMember member
+            @AuthenticationPrincipal AuthMember member
     ) {
         chatRoomService.leaveChatRoom(chatroomId, member.getMemberId());
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/example/mate/domain/member/controller/FollowController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/FollowController.java
@@ -5,6 +5,7 @@ import static com.example.mate.common.response.PageResponse.validatePageable;
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.auth.AuthMember;
+import com.example.mate.common.validator.ValidPageable;
 import com.example.mate.domain.member.dto.response.MemberSummaryResponse;
 import com.example.mate.domain.member.service.FollowService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,7 +13,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -52,7 +52,7 @@ public class FollowController {
     @GetMapping("{memberId}/followings")
     public ResponseEntity<ApiResponse<PageResponse<MemberSummaryResponse>>> getFollowings(
             @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
-            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
+            @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
         pageable = validatePageable(pageable);
         PageResponse<MemberSummaryResponse> response = followService.getFollowingsPage(memberId, pageable);
@@ -63,7 +63,7 @@ public class FollowController {
     @GetMapping("{memberId}/followers")
     public ResponseEntity<ApiResponse<PageResponse<MemberSummaryResponse>>> getFollowers(
             @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
-            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
+            @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
         pageable = validatePageable(pageable);
         PageResponse<MemberSummaryResponse> response = followService.getFollowersPage(memberId, pageable);

--- a/src/main/java/com/example/mate/domain/member/controller/FollowController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/FollowController.java
@@ -1,7 +1,5 @@
 package com.example.mate.domain.member.controller;
 
-import static com.example.mate.common.response.PageResponse.validatePageable;
-
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.auth.AuthMember;
@@ -54,7 +52,6 @@ public class FollowController {
             @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
             @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
-        pageable = validatePageable(pageable);
         PageResponse<MemberSummaryResponse> response = followService.getFollowingsPage(memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -65,7 +62,6 @@ public class FollowController {
             @Parameter(description = "특정 회원 ID") @PathVariable Long memberId,
             @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
-        pageable = validatePageable(pageable);
         PageResponse<MemberSummaryResponse> response = followService.getFollowersPage(memberId, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
@@ -7,6 +7,7 @@ import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.auth.AuthMember;
+import com.example.mate.common.validator.ValidPageable;
 import com.example.mate.domain.member.dto.response.MyGoodsRecordResponse;
 import com.example.mate.domain.member.dto.response.MyReviewResponse;
 import com.example.mate.domain.member.dto.response.MyVisitResponse;
@@ -16,7 +17,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,7 +36,7 @@ public class ProfileController {
     @GetMapping("/{memberId}/review/goods")
     public ResponseEntity<ApiResponse<PageResponse<MyReviewResponse>>> getGoodsReviews(
             @Parameter(description = "회원 ID") @PathVariable Long memberId,
-            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
+            @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
         validatePageable(pageable);
         PageResponse<MyReviewResponse> response = profileService.getGoodsReviewPage(memberId, pageable);
@@ -47,7 +47,7 @@ public class ProfileController {
     @GetMapping("{memberId}/review/mate")
     public ResponseEntity<ApiResponse<PageResponse<MyReviewResponse>>> getMateReviews(
             @Parameter(description = "회원 ID") @PathVariable Long memberId,
-            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
+            @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
         validatePageable(pageable);
         PageResponse<MyReviewResponse> response = profileService.getMateReviewPage(memberId, pageable);
@@ -58,7 +58,7 @@ public class ProfileController {
     @GetMapping("/timeline")
     public ResponseEntity<ApiResponse<PageResponse<MyVisitResponse>>> getMyVisits(
             @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember,
-            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
+            @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
         validatePageable(pageable);
         PageResponse<MyVisitResponse> response = profileService.getMyVisitPage(authMember.getMemberId(), pageable);
@@ -69,7 +69,7 @@ public class ProfileController {
     @GetMapping("/{memberId}/goods/sold")
     public ResponseEntity<ApiResponse<PageResponse<MyGoodsRecordResponse>>> getSoldGoods(
             @Parameter(description = "회원 ID") @PathVariable Long memberId,
-            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable
+            @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
         pageable = validatePageable(pageable);
         PageResponse<MyGoodsRecordResponse> response = profileService.getSoldGoodsPage(memberId, pageable);
@@ -80,7 +80,7 @@ public class ProfileController {
     @GetMapping("/{memberId}/goods/bought")
     public ResponseEntity<ApiResponse<PageResponse<MyGoodsRecordResponse>>> getBoughtGoods(
             @Parameter(description = "회원 ID") @PathVariable Long memberId,
-            @Parameter(description = "페이지 요청 정보") @PageableDefault Pageable pageable,
+            @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable,
             @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember
     ) {
         if (!authMember.getMemberId().equals(memberId)) {

--- a/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/ProfileController.java
@@ -1,7 +1,5 @@
 package com.example.mate.domain.member.controller;
 
-import static com.example.mate.common.response.PageResponse.validatePageable;
-
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.response.ApiResponse;
@@ -38,7 +36,6 @@ public class ProfileController {
             @Parameter(description = "회원 ID") @PathVariable Long memberId,
             @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
-        validatePageable(pageable);
         PageResponse<MyReviewResponse> response = profileService.getGoodsReviewPage(memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -49,7 +46,6 @@ public class ProfileController {
             @Parameter(description = "회원 ID") @PathVariable Long memberId,
             @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
-        validatePageable(pageable);
         PageResponse<MyReviewResponse> response = profileService.getMateReviewPage(memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -60,7 +56,6 @@ public class ProfileController {
             @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember,
             @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
-        validatePageable(pageable);
         PageResponse<MyVisitResponse> response = profileService.getMyVisitPage(authMember.getMemberId(), pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -71,7 +66,6 @@ public class ProfileController {
             @Parameter(description = "회원 ID") @PathVariable Long memberId,
             @Parameter(description = "페이지 요청 정보") @ValidPageable Pageable pageable
     ) {
-        pageable = validatePageable(pageable);
         PageResponse<MyGoodsRecordResponse> response = profileService.getSoldGoodsPage(memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -86,7 +80,6 @@ public class ProfileController {
         if (!authMember.getMemberId().equals(memberId)) {
             throw new CustomException(ErrorCode.MEMBER_UNAUTHORIZED_ACCESS);
         }
-        pageable = validatePageable(pageable);
         PageResponse<MyGoodsRecordResponse> response = profileService.getBoughtGoodsPage(memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/example/mate/domain/member/service/FollowService.java
+++ b/src/main/java/com/example/mate/domain/member/service/FollowService.java
@@ -56,14 +56,7 @@ public class FollowService {
                 .map(MemberSummaryResponse::from)
                 .toList();
 
-        return PageResponse.<MemberSummaryResponse>builder()
-                .content(content)
-                .totalPages(followingsPage.getTotalPages())
-                .totalElements(followingsPage.getTotalElements())
-                .hasNext(followingsPage.hasNext())
-                .pageNumber(followingsPage.getNumber())
-                .pageSize(followingsPage.getSize())
-                .build();
+        return PageResponse.from(followingsPage, content);
     }
 
     // 특정 회원의 팔로워 리스트 페이징 조회
@@ -78,14 +71,7 @@ public class FollowService {
                 .map(MemberSummaryResponse::from)
                 .toList();
 
-        return PageResponse.<MemberSummaryResponse>builder()
-                .content(content)
-                .totalPages(followingsPage.getTotalPages())
-                .totalElements(followingsPage.getTotalElements())
-                .hasNext(followingsPage.hasNext())
-                .pageNumber(followingsPage.getNumber())
-                .pageSize(followingsPage.getSize())
-                .build();
+        return PageResponse.from(followingsPage, content);
     }
 
     private Map<String, Member> isValidMemberFollow(Long followerId, Long followingId) {

--- a/src/main/java/com/example/mate/domain/member/service/ProfileService.java
+++ b/src/main/java/com/example/mate/domain/member/service/ProfileService.java
@@ -4,7 +4,6 @@ import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.goods.entity.GoodsPost;
-import com.example.mate.domain.goods.entity.GoodsPostImage;
 import com.example.mate.domain.goods.entity.Status;
 import com.example.mate.domain.goods.repository.GoodsPostRepository;
 import com.example.mate.domain.goods.repository.GoodsReviewRepositoryCustom;
@@ -56,14 +55,7 @@ public class ProfileService {
         List<MyGoodsRecordResponse> content = soldGoodsPage.getContent().stream()
                 .map(this::convertToRecordResponse).toList();
 
-        return PageResponse.<MyGoodsRecordResponse>builder()
-                .content(content)
-                .totalPages(soldGoodsPage.getTotalPages())
-                .totalElements(soldGoodsPage.getTotalElements())
-                .hasNext(soldGoodsPage.hasNext())
-                .pageNumber(soldGoodsPage.getNumber())
-                .pageSize(soldGoodsPage.getSize())
-                .build();
+        return PageResponse.from(soldGoodsPage, content);
     }
 
     // 굿즈 구매기록 페이징 조회
@@ -77,14 +69,7 @@ public class ProfileService {
         List<MyGoodsRecordResponse> content = boughtGoodsPage.getContent().stream()
                 .map(this::convertToRecordResponse).toList();
 
-        return PageResponse.<MyGoodsRecordResponse>builder()
-                .content(content)
-                .totalPages(boughtGoodsPage.getTotalPages())
-                .totalElements(boughtGoodsPage.getTotalElements())
-                .hasNext(boughtGoodsPage.hasNext())
-                .pageNumber(boughtGoodsPage.getNumber())
-                .pageSize(boughtGoodsPage.getSize())
-                .build();
+        return PageResponse.from(boughtGoodsPage, content);
     }
 
     private void validateMemberId(Long memberId) {
@@ -105,14 +90,7 @@ public class ProfileService {
         Page<MyReviewResponse> mateReviewPage = mateReviewRepositoryCustom.findMateReviewsByRevieweeId(
                 memberId, pageable);
 
-        return PageResponse.<MyReviewResponse>builder()
-                .content(mateReviewPage.getContent())
-                .totalPages(mateReviewPage.getTotalPages())
-                .totalElements(mateReviewPage.getTotalElements())
-                .hasNext(mateReviewPage.hasNext())
-                .pageNumber(mateReviewPage.getNumber())
-                .pageSize(mateReviewPage.getSize())
-                .build();
+        return PageResponse.from(mateReviewPage);
     }
 
     // 굿즈거래 후기 페이징 조회
@@ -123,14 +101,7 @@ public class ProfileService {
         Page<MyReviewResponse> goodsReviewPage = goodsReviewRepositoryCustom.findGoodsReviewsByRevieweeId(
                 memberId, pageable);
 
-        return PageResponse.<MyReviewResponse>builder()
-                .content(goodsReviewPage.getContent())
-                .totalPages(goodsReviewPage.getTotalPages())
-                .totalElements(goodsReviewPage.getTotalElements())
-                .hasNext(goodsReviewPage.hasNext())
-                .pageNumber(goodsReviewPage.getNumber())
-                .pageSize(goodsReviewPage.getSize())
-                .build();
+        return PageResponse.from(goodsReviewPage);
     }
 
     // TODO : 쿼리가 너무 많이 나오는 문제 -> 멘토링 및 리팩토링 필요

--- a/src/test/java/com/example/mate/domain/file/FileValidatorTest.java
+++ b/src/test/java/com/example/mate/domain/file/FileValidatorTest.java
@@ -1,8 +1,7 @@
-package com.example.mate.common.utils.file;
+package com.example.mate.domain.file;
 
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
-import com.example.mate.domain.file.FileValidator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
## 💡 작업 내용

- [x] Pageable 객체 유효성 검증 커스텀 어노테이션 구현
- [x] 중복 코드 제거
- [x] 전체적인 코드 리팩토링

## 💡 자세한 설명
기존 `@PageableDefault` 랑 동작 방식은 같지만 유효성 검증을 추가했습니다.
멘토님 말씀 듣고 커스텀 어노테이션으로 구현했습니다. 
또한 다른분들 코드 로직에는 변경없이 리팩토링도 진행했습니당

📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
수정이 잘못된 부분이 있으면 말씀해주세요 !

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?