### PR TITLE
MATE-127 : [REFACTOR] CATCH Mi 로그아웃 및 JWT 로직 리팩토링

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "A003", "접근 권한이 없습니다. 권한을 확인해주세요."),
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "A004", "인증되지 않은 사용자입니다"),
     INVALID_AUTH_TOKEN(HttpStatus.BAD_REQUEST, "A005", "잘못된 토큰 형식입니다."),
+    EXPIRED_AUTH_TOKEN(HttpStatus.BAD_REQUEST, "A006", "이미 만료된 토큰입니다."),
 
     // Team
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "팀을 찾을 수 없습니다"),
@@ -34,6 +35,7 @@ public enum ErrorCode {
     ALREADY_USED_NICKNAME(HttpStatus.BAD_REQUEST, "M003", "이미 사용 중인 닉네임입니다."),
     MEMBER_NOT_FOUND_BY_EMAIL(HttpStatus.NOT_FOUND, "M004", "해당 이메일의 회원 정보를 찾을 수 없습니다."),
     MEMBER_UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "M005", "해당 회원의 접근 권한이 없습니다."),
+    MEMBER_AUTHENTICATION_REQUIRED(HttpStatus.BAD_REQUEST, "M006", "미리 인증된 회원의 정보가 필요합니다."),
 
     // Follow
     ALREADY_FOLLOWED_MEMBER(HttpStatus.BAD_REQUEST, "F001", "이미 팔로우한 회원입니다."),

--- a/src/main/java/com/example/mate/common/security/util/JwtUtil.java
+++ b/src/main/java/com/example/mate/common/security/util/JwtUtil.java
@@ -40,7 +40,7 @@ public class JwtUtil {
                 .build();
     }
 
