### PR TITLE
MATE-125 : [FEAT] S3 정적 호스팅 페이지 CORS 연결 허용 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy To EC2
 on:
-  push:
-    branches:
-      - develop
+  push
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy To EC2
 on:
-  push
+  push:
+    branches:
+      - develop
 
 jobs:
   deploy:

--- a/src/main/java/com/example/mate/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/mate/common/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.example.mate.common.config;
 
 import com.example.mate.common.security.filter.JwtCheckFilter;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +14,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -45,7 +46,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:8080"));
+        config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:8080", "http://catchmi-web-page.s3-website.ap-northeast-2.amazonaws.com/"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
         config.setAllowedHeaders(List.of("Authorization", "Content-Type", "Cache-Control"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
## 💡 작업 내용

- [x] 프론트엔드에서 연결한 S3 정적 호스팅 페이지의 CORS 문제 해결

## 📗 참고 자료 (선택)

#### 추가) [AWS] S3 정적 호스팅 페이지 새로고침 시 404 NoSuchKey 에러가 발생하는 이슈

해결 : 
https://velog.io/@jinny-l/AWS-S3-web-hosting-reload-404-NoSuchKey-error 


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?