### PR TITLE
MATE-144 : [FIX] 배너 경기 데이터 조회 수정

### DIFF
--- a/http/Match.http
+++ b/http/Match.http
@@ -3,25 +3,26 @@
 
 ### 전체 경기 조회 ###
 ### 메인 배너용 경기 조회(5개) (상단 배너)
-GET http://localhost:8000/api/matches/main
+GET http://localhost:8080/api/matches/main
 Content-Type: application/json
 
 ### 팀별 경기 조회 (3개) (상단 배너)
-GET http://localhost:8000/api/matches/team/1
+GET http://localhost:8080/api/matches/team/1
 Content-Type: application/json
 
 ### 팀별 완료된 경기 전적 조회
 ### KIA 팀 완료된 경기 전적 조회
-GET http://localhost:8000/api/matches/team/1/completed
+GET http://localhost:8080/api/matches/team/1/completed
 Content-Type: application/json
 
 ### 팀별 주차별 경기 일정 조회 (KIA) - 날짜 지정
-GET http://localhost:8000/api/matches/team/1/weekly?startDate=2024-11-15
-Accept: application/json
+GET http://localhost:8080/api/matches/team/1/weekly?startDate=2024-11-15
+Content-Type: application/json
 
 ### 팀별 주차별 경기 일정 조회 (KIA) - 오늘 날짜 기준
-GET http://localhost:8000/api/matches/team/1/weekly
-Accept: application/json
+GET http://localhost:8080/api/matches/team/2/weekly
+Content-Type: application/json
+Authorization: Bearer
 
 ### [Team API] ###
 #################

--- a/src/main/java/com/example/mate/domain/crawler/service/CrawlingService.java
+++ b/src/main/java/com/example/mate/domain/crawler/service/CrawlingService.java
@@ -685,7 +685,7 @@ public class CrawlingService {
                             teamName, rank, gamesPlayed, wins, losses, draws, gamesBehind);
 
                     TeamRecord record = TeamRecord.builder()
-                            .teamId(team.id)  // teamId로 변경
+                            .teamId(team.id)
                             .rank(rank)
                             .gamesPlayed(gamesPlayed)
                             .totalGames(144)  // KBO 정규시즌 경기 수

