### PR TITLE
MATE-140 : [REFACTOR] 연도가 바뀌어 오류났던 자체 회원 가입 테스트 코드 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy To EC2
 on:
-  push:
-    branches:
-      - develop
+  push
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy To EC2
 on:
-  push
+  push:
+    branches:
+      - develop
 
 jobs:
   deploy:

--- a/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
@@ -8,9 +8,9 @@ import com.example.mate.domain.constant.Rating;
 import com.example.mate.domain.goodsPost.dto.response.LocationInfo;
 import com.example.mate.domain.goodsPost.entity.Category;
 import com.example.mate.domain.goodsPost.entity.GoodsPost;
-import com.example.mate.domain.goodsReview.entity.GoodsReview;
 import com.example.mate.domain.goodsPost.entity.Status;
 import com.example.mate.domain.goodsPost.repository.GoodsPostRepository;
+import com.example.mate.domain.goodsReview.entity.GoodsReview;
 import com.example.mate.domain.goodsReview.repository.GoodsReviewRepository;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
@@ -297,7 +297,7 @@ class MemberIntegrationTest {
                     .andExpect(jsonPath("$.status").value("SUCCESS"))
                     .andExpect(jsonPath("$.data.name").value("이철수"))
                     .andExpect(jsonPath("$.data.email").value("tester3@example.com"))
-                    .andExpect(jsonPath("$.data.age").value(22))
+                    .andExpect(jsonPath("$.data.age").value(LocalDateTime.now().getYear() - 2002))
                     .andExpect(jsonPath("$.data.nickname").value("tester3"))
                     .andDo(print());
         }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 기존 테스트 코드 중, 나이를 검증했던 테스트 코드가 해가 바뀌어 오류나던 부분 수정

## 💡 자세한 설명

- 나이 검증을 하드 코딩된 값이 아닌, 현재 연도 기준으로 변경

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?