### PR TITLE
MATE-136 : [FEAT] 사용자 활동에 따른 매너 타율 업데이트 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -82,6 +82,8 @@ public enum ErrorCode {
     // Mate Review
     NOT_PARTICIPANT_OR_AUTHOR(HttpStatus.FORBIDDEN, "R002", "리뷰어와 리뷰 대상자 모두 직관 참여자여야 합니다."),
     REVIEW_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND, "R005", "해당 ID의 리뷰를 찾을 수 없습니다."),
+    MATE_REVIEW_STATUS_NOT_VISIT_COMPLETE(HttpStatus.BAD_REQUEST, "MR003", "메이트 후기는 직관완료 상태에서만 작성할 수 있습니다."),
+    MATE_REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MR004", "메이트 후기는 한 번만 작성할 수 있습니다."),
 
     // FILE
     FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "F001", "빈 파일을 업로드할 수 없습니다. 파일 내용을 확인해주세요."),

--- a/src/main/java/com/example/mate/domain/goodsPost/service/GoodsPostService.java
+++ b/src/main/java/com/example/mate/domain/goodsPost/service/GoodsPostService.java
@@ -15,6 +15,7 @@ import com.example.mate.domain.goodsPost.entity.GoodsPostImage;
 import com.example.mate.domain.goodsPost.entity.Status;
 import com.example.mate.domain.goodsPost.repository.GoodsPostImageRepository;
 import com.example.mate.domain.goodsPost.repository.GoodsPostRepository;
+import com.example.mate.domain.member.entity.ActivityType;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import java.util.ArrayList;
@@ -47,10 +48,14 @@ public class GoodsPostService {
 
         attachImagesToGoodsPost(savedPost, files);
 
+        seller.updateManner(ActivityType.POST);
+        memberRepository.save(seller);
+
         return GoodsPostResponse.of(savedPost);
     }
 
