### PR TITLE
MATE-145 : [FEAT] MongoDB 의존성 추가 및 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // MongoDB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
     // Logging
     implementation 'org.slf4j:slf4j-api'
     implementation 'ch.qos.logback:logback-classic'

--- a/src/main/java/com/example/mate/common/config/MongoConfig.java
+++ b/src/main/java/com/example/mate/common/config/MongoConfig.java
@@ -1,0 +1,24 @@
+package com.example.mate.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.core.convert.DbRefResolver;
+import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+@Configuration
+public class MongoConfig {
+
+    @Bean
+    public MappingMongoConverter mappingMongoConverter(MongoDatabaseFactory mongoDatabaseFactory,
+                                                       MongoMappingContext mongoMappingContext) {
+        DbRefResolver dbRefResolver = new DefaultDbRefResolver(mongoDatabaseFactory);
+        MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, mongoMappingContext);
+        converter.setTypeMapper(new DefaultMongoTypeMapper(null));
+
+        return converter;
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] MongoDB 의존성 추가
- [x] Config 클래스 구현
- [x] MongoDB Atals 를 통해 DB, 컬렉션 생성
- [x] DB 연결 및 읽기/쓰기 테스트

## 💡 자세한 설명

> 아래 내용은 노션 - 트러블 슈팅 쪽에 적어놓은 몽고디비 설치 및 설정입니다.
노션이 더 보기 쉬우니 노션으로 보시는걸 추천합니다!
이후 본격적으로 굿즈거래 채팅 메시지를 몽고디비로 마이그레이션하려고 합니다.

<br>

## 1. 배경

- 현재 채팅 데이터는 `MySQL`의  `ChatMessage` 테이블에 정의되어, 채팅 내용이 보내질때마다 DB 에 접근하여 저장하고 있음
- 이로 인해, I/O 비용과 트랜잭션 비용이 발생하여 트래픽이 많아질수록 성능 저하가 우려됨
    - I/O : 데이터를 넣고 빼는 리소스(cpu, disk, memory)
- 채팅 데이터는 실시간 성이 중요하기 때문에 낮은 지연시간을 유지할 수 있는 다른 방법으로 데이터를 저장할 필요가 있음

## 2. 개선 방법 ( RDB → NoSQL )

- 상대적으로 `RDB` 보다 `NoSQL`이 데이터 접근 비용(I/O)이 적다.
- 채팅 데이터는 `읽기/쓰기` 연산만 주로 이루어지므로, `JOIN` 과 같은 관계연산을 사용하지 않으니 `RDB`를 사용할 필요가 없다.
- 데이터와 트래픽의 증가에 따라 수평 확장(`scale-out`)이 가능하다.
    - 수평적 확장은 더 많은 서버를 추가해서 데이터베이스를 전체적으로 분산시키는 것을 의미함
    - 현재 캐치미 서비스의 특성상 사용자가 많아지기 시작하면 채팅 데이터는 기하급수적으로 많아지기 때문에 확장에 용이한 `NoSQL` 을 사용하는 것이 적절함

## 3. MongoDB 선택 이유

1. 채팅 데이터에 저장될 유형은 `이모지, 파일, 메시지` 등이 존재할 수 있고, 채팅 유형은 일대일 채팅, 굿즈거래채팅, 메이트 단체 채팅들이 있다. 

→ 다양한 데이터 포맷이 존재할 수 있는 상황임
→ 데이터 포맷을 신경쓰지 않고 저장할 수 있는 MongoDB가 적합함

1. 빈번하게 채팅 데이터의 `읽기/쓰기` 연산이 일어나게 됨.

→  이렇게 많은 연산이 짧은 시간에 일어나도 수행 시간에 문제가 없는 MongoDB가 적합함

1. `NoSQL` 중 가장 많은 사용 레퍼런스를 보유하고 있으며, 스프링과 호완성이 좋음
2. `index` 및 복잡한 쿼리 지원 등등 더 찾아보면 많음

## 4. Spring + MongoDB 연동

### 4-1. Local 에 MongoDB 다운로드

<aside>

`이건 안해도 됩니다 !!`

혹시 로컬 환경에서 사용해보고 싶은 분은 하셔도 됩니당
저는 깔아놓기만 하고, 아래 `Atlas` 통해서 원격으로 연결했어요

</aside>

- Mac
- https://www.mongodb.com/ko-kr/docs/manual/tutorial/install-mongodb-on-os-x/
    
    ```bash
    # MongoDB Homebrew Tap  추가
    $ brew tap mongodb/brew 
    
    # Homebrew를 최신 버전으로 업데이트
    $ brew update
    
    # MongoDB 설치
    $ brew install mongodb-community@8.0
    
    # MongoDB 실행
    brew services start mongodb-community@8.0
    
    # MongoDB 정지
    brew services stop mongodb-community@8.0
    ```
    

