### PR TITLE
MATE-146 : [FIX] 배너 경기 데이터 조회 SQL 수정

### DIFF
--- a/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 @Repository
 public interface MatchRepository extends JpaRepository<Match, Long> {
     @Query("SELECT m FROM Match m WHERE m.matchTime > :now ORDER BY m.matchTime ASC")
-    List<Match> findMainBannerMatches(@Param("now") LocalDateTime now, Pageable pageable);  // Page<Match>가 아닌 List<Match>
+    List<Match> findMainBannerMatches(@Param("now") LocalDateTime now, Pageable pageable);
 
     @Query("SELECT m FROM Match m " +
             "WHERE (m.homeTeamId = :teamId OR m.awayTeamId = :teamId) " +

--- a/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/example/mate/domain/match/repository/MatchRepository.java
@@ -2,6 +2,7 @@ package com.example.mate.domain.match.repository;
 
 import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.entity.MatchStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,16 +14,18 @@ import java.util.Optional;
 
 @Repository
 public interface MatchRepository extends JpaRepository<Match, Long> {
-    @Query(value = "SELECT * FROM \"match\" m " +
-            "WHERE m.match_time > :now " +
-            "ORDER BY m.match_time ASC LIMIT 5", nativeQuery = true)
-    List<Match> findMainBannerMatches(@Param("now") LocalDateTime now);
+    @Query("SELECT m FROM Match m WHERE m.matchTime > :now ORDER BY m.matchTime ASC")
+    List<Match> findMainBannerMatches(@Param("now") LocalDateTime now, Pageable pageable);  // Page<Match>가 아닌 List<Match>
 
-    @Query(value = "SELECT * FROM \"match\" m " +
-            "WHERE (m.home_team_id = :teamId OR m.away_team_id = :teamId) " +
-            "AND m.match_time > :now " +
-            "ORDER BY m.match_time ASC LIMIT 3", nativeQuery = true)
-    List<Match> findTop3TeamMatchesAfterNow(@Param("teamId") Long teamId, @Param("now") LocalDateTime now);
+    @Query("SELECT m FROM Match m " +
+            "WHERE (m.homeTeamId = :teamId OR m.awayTeamId = :teamId) " +
+            "AND m.matchTime > :now " +
+            "ORDER BY m.matchTime ASC")
+    List<Match> findTop3TeamMatchesAfterNow(
+            @Param("teamId") Long teamId,
+            @Param("now") LocalDateTime now,
+            Pageable pageable
+    );
 
     @Query("SELECT m FROM Match m " +
             "WHERE (m.status = :status1 AND m.homeTeamId = :homeTeamId) " +

--- a/src/main/java/com/example/mate/domain/match/service/MatchService.java
+++ b/src/main/java/com/example/mate/domain/match/service/MatchService.java
@@ -8,6 +8,7 @@ import com.example.mate.domain.match.entity.Match;
 import com.example.mate.domain.match.repository.MatchRepository;
 import com.example.mate.domain.match.util.WeekCalculator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
@@ -27,16 +28,15 @@ public class MatchService {
     private static final int WEEKS_TO_FETCH = 4;
 
     public List<MatchResponse> getMainBannerMatches() {
-        return matchRepository.findMainBannerMatches(LocalDateTime.now())
+        return matchRepository.findMainBannerMatches(LocalDateTime.now(), PageRequest.of(0, 5))
                 .stream()
                 .map(match -> MatchResponse.from(match, null))
                 .collect(Collectors.toList());
     }
 
-
     public List<MatchResponse> getTeamMatches(Long teamId) {
         TeamInfo.getById(teamId);
-        return matchRepository.findTop3TeamMatchesAfterNow(teamId, LocalDateTime.now())
+        return matchRepository.findTop3TeamMatchesAfterNow(teamId, LocalDateTime.now(), PageRequest.of(0, 3))
                 .stream()
                 .map(match -> MatchResponse.from(match, teamId))
                 .collect(Collectors.toList());

--- a/src/test/java/com/example/mate/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/com/example/mate/domain/match/service/MatchServiceTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -45,14 +47,18 @@ class MatchServiceTest {
         // Given
         LocalDateTime now = LocalDateTime.now();
         List<Match> matches = createTestMatches();
-        when(matchRepository.findMainBannerMatches(any(LocalDateTime.class))).thenReturn(matches);
+        when(matchRepository.findMainBannerMatches(any(LocalDateTime.class), any(Pageable.class)))
+                .thenReturn(matches);
 
         // When
         List<MatchResponse> result = matchService.getMainBannerMatches();
 
         // Then
         assertThat(result).hasSize(5);
-        verify(matchRepository).findMainBannerMatches(any(LocalDateTime.class));
+        verify(matchRepository).findMainBannerMatches(
+                any(LocalDateTime.class),
+                eq(PageRequest.of(0, 5))
+        );
     }
 
     @Test
@@ -61,15 +67,22 @@ class MatchServiceTest {
         // Given
         Long teamId = 1L;
         List<Match> matches = createTestMatches().subList(0, 3);
-        when(matchRepository.findTop3TeamMatchesAfterNow(eq(teamId), any(LocalDateTime.class)))
-                .thenReturn(matches);
+        when(matchRepository.findTop3TeamMatchesAfterNow(
+                eq(teamId),
+                any(LocalDateTime.class),
+                any(Pageable.class)
+        )).thenReturn(matches);
 
         // When
         List<MatchResponse> result = matchService.getTeamMatches(teamId);
 
         // Then
         assertThat(result).hasSize(3);
-        verify(matchRepository).findTop3TeamMatchesAfterNow(eq(teamId), any(LocalDateTime.class));
+        verify(matchRepository).findTop3TeamMatchesAfterNow(
+                eq(teamId),
+                any(LocalDateTime.class),
+                eq(PageRequest.of(0, 3))
+        );
     }
 
     @Test


### PR DESCRIPTION
## 💡 작업 내용

- [x] Native Query 대신 JPQL Pageable 사용

## 💡 자세한 설명
변경 전 코드 작성 이유
> 이전 코드에서의 진행 중 테스트코드 실행 중 아래와 같은 문제상황 발생:
> - Native Query 사용 시 H2 데이터베이스에서 테이블명 'match'를 'MATCH'로 인식하여 테이블을 찾지 못하는 문제 발생
> - "Table "MATCH" not found (candidates are: "match")" 에러 발생
> 
> 해결방법:
> - 테이블명을 쌍따옴표로 감싸서 사용 ("match")
> 
> 발생했던 이유:
> - Native Query는 JPA의 변환 과정 없이 SQL을 직접 데이터베이스에 실행
> - 다른 쿼리 방식(JPQL, 메서드명 쿼리)은 JPA가 알아서 적절히 변환
> - H2 데이터베이스는 기본적으로 대문자로 테이블명을 인식하므로, 쌍따옴표로 감싸서 정확한 테이블명 지정 필요

현재 EC2에서의 MySQL 문제 발생:
> Native Query 사용 시 MySQL 예약어인 'match' 테이블명으로 인한 SQL 구문 오류 발생
> "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '"match"'" 에러 발생
> 
> 원인:
> Native Query는 데이터베이스에 직접 실행되는 SQL 쿼리
> MySQL에서는 예약어를 테이블명으로 사용할 때 백틱(`)으로 감싸야 함
> H2와 MySQL의 식별자(테이블명) 처리 방식 차이
> 
> H2: 쌍따옴표(") 사용
> MySQL: 백틱(`) 사용

변경 후 코드

> 해결 방법:
> JPQL로 변경
```
@Query("SELECT m FROM Match m WHERE m.matchTime > :now ORDER BY m.matchTime ASC")
List<Match> findMainBannerMatches(@Param("now") LocalDateTime now, Pageable pageable);
```
> 
> 페이징 처리를 위한 Pageable 도입
```
// Repository
List<Match> findMainBannerMatches(LocalDateTime now, Pageable pageable);
```
> 

```
// Service
matchRepository.findMainBannerMatches(LocalDateTime.now(), PageRequest.of(0, 5))
```

> 
> JPQL을 사용하여 데이터베이스 독립적인 쿼리 작성 가능 (H2, MySQL 모두 동작)
> 

정리 :
> Native Query 사용 시 데이터베이스별 문법 차이 고려 필요
> 가능하면 JPQL을 사용하여 데이터베이스 독립적인 쿼리 작성
> 예약어를 테이블명으로 사용할 때는 각별한 주의 필요


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?