### PR TITLE
MATE-154 : [FEAT] 회원의 알림 페이징 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/mate/domain/notification/controller/NotificationController.java
@@ -3,7 +3,7 @@ package com.example.mate.domain.notification.controller;
 import com.example.mate.common.response.ApiResponse;
 import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.auth.AuthMember;
-import com.example.mate.common.validator.ValidPageable;
+import com.example.mate.common.util.validator.ValidPageable;
 import com.example.mate.domain.notification.dto.response.NotificationResponse;
 import com.example.mate.domain.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/example/mate/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/mate/domain/notification/controller/NotificationController.java
@@ -1,16 +1,22 @@
 package com.example.mate.domain.notification.controller;
 
+import com.example.mate.common.response.ApiResponse;
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.auth.AuthMember;
+import com.example.mate.common.validator.ValidPageable;
+import com.example.mate.domain.notification.dto.response.NotificationResponse;
 import com.example.mate.domain.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -21,11 +27,23 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @Operation(summary = "알림 구독 기능", description = "알림을 구독합니다.")
+    @Operation(summary = "알림 구독", description = "알림을 구독합니다.")
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> subscribe(
             @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember,
             @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
         return ResponseEntity.ok(notificationService.subscribe(authMember.getMemberId(), lastEventId));
+    }
+
+    @Operation(summary = "알림 페이징 조회", description = "알림 페이지에서 전체/메이트 찾기/굿즈 거래 알림을 조회합니다.")
+    @GetMapping("/api/notifications")
+    public ResponseEntity<ApiResponse<PageResponse<NotificationResponse>>> getNotifications(
+            @Parameter(description = "알림 분류") @RequestParam(required = false, defaultValue = "all") String type,
+            @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember,
+            @Parameter(description = "페이징 정보", required = true) @ValidPageable Pageable pageable
+    ) {
+        PageResponse<NotificationResponse> response = notificationService.getNotificationsPage(type,
+                authMember.getMemberId(), pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/example/mate/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/example/mate/domain/notification/dto/response/NotificationResponse.java
@@ -27,13 +27,17 @@ public class NotificationResponse {
     @Schema(description = "알림 확인 여부", example = "false")
     private Boolean isRead;
 
-    public static NotificationResponse from(Notification notification) {
+    @Schema(description = "이벤트 ID", example = "1_1736919132500")
+    private String eventId;
+
+    public static NotificationResponse of(Notification notification, String eventId) {
         return NotificationResponse.builder()
                 .notificationId(notification.getId())
                 .notificationType(notification.getNotificationType().getValue())
                 .content(notification.getContent())
                 .url(notification.getUrl())
                 .isRead(notification.getIsRead())
+                .eventId(eventId)
                 .build();
     }
 }

--- a/src/main/java/com/example/mate/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/mate/domain/notification/repository/NotificationRepository.java
@@ -1,9 +1,41 @@
 package com.example.mate.domain.notification.repository;
 
 import com.example.mate.domain.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("""
+            SELECT n
+            FROM Notification n
+            WHERE n.receiver.id = :receiverId
+            AND (n.notificationType = 'MATE_CLOSED' OR n.notificationType = 'MATE_COMPLETE')
+            ORDER BY n.id DESC
+            """)
+    Page<Notification> findMateNotificationsByReceiverId(@Param("receiverId") Long receiverId,
+                                                         Pageable pageable);
+
+    @Query("""
+            SELECT n
+            FROM Notification n
+            WHERE n.receiver.id = :receiverId
+            AND n.notificationType = 'GOODS_CLOSED'
+            ORDER BY n.id DESC
+            """)
+    Page<Notification> findGoodsNotificationsByReceiverId(@Param("receiverId") Long receiverId,
+                                                          Pageable pageable);
+
+    @Query("""
+            SELECT n
+            FROM Notification n
+            WHERE n.receiver.id = :receiverId
+            ORDER BY n.id DESC
+            """)
+    Page<Notification> findNotificationsByReceiverId(@Param("receiverId") Long receiverId, Pageable pageable);
 }

--- a/src/test/java/com/example/mate/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/example/mate/domain/notification/controller/NotificationControllerTest.java
@@ -3,19 +3,29 @@ package com.example.mate.domain.notification.controller;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.common.security.filter.JwtCheckFilter;
 import com.example.mate.config.securityConfig.WithAuthMember;
+import com.example.mate.domain.notification.dto.response.NotificationResponse;
+import com.example.mate.domain.notification.entity.NotificationType;
 import com.example.mate.domain.notification.service.NotificationService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -40,6 +50,17 @@ class NotificationControllerTest {
     private JwtCheckFilter jwtCheckFilter;
 
     private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+
+    private NotificationResponse createNotificationResponse(Long notificationId, NotificationType type) {
+        return NotificationResponse.builder()
+                .notificationId(notificationId)
+                .notificationType(type.getValue())
+                .content("알림")
+                .url("http://test.com")
+                .isRead(false)
+                .eventId(null)
+                .build();
+    }
 
     @Test
     @DisplayName("SSE 알림 구독 성공")
@@ -69,5 +90,132 @@ class NotificationControllerTest {
                         data:dummy event
                         
                         """));
+    }
+
+    @Nested
+    @DisplayName("알림 페이징 조회")
+    class NotificationPage {
+
+        @Test
+        @DisplayName("알림 페이징 조회 성공 - 전체 조회")
+        void get_all_notifications_page_success() throws Exception {
+            // given
+            Long memberId = 1L;
+            String type = "all";
+            Pageable pageable = PageRequest.of(0, 10);
+            NotificationResponse responseDTO1 = createNotificationResponse(1L, NotificationType.GOODS_CLOSED);
+            NotificationResponse responseDTO2 = createNotificationResponse(2L, NotificationType.MATE_CLOSED);
+            List<NotificationResponse> content = List.of(responseDTO2, responseDTO1);
+            PageImpl<NotificationResponse> notificationPage = new PageImpl<>(content);
+
+            PageResponse<NotificationResponse> response = PageResponse.<NotificationResponse>builder()
+                    .content(content)
+                    .totalPages(notificationPage.getTotalPages())
+                    .totalElements(notificationPage.getTotalElements())
+                    .hasNext(notificationPage.hasNext())
+                    .pageNumber(notificationPage.getNumber())
+                    .pageSize(notificationPage.getSize())
+                    .build();
+
+            given(notificationService.getNotificationsPage(type, memberId, pageable)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/notifications")
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageSize())))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content.size()").value(content.size()))
+                    .andExpect(jsonPath("$.data.content[0].notificationId").value(responseDTO2.getNotificationId()))
+                    .andExpect(jsonPath("$.data.content[0].notificationType").value(responseDTO2.getNotificationType()))
+                    .andExpect(jsonPath("$.data.totalPages").value(response.getTotalPages()))
+                    .andExpect(jsonPath("$.data.totalElements").value(response.getTotalElements()))
+                    .andExpect(jsonPath("$.data.pageNumber").value(response.getPageNumber()))
+                    .andExpect(jsonPath("$.data.pageSize").value(response.getPageSize()))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("알림 페이징 조회 성공 - 메이트 조회")
+        void get_mate_notifications_page_success() throws Exception {
+            // given
+            Long memberId = 1L;
+            String type = "mate";
+            Pageable pageable = PageRequest.of(0, 10);
+            NotificationResponse responseDTO1 = createNotificationResponse(1L, NotificationType.MATE_COMPLETE);
+            NotificationResponse responseDTO2 = createNotificationResponse(2L, NotificationType.MATE_CLOSED);
+            List<NotificationResponse> content = List.of(responseDTO2, responseDTO1);
+            PageImpl<NotificationResponse> notificationPage = new PageImpl<>(content);
+
+            PageResponse<NotificationResponse> response = PageResponse.<NotificationResponse>builder()
+                    .content(content)
+                    .totalPages(notificationPage.getTotalPages())
+                    .totalElements(notificationPage.getTotalElements())
+                    .hasNext(notificationPage.hasNext())
+                    .pageNumber(notificationPage.getNumber())
+                    .pageSize(notificationPage.getSize())
+                    .build();
+
+            given(notificationService.getNotificationsPage(type, memberId, pageable)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/notifications")
+                            .param("type", type)
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageSize())))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content.size()").value(content.size()))
+                    .andExpect(jsonPath("$.data.content[0].notificationId").value(responseDTO2.getNotificationId()))
+                    .andExpect(jsonPath("$.data.content[0].notificationType").value(responseDTO2.getNotificationType()))
+                    .andExpect(jsonPath("$.data.totalPages").value(response.getTotalPages()))
+                    .andExpect(jsonPath("$.data.totalElements").value(response.getTotalElements()))
+                    .andExpect(jsonPath("$.data.pageNumber").value(response.getPageNumber()))
+                    .andExpect(jsonPath("$.data.pageSize").value(response.getPageSize()))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("알림 페이징 조회 성공 - 굿즈 조회")
+        void get_goods_notifications_page_success() throws Exception {
+            // given
+            Long memberId = 1L;
+            String type = "mate";
+            Pageable pageable = PageRequest.of(0, 10);
+            NotificationResponse responseDTO1 = createNotificationResponse(1L, NotificationType.GOODS_CLOSED);
+            NotificationResponse responseDTO2 = createNotificationResponse(2L, NotificationType.GOODS_CLOSED);
+            List<NotificationResponse> content = List.of(responseDTO2, responseDTO1);
+            PageImpl<NotificationResponse> notificationPage = new PageImpl<>(content);
+
+            PageResponse<NotificationResponse> response = PageResponse.<NotificationResponse>builder()
+                    .content(content)
+                    .totalPages(notificationPage.getTotalPages())
+                    .totalElements(notificationPage.getTotalElements())
+                    .hasNext(notificationPage.hasNext())
+                    .pageNumber(notificationPage.getNumber())
+                    .pageSize(notificationPage.getSize())
+                    .build();
+
+            given(notificationService.getNotificationsPage(type, memberId, pageable)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/notifications")
+                            .param("type", type)
+                            .param("page", String.valueOf(pageable.getPageNumber()))
+                            .param("size", String.valueOf(pageable.getPageSize())))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content.size()").value(content.size()))
+                    .andExpect(jsonPath("$.data.content[0].notificationId").value(responseDTO2.getNotificationId()))
+                    .andExpect(jsonPath("$.data.content[0].notificationType").value(responseDTO2.getNotificationType()))
+                    .andExpect(jsonPath("$.data.totalPages").value(response.getTotalPages()))
+                    .andExpect(jsonPath("$.data.totalElements").value(response.getTotalElements()))
+                    .andExpect(jsonPath("$.data.pageNumber").value(response.getPageNumber()))
+                    .andExpect(jsonPath("$.data.pageSize").value(response.getPageSize()))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
     }
 }

--- a/src/test/java/com/example/mate/domain/notification/integration/NotificationIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/notification/integration/NotificationIntegrationTest.java
@@ -2,18 +2,23 @@ package com.example.mate.domain.notification.integration;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.mate.config.securityConfig.WithAuthMember;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
+import com.example.mate.domain.notification.entity.Notification;
+import com.example.mate.domain.notification.entity.NotificationType;
 import com.example.mate.domain.notification.repository.EmitterRepository;
 import com.example.mate.domain.notification.repository.NotificationRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -42,12 +47,19 @@ public class NotificationIntegrationTest {
     private ObjectMapper objectMapper;
 
     private Member member;
+    private Notification notification1;
+    private Notification notification2;
+    private Notification notification3;
 
     @BeforeEach
     void setUp() {
         jdbcTemplate.execute("ALTER TABLE member ALTER COLUMN id RESTART WITH 1");
+        jdbcTemplate.execute("ALTER TABLE notification ALTER COLUMN id RESTART WITH 1");
 
         member = createMember();
+        notification1 = createNotification(NotificationType.GOODS_CLOSED);
+        notification2 = createNotification(NotificationType.MATE_CLOSED);
+        notification3 = createNotification(NotificationType.MATE_COMPLETE);
     }
 
     @Test
@@ -67,6 +79,86 @@ public class NotificationIntegrationTest {
                 .andExpect(content().string(containsString("data:EventStream Created. [userId=" + memberId + "]")));
     }
 
+    @Nested
+    @DisplayName("알림 페이징 조회")
+    class NotificationPage {
+
+        @Test
+        @DisplayName("알림 페이징 조회 성공 - 전체 조회")
+        @WithAuthMember
+        void get_all_notifications_page_success() throws Exception {
+            // given
+            Long memberId = member.getId();
+            String type = "all";
+            int page = 0;
+            int size = 10;
+
+            // when & then
+            mockMvc.perform(get("/api/notifications")
+                            .param("type", type)
+                            .param("page", String.valueOf(page))
+                            .param("size", String.valueOf(size)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content.size()").value(3))
+                    .andExpect(jsonPath("$.data.content[0].notificationId").value(3))
+                    .andExpect(jsonPath("$.data.content[0].notificationType").value(
+                            NotificationType.MATE_COMPLETE.getValue()))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("알림 페이징 조회 성공 - 메이트 조회")
+        @WithAuthMember
+        void get_mate_notifications_page_success() throws Exception {
+            // given
+            Long memberId = member.getId();
+            String type = "mate";
+            int page = 0;
+            int size = 10;
+
+            // when & then
+            mockMvc.perform(get("/api/notifications")
+                            .param("type", type)
+                            .param("page", String.valueOf(page))
+                            .param("size", String.valueOf(size)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content.size()").value(2))
+                    .andExpect(jsonPath("$.data.content[1].notificationId").value(2))
+                    .andExpect(jsonPath("$.data.content[1].notificationType").value(
+                            NotificationType.MATE_CLOSED.getValue()))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        @Test
+        @DisplayName("알림 페이징 조회 성공 - 굿즈 조회")
+        @WithAuthMember
+        void get_goods_notifications_page_success() throws Exception {
+            // given
+            Long memberId = member.getId();
+            String type = "goods";
+            int page = 0;
+            int size = 10;
+
+            // when & then
+            mockMvc.perform(get("/api/notifications")
+                            .param("type", type)
+                            .param("page", String.valueOf(page))
+                            .param("size", String.valueOf(size)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.content.size()").value(1))
+                    .andExpect(jsonPath("$.data.content[0].notificationId").value(1))
+                    .andExpect(jsonPath("$.data.content[0].notificationType").value(
+                            NotificationType.GOODS_CLOSED.getValue()))
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+    }
+
     private Member createMember() {
         return memberRepository.save(Member.builder()
                 .name("홍길동")
@@ -76,6 +168,15 @@ public class NotificationIntegrationTest {
                 .gender(Gender.FEMALE)
                 .age(25)
                 .manner(0.3f)
+                .build());
+    }
+
+    private Notification createNotification(NotificationType type) {
+        return notificationRepository.save(Notification.builder()
+                .notificationType(type)
+                .content("알림")
+                .url("http://test.com")
+                .receiver(member)
                 .build());
     }
 }

--- a/src/test/java/com/example/mate/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/example/mate/domain/notification/service/NotificationServiceTest.java
@@ -1,24 +1,34 @@
 package com.example.mate.domain.notification.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.constant.Gender;
 import com.example.mate.domain.member.entity.Member;
+import com.example.mate.domain.member.repository.MemberRepository;
+import com.example.mate.domain.notification.dto.response.NotificationResponse;
 import com.example.mate.domain.notification.entity.Notification;
 import com.example.mate.domain.notification.entity.NotificationType;
 import com.example.mate.domain.notification.repository.EmitterRepository;
 import com.example.mate.domain.notification.repository.NotificationRepository;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,6 +42,9 @@ class NotificationServiceTest {
 
     @Mock
     private NotificationRepository notificationRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
 
     private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
 
@@ -50,6 +63,14 @@ class NotificationServiceTest {
                 .build();
     }
 
+    private Notification createTestNotification(NotificationType type, Member receiver) {
+        return Notification.builder()
+                .notificationType(type)
+                .content("알림")
+                .url("http://test.com")
+                .receiver(receiver)
+                .build();
+    }
 
     @Test
     @DisplayName("알림 구독 성공")
@@ -103,5 +124,109 @@ class NotificationServiceTest {
         verify(notificationRepository).save(any(Notification.class));
         verify(emitterRepository).findAllEmitterStartsWithMemberId(String.valueOf(member.getId()));
         verify(emitterRepository).saveEventCache(eventId, notification);
+    }
+
+    @Nested
+    @DisplayName("알림 페이징 조회")
+    class NotificationPage {
+
+        @Test
+        @DisplayName("알림 페이징 조회 성공 - 전체 조회")
+        void get_all_notifications_page_success() {
+            // given
+            Member member = createTestMember();
+            Long memberId = 1L;
+            String type = "all";
+            Notification notification1 = createTestNotification(NotificationType.GOODS_CLOSED, member);
+            Notification notification2 = createTestNotification(NotificationType.MATE_CLOSED, member);
+            PageImpl<Notification> notificationPage = new PageImpl<>(List.of(notification1, notification2));
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(notificationRepository.findNotificationsByReceiverId(memberId, pageable))
+                    .willReturn(notificationPage);
+
+            // when
+            PageResponse<NotificationResponse> response = notificationService.getNotificationsPage(type, memberId,
+                    pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTotalElements()).isEqualTo(notificationPage.getTotalElements());
+            assertThat(response.getContent().size()).isEqualTo(notificationPage.getContent().size());
+
+            NotificationResponse notificationResponse = response.getContent().get(0);
+            assertThat(notificationResponse.getNotificationType()).isEqualTo(
+                    notification1.getNotificationType().getValue());
+
+            verify(memberRepository).findById(memberId);
+            verify(notificationRepository).findNotificationsByReceiverId(memberId, pageable);
+        }
+
+        @Test
+        @DisplayName("알림 페이징 조회 성공 - 메이트 조회")
+        void get_mate_notifications_page_success() {
+            // given
+            Member member = createTestMember();
+            Long memberId = 1L;
+            String type = "mate";
+            Notification notification1 = createTestNotification(NotificationType.MATE_COMPLETE, member);
+            Notification notification2 = createTestNotification(NotificationType.MATE_CLOSED, member);
+            PageImpl<Notification> notificationPage = new PageImpl<>(List.of(notification1, notification2));
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(notificationRepository.findMateNotificationsByReceiverId(memberId, pageable))
+                    .willReturn(notificationPage);
+
+            // when
+            PageResponse<NotificationResponse> response = notificationService.getNotificationsPage(type, memberId,
+                    pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTotalElements()).isEqualTo(notificationPage.getTotalElements());
+            assertThat(response.getContent().size()).isEqualTo(notificationPage.getContent().size());
+
+            NotificationResponse notificationResponse = response.getContent().get(0);
+            assertThat(notificationResponse.getNotificationType()).isEqualTo(
+                    notification1.getNotificationType().getValue());
+
+            verify(memberRepository).findById(memberId);
+            verify(notificationRepository).findMateNotificationsByReceiverId(memberId, pageable);
+        }
+
+        @Test
+        @DisplayName("알림 페이징 조회 성공 - 굿즈 조회")
+        void get_goods_notifications_page_success() {
+            // given
+            Member member = createTestMember();
+            Long memberId = 1L;
+            String type = "goods";
+            Notification notification1 = createTestNotification(NotificationType.GOODS_CLOSED, member);
+            Notification notification2 = createTestNotification(NotificationType.GOODS_CLOSED, member);
+            PageImpl<Notification> notificationPage = new PageImpl<>(List.of(notification1, notification2));
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            given(notificationRepository.findGoodsNotificationsByReceiverId(memberId, pageable))
+                    .willReturn(notificationPage);
+
+            // when
+            PageResponse<NotificationResponse> response = notificationService.getNotificationsPage(type, memberId,
+                    pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getTotalElements()).isEqualTo(notificationPage.getTotalElements());
+            assertThat(response.getContent().size()).isEqualTo(notificationPage.getContent().size());
+
+            NotificationResponse notificationResponse = response.getContent().get(0);
+            assertThat(notificationResponse.getNotificationType()).isEqualTo(
+                    notification1.getNotificationType().getValue());
+
+            verify(memberRepository).findById(memberId);
+            verify(notificationRepository).findGoodsNotificationsByReceiverId(memberId, pageable);
+        }
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 알림 응답 객체에 이벤트 ID 필드 추가
- [x] 알림 유형에 따른 페이징 조회 기능 구현
- [x] 단위, 통합 테스트

## 💡 자세한 설명

### 알림 유형별로 회원에게 보내진 알림 페이징 조회

#### 전체 알림

- 컨트롤러에서 `type=all` 쿼리 파라미터 요청
    - 기본값으로 `type=all`을 넣고 있어, `type`을 빼고 요청해도 동일한 기능
    - 메이트 찾기, 굿즈 거래 관련 모든 알림 조회

#### 메이트 찾기 관련 알림

- 컨트롤러에서 `type=mate` 쿼리 파라미터 요청
    - "모집완료" : 사용자가 직관 모임의 참여 인원으로 확정되었다는 알림
    - "직관완료" : 사용자가 참여한 모임의 상태가 모집완료에서 직관완료로 변경되었다는 알림

#### 굿즈 거래 관련 알림

- 컨트롤러에서 `type=goods` 쿼리 파라미터 요청
    - "거래완료" : 판매자가 거래완료로 상태를 변경하며, 구매자를 지정했다는 알림

### 알림 응답 객체에 이벤트 ID 필드 추가

- 프론트엔드에서 마지막으로 전달받은 알림의 이벤트 ID를 추적할 수 있도록 응답 객체에 필드 추가

### 도메인 규칙

![스크린샷 2025-01-16 오후 3 20 34](https://github.com/user-attachments/assets/84ad5f55-fda9-428f-8275-56a42220dcc0)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?