### PR TITLE
MATE-121 : [FEAT] 메이트 상세조회 기능의 응답 DTO에 현재 채팅방 인원값 추가

### DIFF
--- a/src/main/java/com/example/mate/domain/mate/dto/response/MatePostDetailResponse.java
+++ b/src/main/java/com/example/mate/domain/mate/dto/response/MatePostDetailResponse.java
@@ -33,8 +33,9 @@ public class MatePostDetailResponse {
     private Long postId;
     private Long matchId;
     private Long authorId;
+    private Integer currentChatMembers;
 
-    public static MatePostDetailResponse from(MatePost post) {
+    public static MatePostDetailResponse from(MatePost post, Integer currentChatMembers) {
         String myTeamName = TeamInfo.getById(post.getTeamId()).shortName;
         String rivalTeamName = getRivalTeamName(post);
 
@@ -57,6 +58,7 @@ public class MatePostDetailResponse {
                 .postId(post.getId())
                 .matchId(post.getMatch().getId())
                 .authorId(post.getAuthor().getId())
+                .currentChatMembers(currentChatMembers)
                 .build();
     }
 

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -15,6 +15,8 @@ import com.example.mate.domain.mate.entity.Status;
 import com.example.mate.domain.mate.entity.Visit;
 import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.mate.repository.MateReviewRepository;
+import com.example.mate.domain.mateChat.repository.MateChatRoomMemberRepository;
+import com.example.mate.domain.mateChat.repository.MateChatRoomRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +41,8 @@ public class MateService {
     private final MatchRepository matchRepository;
     private final MemberRepository memberRepository;
     private final MateReviewRepository mateReviewRepository;
+    private final MateChatRoomRepository mateChatRoomRepository;
+    private final MateChatRoomMemberRepository mateChatRoomMemberRepository;
     private final FileService fileService;
 
     public MatePostResponse createMatePost(MatePostCreateRequest request, MultipartFile file, Long memberId) {
@@ -115,7 +119,15 @@ public class MateService {
     public MatePostDetailResponse getMatePostDetail(Long postId) {
         MatePost matePost = findMatePostById(postId);
 
-        return MatePostDetailResponse.from(matePost);
+        Integer currentChatMembers = getCurrentChatMembers(postId);
+
+        return MatePostDetailResponse.from(matePost, currentChatMembers);
+    }
+
+    private Integer getCurrentChatMembers(Long postId) {
+        return mateChatRoomRepository.findByMatePostId(postId)
+                .map(chatRoom -> mateChatRoomMemberRepository.countByChatRoomIdAndIsActiveTrue(chatRoom.getId()))
+                .orElse(0);
     }
 
     public MatePostResponse updateMatePost(Long memberId, Long postId, MatePostUpdateRequest request,

--- a/src/test/java/com/example/mate/domain/mate/service/MateServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateServiceTest.java
@@ -15,6 +15,8 @@ import com.example.mate.domain.mate.dto.response.MatePostResponse;
 import com.example.mate.domain.mate.dto.response.MatePostSummaryResponse;
 import com.example.mate.domain.mate.entity.*;
 import com.example.mate.domain.mate.repository.MateRepository;
+import com.example.mate.domain.mateChat.repository.MateChatRoomMemberRepository;
+import com.example.mate.domain.mateChat.repository.MateChatRoomRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -60,6 +62,12 @@ class MateServiceTest {
 
     @Mock
     private FileService fileService;
+
+    @Mock
+    private MateChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private MateChatRoomMemberRepository chatRoomMemberRepository;
 
     private static final Long TEST_MEMBER_ID = 1L;
     private static final Long TEST_MATCH_ID = 1L;


### PR DESCRIPTION
## 💡 작업 내용

- [x] 메이트 상세조회 api에 현재 채팅방 인원값 추가

## 💡 자세한 설명
메이트 상세조회 api에 현재 채팅방 인원값 추가

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?