--- a/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
@@ -13,9 +13,16 @@ import java.util.Optional;
 
 @Repository
 public interface MatchRepository extends JpaRepository<Match, Long> {
-    List<Match> findTop5ByOrderByMatchTimeDesc();
+    @Query(value = "SELECT * FROM \"match\" m " +
+            "WHERE m.match_time > :now " +
+            "ORDER BY m.match_time ASC LIMIT 5", nativeQuery = true)
+    List<Match> findMainBannerMatches(@Param("now") LocalDateTime now);
 
-    List<Match> findTop3ByHomeTeamIdOrAwayTeamIdOrderByMatchTimeDesc(Long homeTeamId, Long awayTeamId);
+    @Query(value = "SELECT * FROM \"match\" m " +
+            "WHERE (m.home_team_id = :teamId OR m.away_team_id = :teamId) " +
+            "AND m.match_time > :now " +
+            "ORDER BY m.match_time ASC LIMIT 3", nativeQuery = true)
+    List<Match> findTop3TeamMatchesAfterNow(@Param("teamId") Long teamId, @Param("now") LocalDateTime now);
 
     @Query("SELECT m FROM Match m " +
             "WHERE (m.status = :status1 AND m.homeTeamId = :homeTeamId) " +

--- a/src/main/java/com/example/mate/domain/match/service/MatchService.java
+++ b/src/main/java/com/example/mate/domain/match/service/MatchService.java
@@ -27,8 +27,8 @@ public class MatchService {
     private static final int WEEKS_TO_FETCH = 4;
 
     public List<MatchResponse> getMainBannerMatches() {
-        return matchRepository.findTop5ByOrderByMatchTimeDesc().stream()
-                .filter(match -> match.getMatchTime().isAfter(LocalDateTime.now()))
+        return matchRepository.findMainBannerMatches(LocalDateTime.now())
+                .stream()
                 .map(match -> MatchResponse.from(match, null))
                 .collect(Collectors.toList());
     }
@@ -36,9 +36,8 @@ public class MatchService {
 
     public List<MatchResponse> getTeamMatches(Long teamId) {
         TeamInfo.getById(teamId);
-
-        return matchRepository.findTop3ByHomeTeamIdOrAwayTeamIdOrderByMatchTimeDesc(teamId, teamId).stream()
-                .filter(match -> match.getMatchTime().isAfter(LocalDateTime.now()))
+        return matchRepository.findTop3TeamMatchesAfterNow(teamId, LocalDateTime.now())
+                .stream()
                 .map(match -> MatchResponse.from(match, teamId))
                 .collect(Collectors.toList());
     }

--- a/src/test/java/com/example/mate/domain/match/integration/MatchIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/match/integration/MatchIntegrationTest.java
@@ -91,16 +91,19 @@ class MatchIntegrationTest {
         matchRepository.saveAll(Arrays.asList(pastMatch, futureMatch1, futureMatch2));
 
         // when
-        ResultActions result = mockMvc.perform(get("/api/matches/main")
-                .accept(MediaType.APPLICATION_JSON));
+        MvcResult mvcResult = mockMvc.perform(get("/api/matches/main")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andReturn();
 
         // then
-        result.andExpect(status().isOk())
+        mockMvc.perform(get("/api/matches/main")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].homeTeam.id").value(TeamInfo.SSG.id))
-                .andExpect(jsonPath("$.data[1].homeTeam.id").value(TeamInfo.LG.id));
+                .andExpect(jsonPath("$.data[0].homeTeam.id").value(TeamInfo.LG.id))
+                .andExpect(jsonPath("$.data[1].homeTeam.id").value(TeamInfo.SSG.id));
     }
 
     @Test
@@ -126,8 +129,8 @@ class MatchIntegrationTest {
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].awayTeam.id").value(TeamInfo.NC.id))
-                .andExpect(jsonPath("$.data[1].awayTeam.id").value(TeamInfo.KT.id));
+                .andExpect(jsonPath("$.data[0].awayTeam.id").value(TeamInfo.KT.id))
+                .andExpect(jsonPath("$.data[1].awayTeam.id").value(TeamInfo.NC.id));
     }
 
     @Test

--- a/src/test/java/com/example/mate/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/com/example/mate/domain/match/service/MatchServiceTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,15 +43,16 @@ class MatchServiceTest {
     @DisplayName("메인 배너에 노출할 상위 5개 경기를 조회")
     void getMainBannerMatches_ShouldReturnTop5Matches() {
         // Given
+        LocalDateTime now = LocalDateTime.now();
         List<Match> matches = createTestMatches();
-        when(matchRepository.findTop5ByOrderByMatchTimeDesc()).thenReturn(matches);
+        when(matchRepository.findMainBannerMatches(any(LocalDateTime.class))).thenReturn(matches);
 
         // When
         List<MatchResponse> result = matchService.getMainBannerMatches();
 
         // Then
         assertThat(result).hasSize(5);
-        verify(matchRepository).findTop5ByOrderByMatchTimeDesc();
+        verify(matchRepository).findMainBannerMatches(any(LocalDateTime.class));
     }
 
     @Test
@@ -59,7 +61,7 @@ class MatchServiceTest {
         // Given
         Long teamId = 1L;
         List<Match> matches = createTestMatches().subList(0, 3);
-        when(matchRepository.findTop3ByHomeTeamIdOrAwayTeamIdOrderByMatchTimeDesc(teamId, teamId))
+        when(matchRepository.findTop3TeamMatchesAfterNow(eq(teamId), any(LocalDateTime.class)))
                 .thenReturn(matches);
 
         // When
@@ -67,7 +69,7 @@ class MatchServiceTest {
 
         // Then
         assertThat(result).hasSize(3);
-        verify(matchRepository).findTop3ByHomeTeamIdOrAwayTeamIdOrderByMatchTimeDesc(teamId, teamId);
+        verify(matchRepository).findTop3TeamMatchesAfterNow(eq(teamId), any(LocalDateTime.class));
     }
 
     @Test


### PR DESCRIPTION
## 💡 작업 내용

- [x] 현재 배너 경기 조회에서 Desc 방식으로 조회하여 가장 나중의 경기가 조회가 되어 이를 해결 
-> 현재 시간과 가까운 경기부터 보여주는 것으로 변경

## 💡 자세한 설명
1. Java 스트림에서 하던 필터링을 DB 쿼리로 이동
2. JPQL에서 LIMIT 사용 시도 -> JPQL에서 Limit 사용이 되지 않아 Native Query 사용

## 📗 참고 자료 (선택)
JPQL에서의 Limit 문법 관련
https://velog.io/@dev_tmb/jpql-limit-%EB%AC%B8%EB%B2%95-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?