-    public GoodsPostResponse updateGoodsPost(Long memberId, Long goodsPostId, GoodsPostRequest request, List<MultipartFile> files) {
+    public GoodsPostResponse updateGoodsPost(Long memberId, Long goodsPostId, GoodsPostRequest request,
+                                             List<MultipartFile> files) {
         Member seller = findMemberById(memberId);
         GoodsPost goodsPost = findGoodsPostById(goodsPostId);
 
@@ -74,6 +79,9 @@ public class GoodsPostService {
 
         deleteExistingImageFiles(goodsPostId);
         goodsPostRepository.delete(goodsPost);
+
+        seller.updateManner(ActivityType.DELETE);
+        memberRepository.save(seller);
     }
 
     @Transactional(readOnly = true)
@@ -90,10 +98,12 @@ public class GoodsPostService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<GoodsPostSummaryResponse> getPageGoodsPosts(Long teamId, String categoryVal, Pageable pageable) {
+    public PageResponse<GoodsPostSummaryResponse> getPageGoodsPosts(Long teamId, String categoryVal,
+                                                                    Pageable pageable) {
         validateTeamInfo(teamId);
         Category category = Category.from(categoryVal);
-        Page<GoodsPost> pageGoodsPosts = goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageable);
+        Page<GoodsPost> pageGoodsPosts = goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category,
+                pageable);
         return PageResponse.from(pageGoodsPosts, mapToGoodsPostSummaryResponses(pageGoodsPosts.getContent()));
     }
 

--- a/src/main/java/com/example/mate/domain/goodsPost/service/GoodsPostService.java
+++ b/src/main/java/com/example/mate/domain/goodsPost/service/GoodsPostService.java
@@ -114,6 +114,9 @@ public class GoodsPostService {
 
         validateTransactionEligibility(seller, buyer, goodsPost);
         goodsPost.completeTransaction(buyer);
+
+        seller.updateManner(ActivityType.GOODS);
+        buyer.updateManner(ActivityType.GOODS);
     }
 
     private void attachImagesToGoodsPost(GoodsPost goodsPost, List<MultipartFile> files) {

--- a/src/main/java/com/example/mate/domain/goodsReview/service/GoodsReviewService.java
+++ b/src/main/java/com/example/mate/domain/goodsReview/service/GoodsReviewService.java
@@ -2,12 +2,12 @@ package com.example.mate.domain.goodsReview.service;
 
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
-import com.example.mate.domain.goodsReview.dto.request.GoodsReviewRequest;
-import com.example.mate.domain.goodsReview.dto.response.GoodsReviewResponse;
 import com.example.mate.domain.goodsPost.entity.GoodsPost;
-import com.example.mate.domain.goodsReview.entity.GoodsReview;
 import com.example.mate.domain.goodsPost.entity.Status;
 import com.example.mate.domain.goodsPost.repository.GoodsPostRepository;
+import com.example.mate.domain.goodsReview.dto.request.GoodsReviewRequest;
+import com.example.mate.domain.goodsReview.dto.response.GoodsReviewResponse;
+import com.example.mate.domain.goodsReview.entity.GoodsReview;
 import com.example.mate.domain.goodsReview.repository.GoodsReviewRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
@@ -29,8 +29,13 @@ public class GoodsReviewService {
         GoodsPost goodsPost = findGoodsPostById(goodsPostId);
         validateReviewEligibility(goodsPost, reviewer);
 
-        GoodsReview review = request.toEntity(goodsPost, reviewer, goodsPost.getSeller());
-        return GoodsReviewResponse.of(reviewRepository.save(review));
+        Member seller = goodsPost.getSeller();
+        GoodsReview review = request.toEntity(goodsPost, reviewer, seller);
+        GoodsReview savedReview = reviewRepository.save(review);
+        seller.updateManner(request.getRating());
+        memberRepository.save(seller);
+
+        return GoodsReviewResponse.of(savedReview);
     }
 
     private GoodsPost findGoodsPostById(Long goodsPostId) {

--- a/src/main/java/com/example/mate/domain/mate/entity/Visit.java
+++ b/src/main/java/com/example/mate/domain/mate/entity/Visit.java
@@ -1,12 +1,26 @@
 package com.example.mate.domain.mate.entity;
 
 import com.example.mate.domain.mate.dto.request.MateReviewCreateRequest;
+import com.example.mate.domain.member.entity.ActivityType;
 import com.example.mate.domain.member.entity.Member;
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "visit")
@@ -44,6 +58,7 @@ public class Visit {
                     .visit(visit)
                     .build();
             visit.participants.add(visitPart);
+            member.updateManner(ActivityType.MATE);
         });
 
         return visit;

--- a/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepository.java
+++ b/src/main/java/com/example/mate/domain/mate/repository/MateReviewRepository.java
@@ -1,11 +1,10 @@
 package com.example.mate.domain.mate.repository;
 
 import com.example.mate.domain.mate.entity.MateReview;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface MateReviewRepository extends JpaRepository<MateReview, Long> {
 
@@ -20,4 +19,8 @@ public interface MateReviewRepository extends JpaRepository<MateReview, Long> {
             """)
     List<MateReview> findMateReviewsByVisitIdAndReviewerId(@Param("visitId") Long visitId,
                                                            @Param("reviewerId") Long reviewerId);
+
+    boolean existsByVisitIdAndReviewerIdAndRevieweeId(@Param("visitId") Long visitId,
+                                                      @Param("reviewerId") Long reviewerId,
+                                                      @Param("revieweeId") Long revieweeId);
 }

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -244,6 +244,7 @@ public class MateService {
                 matePost.getMaxParticipants());
 
         matePost.complete(participants);
+        matePost.getAuthor().updateManner(ActivityType.MATE);
         return MatePostCompleteResponse.from(matePost);
     }
 

--- a/src/main/java/com/example/mate/domain/mate/service/MateService.java
+++ b/src/main/java/com/example/mate/domain/mate/service/MateService.java
@@ -39,6 +39,7 @@ import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.mate.repository.MateReviewRepository;
 import com.example.mate.domain.mateChat.repository.MateChatRoomMemberRepository;
 import com.example.mate.domain.mateChat.repository.MateChatRoomRepository;
+import com.example.mate.domain.member.entity.ActivityType;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import java.time.LocalDateTime;
@@ -89,6 +90,9 @@ public class MateService {
         MatePost savedPost = mateRepository.save(matePost);
 
         handleFileUpload(file, matePost);
+
+        author.updateManner(ActivityType.POST);
+        memberRepository.save(author);
 
         return MatePostResponse.from(savedPost);
     }
@@ -216,6 +220,11 @@ public class MateService {
         deleteNonDefaultImage(matePost.getImageUrl());
 
         mateRepository.delete(matePost);
+
+        Member member = memberRepository.findByIdAndNotDeleted(memberId)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND_BY_ID));
+        member.updateManner(ActivityType.DELETE);
+        memberRepository.save(member);
     }
 
     private void validatePostStatus(Status status) {

--- a/src/main/java/com/example/mate/domain/member/entity/ActivityType.java
+++ b/src/main/java/com/example/mate/domain/member/entity/ActivityType.java
@@ -1,0 +1,14 @@
+package com.example.mate.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ActivityType {
+    POST(0.001F),
+    GOODS(0.002F),
+    MATE(0.003F);
+
+    private final Float value;
+}

--- a/src/main/java/com/example/mate/domain/member/entity/ActivityType.java
+++ b/src/main/java/com/example/mate/domain/member/entity/ActivityType.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ActivityType {
     POST(0.001F),
+    DELETE(-0.001F),
     GOODS(0.002F),
     MATE(0.003F);
 

--- a/src/main/java/com/example/mate/domain/member/entity/Member.java
+++ b/src/main/java/com/example/mate/domain/member/entity/Member.java
@@ -111,7 +111,11 @@ public class Member {
     }
 
     public void updateManner(ActivityType activityType) {
-        this.manner = Math.min(1.0F, this.manner + activityType.getValue());
+        if (activityType == ActivityType.DELETE) {
+            this.manner = Math.max(0.0F, this.manner + activityType.getValue());
+        } else {
+            this.manner = Math.min(1.0F, this.manner + activityType.getValue());
+        }
     }
 
     public static Member of(JoinRequest request, String imageUrl) {

--- a/src/main/java/com/example/mate/domain/member/entity/Member.java
+++ b/src/main/java/com/example/mate/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.example.mate.domain.member.entity;
 
 import com.example.mate.domain.constant.Gender;
+import com.example.mate.domain.constant.Rating;
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.member.dto.request.JoinRequest;
 import jakarta.persistence.Column;
@@ -97,6 +98,20 @@ public class Member {
 
     public void changeAboutMe(String aboutMe) {
         this.aboutMe = aboutMe;
+    }
+
+    public void updateManner(Rating rating) {
+        if (rating == Rating.BAD) {
+            this.manner = Math.max(0.0F, this.manner - 0.01F);
+        } else if (rating == Rating.GOOD) {
+            this.manner = Math.min(1.0F, this.manner + 0.02F);
+        } else {
+            this.manner = Math.min(1.0F, this.manner + 0.03F);
+        }
+    }
+
+    public void updateManner(ActivityType activityType) {
+        this.manner = Math.min(1.0F, this.manner + activityType.getValue());
     }
 
     public static Member of(JoinRequest request, String imageUrl) {

--- a/src/test/java/com/example/mate/domain/goodsPost/integration/GoodsPostIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/goodsPost/integration/GoodsPostIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.example.mate.domain.goodsPost.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -52,12 +53,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class GoodsPostIntegrationTest {
 
-    @Autowired private MockMvc mockMvc;
-    @Autowired private MemberRepository memberRepository;
-    @Autowired private GoodsPostRepository goodsPostRepository;
-    @Autowired private GoodsPostImageRepository imageRepository;
-    @Autowired private JdbcTemplate jdbcTemplate;
-    @Autowired private ObjectMapper objectMapper;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private GoodsPostRepository goodsPostRepository;
+    @Autowired
+    private GoodsPostImageRepository imageRepository;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     private Member member;
     private GoodsPost goodsPost;
@@ -106,6 +113,7 @@ public class GoodsPostIntegrationTest {
         // then
         assertApiResponse(apiResponse, goodsPostRequest, files);
         assertActualData(apiResponse.getData().getId(), goodsPostRequest, files);
+        assertThat(member.getManner()).isCloseTo(0.301f, within(0.0001f));
     }
 
     @Test
@@ -127,7 +135,8 @@ public class GoodsPostIntegrationTest {
         );
 
         // when
-        MockMultipartHttpServletRequestBuilder multipartRequest = multipart("/api/goods/{goodsPostId}", goodsPostId).file(data);
+        MockMultipartHttpServletRequestBuilder multipartRequest = multipart("/api/goods/{goodsPostId}",
+                goodsPostId).file(data);
         files.forEach(multipartRequest::file);
         multipartRequest.with(request -> {
             request.setMethod("PUT"); // PUT 메서드로 변경
@@ -204,6 +213,7 @@ public class GoodsPostIntegrationTest {
         // then
         Optional<GoodsPost> goodsPost = goodsPostRepository.findById(goodsPostId);
         assertThat(goodsPost).isEmpty();
+        assertThat(member.getManner()).isCloseTo(0.299f, within(0.0001f));
     }
 
     @Test
@@ -258,7 +268,9 @@ public class GoodsPostIntegrationTest {
                 .getResponse();
         result.setCharacterEncoding("UTF-8");
 
-        ApiResponse<List<GoodsPostSummaryResponse>> apiResponse = objectMapper.readValue(result.getContentAsString(), new TypeReference<>() {});
+        ApiResponse<List<GoodsPostSummaryResponse>> apiResponse = objectMapper.readValue(result.getContentAsString(),
+                new TypeReference<>() {
+                });
 
         // then
         assertThat(apiResponse.getCode()).isEqualTo(200);
@@ -273,7 +285,8 @@ public class GoodsPostIntegrationTest {
         assertThat(response.getTeamName()).isEqualTo(TeamInfo.getById(goodsPost.getTeamId()).shortName);
         assertThat(response.getPrice()).isEqualTo(goodsPost.getPrice());
         assertThat(response.getCategory()).isEqualTo(goodsPost.getCategory().getValue());
-        assertThat(response.getImageUrl()).isEqualTo(FileUtils.getThumbnailImageUrl(goodsPost.getGoodsPostImages().get(0).getImageUrl()));
+        assertThat(response.getImageUrl()).isEqualTo(
+                FileUtils.getThumbnailImageUrl(goodsPost.getGoodsPostImages().get(0).getImageUrl()));
     }
 
     @Test
@@ -319,7 +332,8 @@ public class GoodsPostIntegrationTest {
         result.setCharacterEncoding("UTF-8");
 
         ApiResponse<List<GoodsPostSummaryResponse>> apiResponse = objectMapper.readValue(result.getContentAsString(),
-                new TypeReference<>() {});
+                new TypeReference<>() {
+                });
 
         // then
         assertThat(apiResponse.getCode()).isEqualTo(200);
@@ -361,7 +375,8 @@ public class GoodsPostIntegrationTest {
                 .getResponse();
         result.setCharacterEncoding("UTF-8");
 
-        ApiResponse<Void> apiResponse = objectMapper.readValue(result.getContentAsString(), new TypeReference<>() {});
+        ApiResponse<Void> apiResponse = objectMapper.readValue(result.getContentAsString(), new TypeReference<>() {
+        });
 
         // then
         assertThat(apiResponse.getCode()).isEqualTo(200);

--- a/src/test/java/com/example/mate/domain/goodsPost/integration/GoodsPostIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/goodsPost/integration/GoodsPostIntegrationTest.java
@@ -385,12 +385,14 @@ public class GoodsPostIntegrationTest {
         GoodsPost completedPost = goodsPostRepository.findById(goodsPostId).orElseThrow();
         assertThat(completedPost.getStatus()).isEqualTo(Status.CLOSED);
         assertThat(completedPost.getBuyer()).isNotNull();
+        assertThat(completedPost.getSeller().getManner()).isCloseTo(0.302f, within(0.0001f));
 
         Member resultBuyer = completedPost.getBuyer();
         assertThat(resultBuyer.getId()).isEqualTo(buyer.getId());
         assertThat(resultBuyer.getName()).isEqualTo(buyer.getName());
         assertThat(resultBuyer.getEmail()).isEqualTo(buyer.getEmail());
         assertThat(resultBuyer.getNickname()).isEqualTo(buyer.getNickname());
+        assertThat(resultBuyer.getManner()).isCloseTo(0.502f, within(0.0001f));
     }
 
     private Member createMember() {

--- a/src/test/java/com/example/mate/domain/goodsPost/service/GoodsPostServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goodsPost/service/GoodsPostServiceTest.java
@@ -580,6 +580,8 @@ class GoodsPostServiceTest {
             // then
             assertThat(goodsPost.getStatus()).isEqualTo(Status.CLOSED);
             assertThat(goodsPost.getBuyer()).isEqualTo(buyer);
+            assertThat(member.getManner()).isCloseTo(0.302f, within(0.0001f));
+            assertThat(buyer.getManner()).isCloseTo(0.302f, within(0.0001f));
 
             verify(memberRepository).findById(sellerId);
             verify(goodsPostRepository).findById(goodsPostId);

--- a/src/test/java/com/example/mate/domain/goodsPost/service/GoodsPostServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goodsPost/service/GoodsPostServiceTest.java
@@ -2,6 +2,7 @@ package com.example.mate.domain.goodsPost.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -126,13 +127,15 @@ class GoodsPostServiceTest {
         @DisplayName("굿즈거래 판매글 작성 성공")
         void register_goods_post_success() {
             // given
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content", createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content",
+                    createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
 
             GoodsPost post = GoodsPostRequest.toEntity(member, request);
 
             given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
             given(goodsPostRepository.save(any(GoodsPost.class))).willReturn(post);
+            given(memberRepository.save(any(Member.class))).willReturn(member);
 
             // when
             GoodsPostResponse response = goodsPostService.registerGoodsPost(member.getId(), request, files);
@@ -140,9 +143,11 @@ class GoodsPostServiceTest {
             // then
             assertThat(response).isNotNull();
             assertThat(response.getStatus()).isEqualTo(Status.OPEN.getValue());
+            assertThat(member.getManner()).isCloseTo(0.301f, within(0.0001f));
 
             verify(memberRepository).findById(member.getId());
             verify(goodsPostRepository).save(any(GoodsPost.class));
+            verify(memberRepository).save(any(Member.class));
         }
 
         @Test
@@ -150,7 +155,8 @@ class GoodsPostServiceTest {
         void register_goods_post_failed_with_invalid_member() {
             // given
             Long invalidMemberId = 100L;
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content", createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content",
+                    createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
             given(memberRepository.findById(invalidMemberId)).willReturn(Optional.empty());
 
@@ -168,7 +174,8 @@ class GoodsPostServiceTest {
         @DisplayName("굿즈거래 판매글 작성 실패 - 형식이 잘못된 파일")
         void register_goods_post_failed_with_invalid_file() {
             // given
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content", createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content",
+                    createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.APPLICATION_PDF_VALUE));
             given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
 
@@ -192,7 +199,8 @@ class GoodsPostServiceTest {
         void update_goods_post_success() {
             // given
             Long goodsPostId = 1L;
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....", createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....",
+                    createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
 
             given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
@@ -219,7 +227,8 @@ class GoodsPostServiceTest {
         void update_goods_post_failed_with_invalid_member() {
             // given
             Long goodsPostId = 1L;
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....", createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....",
+                    createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
             Member notSeller = Member.builder().id(11L).name("홍길동").build();
 
@@ -243,7 +252,8 @@ class GoodsPostServiceTest {
         void update_goods_post_failed_with_invalid_post() {
             // given
             Long goodsPostId = 1L;
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....", createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....",
+                    createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
 
             given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
@@ -276,16 +286,20 @@ class GoodsPostServiceTest {
             given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
             given(goodsPostRepository.findById(goodsPostId)).willReturn(Optional.of(goodsPost));
             given(imageRepository.getImageUrlsByPostId(goodsPostId)).willReturn(List.of());
+            given(memberRepository.save(any(Member.class))).willReturn(member);
 
             // when
             goodsPostService.deleteGoodsPost(memberId, goodsPostId);
 
             // then
+            assertThat(member.getManner()).isCloseTo(0.299f, within(0.0001f));
+
             verify(memberRepository).findById(memberId);
             verify(goodsPostRepository).findById(goodsPostId);
             verify(imageRepository).getImageUrlsByPostId(goodsPostId);
             verify(imageRepository).deleteAllByPostId(goodsPostId);
             verify(goodsPostRepository).delete(goodsPost);
+            verify(memberRepository).save(any(Member.class));
         }
 
         @Test
@@ -419,7 +433,8 @@ class GoodsPostServiceTest {
             GoodsPostSummaryResponse goodsPostSummaryResponse = responses.get(0);
             assertThat(goodsPostSummaryResponse.getTitle()).isEqualTo(goodsPost.getTitle());
             assertThat(goodsPostSummaryResponse.getPrice()).isEqualTo(goodsPost.getPrice());
-            assertThat(goodsPostSummaryResponse.getImageUrl()).isEqualTo(FileUtils.getThumbnailImageUrl(goodsPostImage.getImageUrl()));
+            assertThat(goodsPostSummaryResponse.getImageUrl()).isEqualTo(
+                    FileUtils.getThumbnailImageUrl(goodsPostImage.getImageUrl()));
 
             verify(goodsPostRepository).findMainGoodsPosts(1L, Status.OPEN, PageRequest.of(0, 4));
         }
@@ -469,10 +484,12 @@ class GoodsPostServiceTest {
             PageImpl<GoodsPost> goodsPostPage = new PageImpl<>(List.of(postWithoutFilters));
             PageRequest pageRequest = PageRequest.of(0, 10);
 
-            given(goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest)).willReturn(goodsPostPage);
+            given(goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest)).willReturn(
+                    goodsPostPage);
 
             // when
-            PageResponse<GoodsPostSummaryResponse> pageGoodsPosts = goodsPostService.getPageGoodsPosts(teamId, null, pageRequest);
+            PageResponse<GoodsPostSummaryResponse> pageGoodsPosts = goodsPostService.getPageGoodsPosts(teamId, null,
+                    pageRequest);
 
             // then
             assertThat(pageGoodsPosts).isNotNull();
@@ -504,7 +521,8 @@ class GoodsPostServiceTest {
             PageImpl<GoodsPost> goodsPostPage = new PageImpl<>(List.of(postWithFilters));
             PageRequest pageRequest = PageRequest.of(0, 10);
 
-            given(goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest)).willReturn(goodsPostPage);
+            given(goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest)).willReturn(
+                    goodsPostPage);
 
             // when
             PageResponse<GoodsPostSummaryResponse> pageGoodsPosts

--- a/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/mate/integration/MateIntegrationTest.java
@@ -1,6 +1,18 @@
 package com.example.mate.domain.mate.integration;
 
-import com.example.mate.common.security.util.JwtUtil;
+import static com.example.mate.common.error.ErrorCode.MATCH_NOT_FOUND_BY_ID;
+import static com.example.mate.common.error.ErrorCode.MATE_POST_NOT_FOUND_BY_ID;
+import static com.example.mate.common.error.ErrorCode.TEAM_NOT_FOUND;
+import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.example.mate.config.WithAuthMember;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.file.FileUtils;
@@ -16,6 +28,8 @@ import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -23,24 +37,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static com.example.mate.common.error.ErrorCode.*;
-import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
@@ -201,6 +203,7 @@ public class MateIntegrationTest {
             assertThat(savedPost.getAge()).isEqualTo(request.getAge());
             assertThat(savedPost.getGender()).isEqualTo(request.getGender());
             assertThat(savedPost.getTransport()).isEqualTo(request.getTransportType());
+            assertThat(savedPost.getAuthor().getManner()).isCloseTo(0.301f, within(0.0001f));
         }
 
         @Test
@@ -574,6 +577,7 @@ public class MateIntegrationTest {
 
             // DB 검증
             assertThat(mateRepository.findById(openPost.getId())).isEmpty();
+            assertThat(openPost.getAuthor().getManner()).isCloseTo(0.299f, within(0.0001f));
         }
 
         @Test

--- a/src/test/java/com/example/mate/domain/mate/integration/MateStatusIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/mate/integration/MateStatusIntegrationTest.java
@@ -10,6 +10,7 @@ import static com.example.mate.common.error.ErrorCode.MATE_POST_UPDATE_NOT_ALLOW
 import static com.example.mate.common.error.ErrorCode.NOT_CLOSED_STATUS_FOR_COMPLETION;
 import static com.example.mate.domain.match.entity.MatchStatus.SCHEDULED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -17,7 +18,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.example.mate.common.security.util.JwtUtil;
 import com.example.mate.config.WithAuthMember;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.match.entity.Match;
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
@@ -339,6 +338,8 @@ public class MateStatusIntegrationTest {
             assertThat(savedPost.getStatus()).isEqualTo(Status.VISIT_COMPLETE);
             assertThat(savedPost.getVisit()).isNotNull();
             assertThat(savedPost.getVisit().getParticipants()).hasSize(2);
+            assertThat(participant1.getManner()).isCloseTo(0.303f, within(0.0001f));
+            assertThat(participant2.getManner()).isCloseTo(0.303f, within(0.0001f));
         }
 
         @Test
@@ -352,7 +353,7 @@ public class MateStatusIntegrationTest {
 
             // when & then
             mockMvc.perform(patch("/api/mates/{postId}/complete"
-                            ,closedPost.getId())
+                            , closedPost.getId())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsBytes(request)))
                     .andExpect(status().isForbidden())

--- a/src/test/java/com/example/mate/domain/mate/service/MateReviewServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateReviewServiceTest.java
@@ -1,16 +1,34 @@
 package com.example.mate.domain.mate.service;
 
+import static com.example.mate.common.error.ErrorCode.MATE_POST_NOT_FOUND_BY_ID;
+import static com.example.mate.common.error.ErrorCode.MEMBER_NOT_FOUND_BY_ID;
+import static com.example.mate.common.error.ErrorCode.NOT_PARTICIPANT_OR_AUTHOR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import com.example.mate.common.error.CustomException;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.constant.Rating;
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.mate.dto.request.MateReviewCreateRequest;
 import com.example.mate.domain.mate.dto.response.MateReviewCreateResponse;
-import com.example.mate.domain.mate.entity.*;
+import com.example.mate.domain.mate.entity.Age;
+import com.example.mate.domain.mate.entity.MatePost;
+import com.example.mate.domain.mate.entity.MateReview;
+import com.example.mate.domain.mate.entity.Status;
+import com.example.mate.domain.mate.entity.TransportType;
+import com.example.mate.domain.mate.entity.Visit;
 import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.mate.repository.MateReviewRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,17 +36,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-import java.util.Optional;
-
-import static com.example.mate.common.error.ErrorCode.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class MateReviewServiceTest {
@@ -132,6 +139,8 @@ class MateReviewServiceTest {
                     .willReturn(Optional.of(reviewee));
             given(mateReviewRepository.save(any(MateReview.class)))
                     .willReturn(mateReview);
+            given(memberRepository.save(any(Member.class)))
+                    .willReturn(reviewee);
 
             // when
             MateReviewCreateResponse response = mateService.createReview(
@@ -144,10 +153,12 @@ class MateReviewServiceTest {
             assertThat(response.getReviewerId()).isEqualTo(TEST_REVIEWER_ID);
             assertThat(response.getRevieweeId()).isEqualTo(TEST_REVIEWEE_ID);
             assertThat(response.getRating()).isEqualTo(Rating.GOOD.getValue());
+            assertThat(reviewee.getManner()).isCloseTo(0.32f, within(0.0001f));
             verify(mateRepository).findById(TEST_POST_ID);
             verify(memberRepository).findById(TEST_REVIEWER_ID);
             verify(memberRepository).findById(TEST_REVIEWEE_ID);
             verify(mateReviewRepository).save(any(MateReview.class));
+            verify(memberRepository).save(any(Member.class));
         }
 
         @Test

--- a/src/test/java/com/example/mate/domain/mate/service/MateReviewServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateReviewServiceTest.java
@@ -153,7 +153,7 @@ class MateReviewServiceTest {
             assertThat(response.getReviewerId()).isEqualTo(TEST_REVIEWER_ID);
             assertThat(response.getRevieweeId()).isEqualTo(TEST_REVIEWEE_ID);
             assertThat(response.getRating()).isEqualTo(Rating.GOOD.getValue());
-            assertThat(reviewee.getManner()).isCloseTo(0.32f, within(0.0001f));
+            assertThat(reviewee.getManner()).isCloseTo(0.326f, within(0.0001f));
             verify(mateRepository).findById(TEST_POST_ID);
             verify(memberRepository).findById(TEST_REVIEWER_ID);
             verify(memberRepository).findById(TEST_REVIEWEE_ID);

--- a/src/test/java/com/example/mate/domain/mate/service/MateServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateServiceTest.java
@@ -8,6 +8,7 @@ import static com.example.mate.common.error.ErrorCode.MEMBER_NOT_FOUND_BY_ID;
 import static com.example.mate.common.error.ErrorCode.TEAM_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -143,15 +144,18 @@ class MateServiceTest {
                     .willReturn(Optional.of(testMatch));
             given(mateRepository.save(any(MatePost.class)))
                     .willReturn(matePost);
+            given(memberRepository.save(any(Member.class))).willReturn(testMember);
 
             // when
             MatePostResponse response = mateService.createMatePost(request, null, TEST_MEMBER_ID);
 
             // then
             assertThat(response.getStatus()).isEqualTo(Status.OPEN);
+            assertThat(testMember.getManner()).isCloseTo(0.301f, within(0.0001f));
             verify(memberRepository).findById(TEST_MEMBER_ID);
             verify(matchRepository).findById(TEST_MATCH_ID);
             verify(mateRepository).save(any(MatePost.class));
+            verify(memberRepository).save(any(Member.class));
         }
 
         @Test
@@ -909,13 +913,20 @@ class MateServiceTest {
 
             given(mateRepository.findById(POST_ID))
                     .willReturn(Optional.of(matePost));
+            given(memberRepository.findByIdAndNotDeleted(TEST_MEMBER_ID))
+                    .willReturn(Optional.of(testMember));
+            given(memberRepository.save(any(Member.class)))
+                    .willReturn(testMember);
 
             // when
             mateService.deleteMatePost(TEST_MEMBER_ID, POST_ID);
 
             // then
+            assertThat(testMember.getManner()).isCloseTo(0.299f, within(0.0001f));
+
             verify(mateRepository).findById(POST_ID);
             verify(mateRepository).delete(matePost);
+            verify(memberRepository).save(any(Member.class));
         }
 
         @Test
@@ -944,6 +955,10 @@ class MateServiceTest {
 
             given(mateRepository.findById(POST_ID))
                     .willReturn(Optional.of(matePost));
+            given(memberRepository.findByIdAndNotDeleted(TEST_MEMBER_ID))
+                    .willReturn(Optional.of(testMember));
+            given(memberRepository.save(any(Member.class)))
+                    .willReturn(testMember);
 
             // when
             mateService.deleteMatePost(TEST_MEMBER_ID, POST_ID);
@@ -951,7 +966,10 @@ class MateServiceTest {
             // then
             verify(mateRepository).findById(POST_ID);
             verify(mateRepository).delete(matePost);
+            verify(memberRepository).save(any(Member.class));
+
             assertThat(visit.getPost()).isNull();
+            assertThat(testMember.getManner()).isCloseTo(0.299f, within(0.0001f));
         }
 
         @Test

--- a/src/test/java/com/example/mate/domain/mate/service/MateStatusServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mate/service/MateStatusServiceTest.java
@@ -1,5 +1,21 @@
 package com.example.mate.domain.mate.service;
 
+import static com.example.mate.common.error.ErrorCode.ALREADY_COMPLETED_POST;
+import static com.example.mate.common.error.ErrorCode.DIRECT_VISIT_COMPLETE_FORBIDDEN;
+import static com.example.mate.common.error.ErrorCode.INVALID_MATE_POST_PARTICIPANT_IDS;
+import static com.example.mate.common.error.ErrorCode.MATE_POST_COMPLETE_TIME_NOT_ALLOWED;
+import static com.example.mate.common.error.ErrorCode.MATE_POST_MAX_PARTICIPANTS_EXCEEDED;
+import static com.example.mate.common.error.ErrorCode.MATE_POST_NOT_FOUND_BY_ID;
+import static com.example.mate.common.error.ErrorCode.MATE_POST_UPDATE_NOT_ALLOWED;
+import static com.example.mate.common.error.ErrorCode.NOT_CLOSED_STATUS_FOR_COMPLETION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import com.example.mate.common.error.CustomException;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.match.entity.Match;
@@ -14,6 +30,11 @@ import com.example.mate.domain.mate.entity.TransportType;
 import com.example.mate.domain.mate.repository.MateRepository;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,20 +42,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static com.example.mate.common.error.ErrorCode.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class MateStatusServiceTest {
@@ -378,6 +385,9 @@ class MateStatusServiceTest {
             assertThat(response.getId()).isEqualTo(POST_ID);
             assertThat(response.getStatus()).isEqualTo(Status.VISIT_COMPLETE);
             assertThat(response.getParticipantIds()).containsExactlyInAnyOrderElementsOf(participantIds);
+            for (Member member : participants) {
+                assertThat(member.getManner()).isCloseTo(0.303f, within(0.0001f));
+            }
 
             verify(mateRepository).findById(POST_ID);
             verify(memberRepository).findAllById(participantIds);


### PR DESCRIPTION
## 💡 작업 내용

- [x] 사용자에게 메이트 후기가 남겨졌을 때 매너 타율 업데이트
- [x] 사용자에게 거래 후기가 남겨졌을 때 매너 타율 업데이트
- [x] 사용자의 활동 유형에 따른 매너 타율 업데이트
- [x] 테스트 코드 추가

## 💡 자세한 설명

### 매너 타율 도메인 규칙

![스크린샷 2025-01-07 오후 4 52 57](https://github.com/user-attachments/assets/ffe70694-1d30-421d-85b7-0b3c92aacbea)

### 리뷰의 선호도 / 활동 유형에 따른 매너 타율 업데이트

![스크린샷 2025-01-07 오후 4 54 56](https://github.com/user-attachments/assets/c7598eac-0e69-4190-9292-fd791e0c9419)

![스크린샷 2025-01-07 오후 5 04 58](https://github.com/user-attachments/assets/df362ded-ec9a-4f44-b027-357ee8411dbf)

#### 리뷰 선호도

- 리뷰의 Rating에 따라 reviewee의 매너 타율이 변경됩니다.
    - BAD : -0.01
    - GOOD : +0.02
    - GREAT : +0.03

#### 활동 유형

- 사용자의 서비스 활동에 따라 매너 타율이 변경됩니다.
    - 메이트 구인글 / 굿즈 거래글 작성 : +0.001
    - 메이트 구인글 / 굿즈 거래글 삭제 : -0.001
    - 굿즈 거래글 참여(구매자, 판매자 모두) : +0.002
    - 직관 참여(참여자 모두) : +0.003

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?