-    // JWT Access Token 생성. 2분 유효시간
+    // JWT Access Token 생성. 30분 유효시간
     public String createAccessToken(Map<String, Object> valueMap, Date issuedAt) {
         SecretKey key = getSigningKey();
 
@@ -48,7 +48,7 @@ public class JwtUtil {
                 .setHeaderParam("alg", "HS256")
                 .setHeaderParam("typ", "JWT")
                 .setIssuedAt(issuedAt)
-                .setExpiration(new Date(issuedAt.getTime() + Duration.ofMinutes(2).toMillis()))
+                .setExpiration(new Date(issuedAt.getTime() + Duration.ofMinutes(30).toMillis()))
                 .setClaims(valueMap)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();

--- a/src/main/java/com/example/mate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/MemberController.java
@@ -9,7 +9,6 @@ import com.example.mate.domain.member.dto.response.JoinResponse;
 import com.example.mate.domain.member.dto.response.MemberLoginResponse;
 import com.example.mate.domain.member.dto.response.MemberProfileResponse;
 import com.example.mate.domain.member.dto.response.MyProfileResponse;
-import com.example.mate.domain.member.service.LogoutRedisService;
 import com.example.mate.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,9 +27,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberController {
 
     private final MemberService memberService;
-    private final LogoutRedisService logoutRedisService;
 
-    @Operation(summary = "자체 회원가입 기능")
+    @Operation(summary = "CATCH Mi 회원가입 기능", description = "캐치미 서비스에 회원가입합니다.")
     @PostMapping("/join")
     public ResponseEntity<ApiResponse<JoinResponse>> join(
             @Parameter(description = "소셜 로그인 정보와 사용자 추가 입력 정보") @RequestBody @Valid JoinRequest joinRequest
@@ -38,7 +36,7 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.success(memberService.join(joinRequest)));
     }
 
-    @Operation(summary = "CATCH Mi 서비스 로그인", description = "캐치미 서비스에 로그인합니다.")
+    @Operation(summary = "CATCH Mi 로그인", description = "캐치미 서비스에 로그인합니다.")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<MemberLoginResponse>> catchMiLogin(
             @Parameter(description = "회원 로그인 요청 정보", required = true) @Valid @RequestBody MemberLoginRequest request
@@ -50,27 +48,27 @@ public class MemberController {
     @Operation(summary = "CATCH Mi 서비스 로그아웃", description = "캐치미 서비스에 로그아웃합니다.")
     @PostMapping("/logout")
     public ResponseEntity<Void> catchMiLogout(
-            @Parameter(description = "회원 로그인 토큰 헤더", required = true) @RequestHeader("Authorization") String token
+            @Parameter(description = "회원 로그인 토큰 헤더", required = true) @RequestHeader("Authorization") String authorizationHeader
     ) {
-        logoutRedisService.addTokenToBlacklist(token);
+        memberService.logout(authorizationHeader);
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "내 프로필 조회")
+    @Operation(summary = "내 프로필 조회", description = "내 프로필 페이지를 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<MyProfileResponse>> findMyInfo(
             @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember) {
         return ResponseEntity.ok(ApiResponse.success(memberService.getMyProfile(authMember.getMemberId())));
     }
 
-    @Operation(summary = "다른 회원 프로필 조회")
+    @Operation(summary = "다른 회원 프로필 조회", description = "다른 회원의 프로필 페이지를 조회합니다.")
     @GetMapping("/{memberId}")
     public ResponseEntity<ApiResponse<MemberProfileResponse>> findMemberInfo(
             @Parameter(description = "회원 ID") @PathVariable Long memberId) {
         return ResponseEntity.ok(ApiResponse.success(memberService.getMemberProfile(memberId)));
     }
 
-    @Operation(summary = "회원 내 정보 수정")
+    @Operation(summary = "회원 내 정보 수정", description = "프로필 사진 및 회원 정보를 수정합니다.")
     @PutMapping(value = "/me")
     public ResponseEntity<ApiResponse<MyProfileResponse>> updateMemberInfo(
             @Parameter(description = "프로필 사진") @RequestPart(value = "file", required = false) MultipartFile image,
@@ -80,7 +78,7 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.success(memberService.updateMyProfile(image, updateRequest)));
     }
 
-    @Operation(summary = "회원 탈퇴")
+    @Operation(summary = "CATCH Mi 회원 탈퇴", description = "캐치미 서비스를 탈퇴합니다.")
     @DeleteMapping("/me")
     public ResponseEntity<Void> deleteMember(
             @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember) {

--- a/src/main/java/com/example/mate/domain/member/service/LogoutRedisService.java
+++ b/src/main/java/com/example/mate/domain/member/service/LogoutRedisService.java
@@ -2,10 +2,14 @@ package com.example.mate.domain.member.service;
 
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
+import com.example.mate.common.security.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -13,18 +17,24 @@ import java.util.concurrent.TimeUnit;
 public class LogoutRedisService {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final JwtUtil jwtUtil;
 
-    // 로그아웃 시 블랙리스트에 토큰 추가
-    public void addTokenToBlacklist(String token) {
-        if (token == null || !token.startsWith("Bearer ")) {
+    // 로그아웃 시 액세스 토큰의 남은 시간만큼 블랙리스트에 추가
+    public void addTokenToBlacklist(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
             throw new CustomException(ErrorCode.INVALID_AUTH_TOKEN);
         }
 
-        // TODO : 테스트용 1분 유효를 변경
-        redisTemplate.opsForValue().set("blacklist:" + token.substring(7), "blacklisted", 1, TimeUnit.MINUTES);
+        String accessToken = authorizationHeader.substring(7);
+        Map<String, Object> claims = jwtUtil.validateToken(accessToken);
+
+        long remainingTime = (long) claims.get("iat") + Duration.ofMinutes(2).toMillis() - new Date().getTime();
+
+        redisTemplate.opsForValue().set(
+                "blacklist:" + accessToken, "blacklisted", remainingTime, TimeUnit.MILLISECONDS);
     }
 
-    // 블랙리스트에 토큰 있는지 확인
+    // 블랙리스트에 해당 액세스 토큰 있는지 확인
     public boolean isTokenBlacklisted(String accessToken) {
         return redisTemplate.hasKey("blacklist:" + accessToken);
     }

--- a/src/main/java/com/example/mate/domain/member/service/LogoutRedisService.java
+++ b/src/main/java/com/example/mate/domain/member/service/LogoutRedisService.java
@@ -28,7 +28,7 @@ public class LogoutRedisService {
         String accessToken = authorizationHeader.substring(7);
         Map<String, Object> claims = jwtUtil.validateToken(accessToken);
 
-        long remainingTime = (long) claims.get("iat") + Duration.ofMinutes(2).toMillis() - new Date().getTime();
+        long remainingTime = (long) claims.get("iat") + Duration.ofMinutes(30).toMillis() - new Date().getTime();
 
         redisTemplate.opsForValue().set(
                 "blacklist:" + accessToken, "blacklisted", remainingTime, TimeUnit.MILLISECONDS);

--- a/src/test/java/com/example/mate/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/MemberControllerTest.java
@@ -441,24 +441,6 @@ class MemberControllerTest {
             mockMvc.perform(post("/api/members/logout")
                             .header(HttpHeaders.AUTHORIZATION, token))
                     .andExpect(status().isNoContent());
-
-            verify(logoutRedisService).addTokenToBlacklist(token);
-        }
-
-        @Test
-        @DisplayName("로그아웃 실패 - 잘못된 토큰 형식")
-        void catchMiLogout_invalid_token_format() throws Exception {
-            // given
-            String invalidToken = "InvalidToken";
-
-            willThrow(new CustomException(ErrorCode.INVALID_AUTH_TOKEN))
-                    .given(logoutRedisService).addTokenToBlacklist(invalidToken);
-
-
-            // when & then
-            mockMvc.perform(post("/api/members/logout")
-                            .header(HttpHeaders.AUTHORIZATION, invalidToken))
-                    .andExpect(status().isBadRequest());
         }
     }
 }

--- a/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.member.integration;
 
+import com.example.mate.common.jwt.JwtToken;
 import com.example.mate.common.security.util.JwtUtil;
 import com.example.mate.config.WithAuthMember;
 import com.example.mate.domain.constant.Gender;
@@ -47,12 +48,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
 import static com.example.mate.domain.mate.entity.Status.CLOSED;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -277,7 +280,7 @@ class MemberIntegrationTest {
                 .memberId(member.getId())
                 .build();
     }
-
+    
     @Nested
     @DisplayName("자체 회원 가입")
     class Join {
@@ -462,6 +465,16 @@ class MemberIntegrationTest {
                     .email("tester@example.com")
                     .build();
 
+            // mockJwtToken 객체 생성
+            JwtToken mockJwtToken = JwtToken.builder()
+                    .grantType("Bearer")
+                    .accessToken("mockAccessToken")
+                    .refreshToken("mockRefreshToken")
+                    .build();
+
+            // JwtUtil의 createTokens 메서드 mock 처리
+            when(jwtUtil.createTokens(any(Member.class))).thenReturn(mockJwtToken);
+
             // when & then
             mockMvc.perform(post("/api/members/login")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -505,6 +518,11 @@ class MemberIntegrationTest {
         void logout_member_success_with_my_info_denied() throws Exception {
             // given
             String token = "Bearer accessToken";
+
+            // mockJwtToken 객체 생성
+            Map<String, Object> mockClaims = Map.of("iat", new Date().getTime()); // 'iat' 필드를 mock 처리
+            when(jwtUtil.validateToken(anyString())).thenReturn(mockClaims);
+
 
             // when & then
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);

--- a/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.example.mate.domain.member.service;
 
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
+import com.example.mate.common.jwt.JwtToken;
 import com.example.mate.common.security.util.JwtUtil;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.constant.Rating;
@@ -492,8 +493,14 @@ class MemberServiceTest {
             MemberLoginRequest request = MemberLoginRequest.builder()
                     .email("test@example.com")
                     .build();
+            JwtToken jwtToken = JwtToken.builder()
+                    .grantType("Bearer")
+                    .accessToken("accessToken")
+                    .refreshToken("refreshToken")
+                    .build();
 
             given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
+            given(jwtUtil.createTokens(any(Member.class))).willReturn(jwtToken);
 
             // when
             MemberLoginResponse response = memberService.loginByEmail(request);


### PR DESCRIPTION
## 💡 작업 내용

- [x] JWT 액세스 토큰의 Claim 수정
- [x] 로그아웃 과정에서 액세스 토큰의 남은 시간만큼 블랙리스트에 등록되도록 수정

## 💡 자세한 설명

### JWT Claim 수정

- 토큰의 생성 시점에 따라 액세스 토큰의 값이 달라지도록 수정
    - 로그아웃 시 해당 토큰이 블랙리스트에 올라가기 때문에, 다른 토큰을 발급받아야 함

### CATCH Mi 로그아웃 시 블랙리스트 등록 기간 수정

- 기존의 테스트용으로 1분간 하드 코딩된 블랙 리스트 등록 기간
-> 해당 액세스 토큰의 남은 유효 기간만큼 블랙 리스트에 등록되도록 수정


### TODO

- 리프레시 토큰을 이용한 액세스 토큰 재발급

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?