### PR TITLE
MATE-114 : [FIX] Docker 컨테이너 내부에 Redis 환경 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
 FROM eclipse-temurin:17-jdk-alpine
+
+# Redis 설치
+RUN apk add --no-cache redis
+
 COPY ./build/libs/*SNAPSHOT.jar project.jar
-ENTRYPOINT ["java", "-jar", "project.jar"]
+ENTRYPOINT redis-server & java -jar project.jar


### PR DESCRIPTION
## 💡 작업 내용

- [x] Redis 적용 이후 Docker 이미지가 Authorization 관련 기능을 수행하지 못하는 문제 해결

## 💡 자세한 설명

#### Dockerfile 수정을 통해 Redis 이미지 내부에 적용

- 단순 yml 파일이나 build.gradle 의존성만으로 적용됐던 Redis가 도커 이미지엔 적용이 안됐습니다.
    - EC2 보안그룹의 Redis의 포트 6379에 대한 인바운드 설정도 추가
    - 도커 파일도 단일 컨테이너 안에 jar와 함께 redis도 설정하도록 수정

## 📗 참고 자료 (선택)


https://moon-kotlin.tistory.com/68

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?