### PR TITLE
MATE-141 : [FEAT] 도커파일에 환경변수 전달

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -8,8 +8,13 @@ files:
     # EC2의 어떤 경로에 저장할 지 지정한다.
     destination: /home/ubuntu/WEB1_2_PitchingMate_BE
 
+
 permissions:
   - object: /
+    owner: ubuntu
+    group: ubuntu
+  - object: /home/ubuntu/WEB1_2_PitchingMate_BE/scripts/start-server.sh
+    mode: 755
     owner: ubuntu
     group: ubuntu
 

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 
-#!/bin/bash
 echo "--------------- 서버 배포 시작 -----------------"
 docker stop catchmi-server || true
 docker rm catchmi-server || true
 docker pull 533267244952.dkr.ecr.ap-northeast-2.amazonaws.com/catchmi-server:latest
-docker run -d --name catchmi-server \
+docker run -d \
+  --name catchmi-server \
+  --restart unless-stopped \
   -p 8080:8080 \
+  -e TZ=Asia/Seoul \
   -e JWT_SECRET_KEY="${JWT_SECRET_KEY}" \
   -e NAVER_CLIENT_ID="${NAVER_CLIENT_ID}" \
   -e NAVER_REDIRECT_URI="${NAVER_REDIRECT_URI}" \
   -e NAVER_CLIENT_SECRET="${NAVER_CLIENT_SECRET}" \
   -e OPENWEATHER_API_KEY="${OPENWEATHER_API_KEY}" \
+  -e S3_BUCKET_NAME="${S3_BUCKET_NAME}" \
+  -e IAM_ACCESS_KEY="${IAM_ACCESS_KEY}" \
+  -e IAM_SECRET_KEY="${IAM_SECRET_KEY}" \
   533267244952.dkr.ecr.ap-northeast-2.amazonaws.com/catchmi-server:latest
 echo "--------------- 서버 배포 끝 -----------------"


### PR DESCRIPTION
## 💡 작업 내용

- [x] start-server.sh 스크립트에 S3 관련 환경 변수들을 추가
- [x] appspec.yml 파일 내 스크립트 실행 권한 추가

## 💡 자세한 설명
1. 현재 배포 후 바로 중지되는 이유가 환경 변수들이 Docker 컨테이너에 전달되지 않아서 발생하는 문제로 예상
2. CodeDeploy가 배포할 때 자동으로 start-server.sh에 실행 권한을 부여 (appspec.yml 파일)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?