- Window
    - https://www.mongodb.com/ko-kr/docs/manual/tutorial/install-mongodb-on-windows/

### 4-2. MongoDB Atlas 시작하기

- MongoDB Atlas 가입 및 생성
    - 아래 두 가지 링크를 보시면서 하시면 쉽게 하실 수 있습니당.
    - `Driver` 설정만 `Java`로 바꿔주세요
        
        [[mongoDB Atlas](https://velog.io/@baekgom/mongoDB-Atlas)](https://velog.io/@baekgom/mongoDB-Atlas)
        
        [[MongoDB Atlas 사용법 | 코드잇](https://www.codeit.kr/tutorials/70/mongodb-atlas)](https://www.codeit.kr/tutorials/70/mongodb-atlas)
        
        [[MongoDB Atlas: Cloud Document Database](https://www.mongodb.com/ko-kr/lp/cloud/atlas/try4?utm_source=google&utm_campaign=search_gs_pl_evergreen_atlas_general_prosp-brand_gic-null_ww-tier1_ps-all_desktop_eng_lead&utm_term=atlas%20mongo&utm_medium=cpc_paid_search&utm_ad=p&utm_ad_campaign_id=22031347581&adgroup=173739100553&cq_cmp=22031347581&gad_source=1&gclid=Cj0KCQiAvvO7BhC-ARIsAGFyToU3wGlZG1gzDG-pmp_x5SDHvJwOq6-cgVt95lX5fF5eP0EduJunjnoaArwqEALw_wcB)](https://www.mongodb.com/ko-kr/lp/cloud/atlas/try4?utm_source=google&utm_campaign=search_gs_pl_evergreen_atlas_general_prosp-brand_gic-null_ww-tier1_ps-all_desktop_eng_lead&utm_term=atlas%20mongo&utm_medium=cpc_paid_search&utm_ad=p&utm_ad_campaign_id=22031347581&adgroup=173739100553&cq_cmp=22031347581&gad_source=1&gclid=Cj0KCQiAvvO7BhC-ARIsAGFyToU3wGlZG1gzDG-pmp_x5SDHvJwOq6-cgVt95lX5fF5eP0EduJunjnoaArwqEALw_wcB)
        

<aside>

`MongoDB Atlas` 는 외부에서 `MongoDB` 를 생성하고, 연결할 수 있는 클라우드 서비스입니다.

로컬에서 생성해서 서버에 연결할 수 있지만, OS 환경마다 방법이 다를 수 있어서 `MongoDB Atlas` 를 사용했습니다.

`MongoDB Compass` 는 `MySQL WorkBench` 와 같은 GUI 인터페이스인데, `Atlas` 로 DB를 만들고 Spring 서버랑 연결한 후에 각자 로컬에서 `Compass` 로 확인하면 될 거 같아요.

https://4sii.tistory.com/55

</aside>

### 4-3. Spring Boot 서버와 MongoDB 연동

- 참고 링크
    - https://velog.io/@murphytklee/Spring-Boot%EC%97%90%EC%84%9C-MongoDB-Atlas-%EC%97%B0%EA%B2%B0%ED%95%98%EA%B8%B0-Mysql-MongoDB

1. `build.gradle` 설정
    
    ```java
    // Spring Data MongoDB 의존성 추가
    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
    ```
    

1. `application-local.yml` 설정
    
    ```java
    spring:
      data:
        mongodb:
          uri: mongodb+srv://hongjeZZ:BE3GJm52wAjzV4XG@catchmitest0.0oacs.mongodb.net/catch-mi?retryWrites=true&w=majority&appName=catchmiTest0
    ```
    
2. `MongoConfig`
    
    ```java
    @Configuration
    public class MongoConfig {
    
        @Bean
        public MappingMongoConverter mappingMongoConverter(MongoDatabaseFactory mongoDatabaseFactory,
                                                           MongoMappingContext mongoMappingContext) {
            DbRefResolver dbRefResolver = new DefaultDbRefResolver(mongoDatabaseFactory);
            MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, mongoMappingContext);
            converter.setTypeMapper(new DefaultMongoTypeMapper(null));
    
            return converter;
        }
    }
    ```
    
    - 위 설정에 큰 기능은 없고, 객체를 컬렉션에 저장할 때 `_class` 라는 필드가 자동으로 추가되어 객체의 패키지 + 클래스를 저장합니다.
    - 위 설정을 추가하면 `_class` 필드가 저장되는 걸 막을 수 있습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?