### PR TITLE
MATE-155 : [FEAT] 굿즈 거래완료 메시지 전송 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/domain/constant/MessageType.java
+++ b/src/main/java/com/example/mate/domain/constant/MessageType.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum MessageType {
     ENTER("입장"),      // 채팅방 입장
     TALK("대화"),       // 일반 메시지
-    LEAVE("퇴장");      // 채팅방 퇴장
+    LEAVE("퇴장"),      // 채팅방 퇴장
+    GOODS("굿즈");      // 굿즈 거래완료
 
     private final String value;
 

--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
@@ -34,7 +34,7 @@ public class GoodsChatRoomController {
     private final GoodsChatService goodsChatService;
 
     @PostMapping
-    @Operation(summary = "굿즈거래 채팅방 입장 및 생성", description = "굿즈 거래 게시글에 대한 채팅방을 생성하거나 기존 채팅방 정보를 조회합니다.")
+    @Operation(summary = "굿즈거래 채팅방 입장 및 생성", description = "굿즈거래 게시글에 대한 채팅방을 생성하거나 기존 채팅방 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> createGoodsChatRoom(
             @AuthenticationPrincipal AuthMember member,
             @Parameter(description = "판매글 ID", required = true) @RequestParam Long goodsPostId
@@ -75,7 +75,7 @@ public class GoodsChatRoomController {
     }
 
     @GetMapping("/{chatRoomId}")
-    @Operation(summary = "굿즈거래 채팅방 입장", description = "굿즈 거래 채팅방의 정보를 조회합니다.")
+    @Operation(summary = "굿즈거래 채팅방 입장", description = "굿즈거래 채팅방의 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> getGoodsChatRoomInfo(
             @AuthenticationPrincipal AuthMember member,
             @Parameter(description = "채팅방 ID", required = true) @PathVariable Long chatRoomId
@@ -92,5 +92,15 @@ public class GoodsChatRoomController {
     ) {
         List<MemberSummaryResponse> responses = goodsChatService.getMembersInChatRoom(member.getMemberId(), chatRoomId);
         return ResponseEntity.ok(ApiResponse.success(responses));
+    }
+
+    @PostMapping("/{chatRoomId}/complete")
+    @Operation(summary = "굿즈 거래 완료", description = "굿즈거래 채팅방에서 굿즈거래를 거래완료 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> completeGoodsPost(
+            @AuthenticationPrincipal AuthMember member,
+            @Parameter(description = "채팅방 ID", required = true) @PathVariable Long chatRoomId
+    ) {
+        goodsChatService.completeTransaction(member.getMemberId(), chatRoomId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/example/mate/domain/goodsChat/event/GoodsChatEventHandler.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/event/GoodsChatEventHandler.java
@@ -4,8 +4,6 @@ import com.example.mate.domain.goodsChat.service.GoodsChatMessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
@@ -16,7 +14,6 @@ public class GoodsChatEventHandler {
 
     @Async
     @TransactionalEventListener
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(GoodsChatEvent event) {
         messageService.sendChatEventMessage(event);
     }

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageService.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageService.java
@@ -28,8 +28,11 @@ public class GoodsChatMessageService {
     private final GoodsChatMessageRepository messageRepository;
     private final SimpMessagingTemplate messagingTemplate;
 
+    private static final String GOODS_CHAT_SUBSCRIBE_PATH = "/sub/chat/goods/";
+
     private static final String MEMBER_ENTER_MESSAGE = "님이 대화를 시작했습니다.";
     private static final String MEMBER_LEAVE_MESSAGE = "님이 대화를 떠났습니다.";
+    private static final String MEMBER_TRANSACTION_MESSAGE = "님이 거래를 완료했습니다. 상품에 대한 거래후기를 남겨주세요!";
 
     public void sendMessage(GoodsChatMessageRequest message) {
         Member member = findMemberById(message.getSenderId());
@@ -44,7 +47,7 @@ public class GoodsChatMessageService {
         sendToSubscribers(message.getRoomId(), response);
     }
 
-    // 입장 및 퇴장 메시지 전송
+    // 이벤트 메시지 전송
     public void sendChatEventMessage(GoodsChatEvent event) {
         Member member = event.member();
         Long chatRoomId = event.chatRoomId();
@@ -55,6 +58,7 @@ public class GoodsChatMessageService {
         switch (event.type()) {
             case ENTER -> message += MEMBER_ENTER_MESSAGE;
             case LEAVE -> message += MEMBER_LEAVE_MESSAGE;
+            case GOODS -> message += MEMBER_TRANSACTION_MESSAGE;
         }
         GoodsChatMessage chatMessage = createChatMessage(chatRoomId, member.getId(), message, event.type());
 
@@ -87,6 +91,6 @@ public class GoodsChatMessageService {
     }
 
     private void sendToSubscribers(Long chatRoomId, GoodsChatMessageResponse message) {
-        messagingTemplate.convertAndSend("/sub/chat/goods/" + chatRoomId, message);
+        messagingTemplate.convertAndSend(GOODS_CHAT_SUBSCRIBE_PATH + chatRoomId, message);
     }
 }

--- a/src/main/java/com/example/mate/domain/goodsPost/controller/GoodsPostController.java
+++ b/src/main/java/com/example/mate/domain/goodsPost/controller/GoodsPostController.java
@@ -95,15 +95,4 @@ public class GoodsPostController {
 
         return ResponseEntity.ok(ApiResponse.success(pageGoodsPosts));
     }
-
-    @PostMapping("/{goodsPostId}/complete")
-    @Operation(summary = "굿즈 거래 완료", description = "굿즈거래 채팅방에서 굿즈거래를 거래완료 처리합니다.")
-    public ResponseEntity<ApiResponse<Void>> completeGoodsPost(
-            @AuthenticationPrincipal AuthMember member,
-            @Parameter(description = "판매글 ID", required = true) @PathVariable Long goodsPostId,
-            @Parameter(description = "구매자 ID", required = true) @RequestParam Long buyerId
-    ) {
-        goodsPostService.completeTransaction(member.getMemberId(), goodsPostId, buyerId);
-        return ResponseEntity.ok(ApiResponse.success(null));
-    }
 }

--- a/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -385,5 +386,24 @@ class GoodsChatRoomControllerTest {
                 .andExpect(jsonPath("$.message").value(ErrorCode.GOODS_CHAT_NOT_FOUND_CHAT_PART.getMessage()));
 
         verify(goodsChatService).getMembersInChatRoom(memberId, chatRoomId);
+    }
+
+    @Test
+    @DisplayName("굿즈 거래완료 - API 테스트")
+    void complete_goods_post_success() throws Exception {
+        // given
+        Long memberId = 1L;
+        Long chatRoomId = 1L;
+
+        willDoNothing().given(goodsChatService).completeTransaction(memberId, chatRoomId);
+
+        // when & then
+        mockMvc.perform(post("/api/goods/chat/{chatRoomId}/complete", chatRoomId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(goodsChatService).completeTransaction(memberId, chatRoomId);
     }
 }

--- a/src/test/java/com/example/mate/domain/goodsPost/controller/GoodsPostControllerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsPost/controller/GoodsPostControllerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -270,25 +269,5 @@ class GoodsPostControllerTest {
                 .andExpect(jsonPath("$.code").value(200));
 
         verify(goodsPostService).getPageGoodsPosts(teamId, categoryVal, pageRequest);
-    }
-
-    @Test
-    @DisplayName("굿즈 판매글 거래 완료 - API 테스트")
-    void complete_goods_post_success() throws Exception {
-        // given
-        Long memberId = 1L;
-        Long goodsPostId = 1L;
-        Long buyerId = 2L;
-
-        willDoNothing().given(goodsPostService).completeTransaction(memberId, goodsPostId, buyerId);
-
-        // when & then
-        mockMvc.perform(post("/api/goods/{goodsPostId}/complete", goodsPostId).param("buyerId", String.valueOf(buyerId)))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.code").value(200));
-
-        verify(goodsPostService).completeTransaction(memberId, goodsPostId, buyerId);
     }
 }

--- a/src/test/java/com/example/mate/domain/goodsPost/integration/GoodsPostIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/goodsPost/integration/GoodsPostIntegrationTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.within;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -68,7 +67,6 @@ public class GoodsPostIntegrationTest {
 
     private Member member;
     private GoodsPost goodsPost;
-
 
     @BeforeEach
     void setUp() {
@@ -347,52 +345,6 @@ public class GoodsPostIntegrationTest {
         assertThat(firstResponse.getPrice()).isEqualTo(3_000);
         assertThat(firstResponse.getCategory()).isEqualTo(Category.ACCESSORY.getValue());
         assertThat(firstResponse.getImageUrl()).isEqualTo(FileUtils.getThumbnailImageUrl("upload/test_img_url 3"));
-    }
-
-    @Test
-    @DisplayName("굿즈 판매글 거래 완료 통합 테스트")
-    @WithAuthMember
-    void complete_goods_post_integration_test() throws Exception {
-        // given
-        Long memberId = member.getId(); // 판매자 ID
-        Long goodsPostId = goodsPost.getId(); // 판매글 ID
-        Member buyer = memberRepository.save(Member.builder()
-                .name("구매자")
-                .email("buyer@gmail.com")
-                .nickname("구매자닉네임")
-                .imageUrl("upload/buyer.jpg")
-                .gender(Gender.MALE)
-                .age(30)
-                .manner(0.5f)
-                .build());
-
-        // when
-        MockHttpServletResponse result = mockMvc.perform(post("/api/goods/{goodsPostId}/complete", goodsPostId)
-                        .param("buyerId", String.valueOf(buyer.getId())))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andReturn()
-                .getResponse();
-        result.setCharacterEncoding("UTF-8");
-
-        ApiResponse<Void> apiResponse = objectMapper.readValue(result.getContentAsString(), new TypeReference<>() {
-        });
-
-        // then
-        assertThat(apiResponse.getCode()).isEqualTo(200);
-        assertThat(apiResponse.getStatus()).isEqualTo("SUCCESS");
-
-        GoodsPost completedPost = goodsPostRepository.findById(goodsPostId).orElseThrow();
-        assertThat(completedPost.getStatus()).isEqualTo(Status.CLOSED);
-        assertThat(completedPost.getBuyer()).isNotNull();
-        assertThat(completedPost.getSeller().getManner()).isCloseTo(0.302f, within(0.0001f));
-
-        Member resultBuyer = completedPost.getBuyer();
-        assertThat(resultBuyer.getId()).isEqualTo(buyer.getId());
-        assertThat(resultBuyer.getName()).isEqualTo(buyer.getName());
-        assertThat(resultBuyer.getEmail()).isEqualTo(buyer.getEmail());
-        assertThat(resultBuyer.getNickname()).isEqualTo(buyer.getNickname());
-        assertThat(resultBuyer.getManner()).isCloseTo(0.502f, within(0.0001f));
     }
 
     private Member createMember() {

--- a/src/test/java/com/example/mate/domain/goodsPost/service/GoodsPostServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goodsPost/service/GoodsPostServiceTest.java
@@ -61,9 +61,6 @@ class GoodsPostServiceTest {
     @Mock
     private FileService fileService;
 
-    @Mock
-    private GoodsPostEventPublisher eventPublisher;
-
     private Member member;
 
     private GoodsPost goodsPost;
@@ -131,8 +128,7 @@ class GoodsPostServiceTest {
         @DisplayName("굿즈거래 판매글 작성 성공")
         void register_goods_post_success() {
             // given
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content",
-                    createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content", createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
 
             GoodsPost post = GoodsPostRequest.toEntity(member, request);
@@ -159,8 +155,7 @@ class GoodsPostServiceTest {
         void register_goods_post_failed_with_invalid_member() {
             // given
             Long invalidMemberId = 100L;
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content",
-                    createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content", createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
             given(memberRepository.findById(invalidMemberId)).willReturn(Optional.empty());
 
@@ -178,8 +173,7 @@ class GoodsPostServiceTest {
         @DisplayName("굿즈거래 판매글 작성 실패 - 형식이 잘못된 파일")
         void register_goods_post_failed_with_invalid_file() {
             // given
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content",
-                    createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.ACCESSORY, 10_000, "content", createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.APPLICATION_PDF_VALUE));
             given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
 
@@ -203,8 +197,7 @@ class GoodsPostServiceTest {
         void update_goods_post_success() {
             // given
             Long goodsPostId = 1L;
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....",
-                    createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....", createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
 
             given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
@@ -231,8 +224,7 @@ class GoodsPostServiceTest {
         void update_goods_post_failed_with_invalid_member() {
             // given
             Long goodsPostId = 1L;
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....",
-                    createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....", createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
             Member notSeller = Member.builder().id(11L).name("홍길동").build();
 
@@ -256,8 +248,7 @@ class GoodsPostServiceTest {
         void update_goods_post_failed_with_invalid_post() {
             // given
             Long goodsPostId = 1L;
-            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....",
-                    createLocationInfo());
+            GoodsPostRequest request = new GoodsPostRequest(1L, "title", Category.CAP, 100_000, "test....", createLocationInfo());
             List<MultipartFile> files = List.of(createFile(MediaType.IMAGE_JPEG_VALUE));
 
             given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
@@ -437,8 +428,7 @@ class GoodsPostServiceTest {
             GoodsPostSummaryResponse goodsPostSummaryResponse = responses.get(0);
             assertThat(goodsPostSummaryResponse.getTitle()).isEqualTo(goodsPost.getTitle());
             assertThat(goodsPostSummaryResponse.getPrice()).isEqualTo(goodsPost.getPrice());
-            assertThat(goodsPostSummaryResponse.getImageUrl()).isEqualTo(
-                    FileUtils.getThumbnailImageUrl(goodsPostImage.getImageUrl()));
+            assertThat(goodsPostSummaryResponse.getImageUrl()).isEqualTo(FileUtils.getThumbnailImageUrl(goodsPostImage.getImageUrl()));
 
             verify(goodsPostRepository).findMainGoodsPosts(1L, Status.OPEN, PageRequest.of(0, 4));
         }
@@ -488,12 +478,10 @@ class GoodsPostServiceTest {
             PageImpl<GoodsPost> goodsPostPage = new PageImpl<>(List.of(postWithoutFilters));
             PageRequest pageRequest = PageRequest.of(0, 10);
 
-            given(goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest)).willReturn(
-                    goodsPostPage);
+            given(goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest)).willReturn(goodsPostPage);
 
             // when
-            PageResponse<GoodsPostSummaryResponse> pageGoodsPosts = goodsPostService.getPageGoodsPosts(teamId, null,
-                    pageRequest);
+            PageResponse<GoodsPostSummaryResponse> pageGoodsPosts = goodsPostService.getPageGoodsPosts(teamId, null, pageRequest);
 
             // then
             assertThat(pageGoodsPosts).isNotNull();
@@ -525,8 +513,7 @@ class GoodsPostServiceTest {
             PageImpl<GoodsPost> goodsPostPage = new PageImpl<>(List.of(postWithFilters));
             PageRequest pageRequest = PageRequest.of(0, 10);
 
-            given(goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest)).willReturn(
-                    goodsPostPage);
+            given(goodsPostRepository.findPageGoodsPosts(teamId, Status.OPEN, category, pageRequest)).willReturn(goodsPostPage);
 
             // when
             PageResponse<GoodsPostSummaryResponse> pageGoodsPosts
@@ -558,83 +545,6 @@ class GoodsPostServiceTest {
             assertThatThrownBy(() -> goodsPostService.getPageGoodsPosts(teamId, category.getValue(), pageRequest))
                     .isExactlyInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.TEAM_NOT_FOUND.getMessage());
-        }
-    }
-
-    @Nested
-    @DisplayName("굿즈거래 판매글 거래완료 테스트")
-    class GoodsPostServiceCompleteTransactionTest {
-
-        @Test
-        @DisplayName("굿즈거래 판매글 거래완료 성공")
-        void complete_goods_post_transaction_success() {
-            // given
-            Long sellerId = member.getId();
-            Long goodsPostId = goodsPost.getId();
-            Member buyer = Member.builder().id(2L).name("구매자").build();
-            Long buyerId = buyer.getId();
-
-            given(memberRepository.findById(sellerId)).willReturn(Optional.of(member));
-            given(goodsPostRepository.findById(goodsPostId)).willReturn(Optional.of(goodsPost));
-            given(memberRepository.findById(buyerId)).willReturn(Optional.of(buyer));
-
-            // when
-            goodsPostService.completeTransaction(sellerId, goodsPostId, buyerId);
-
-            // then
-            assertThat(goodsPost.getStatus()).isEqualTo(Status.CLOSED);
-            assertThat(goodsPost.getBuyer()).isEqualTo(buyer);
-            assertThat(member.getManner()).isCloseTo(0.302f, within(0.0001f));
-            assertThat(buyer.getManner()).isCloseTo(0.302f, within(0.0001f));
-
-            verify(memberRepository).findById(sellerId);
-            verify(goodsPostRepository).findById(goodsPostId);
-            verify(memberRepository).findById(buyerId);
-        }
-
-        @Test
-        @DisplayName("굿즈거래 판매글 거래완료 실패 - 이미 거래완료 상태인 판매글")
-        void complete_goods_post_transaction_failed_with_closed_status() {
-            // given
-            Long sellerId = member.getId();
-            Long goodsPostId = goodsPost.getId();
-            Member buyer = Member.builder().id(2L).name("구매자").build();
-            Long buyerId = 2L;
-            goodsPost.completeTransaction(buyer);       // 판매글 상태를 거래 완료로 설정
-
-            given(memberRepository.findById(sellerId)).willReturn(Optional.of(member));
-            given(goodsPostRepository.findById(goodsPostId)).willReturn(Optional.of(goodsPost));
-            given(memberRepository.findById(buyerId)).willReturn(Optional.of(buyer));
-
-            // when & then
-            assertThatThrownBy(() -> goodsPostService.completeTransaction(sellerId, goodsPostId, buyerId))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ErrorCode.GOODS_ALREADY_COMPLETED.getMessage());
-
-            verify(memberRepository).findById(sellerId);
-            verify(goodsPostRepository).findById(goodsPostId);
-            verify(memberRepository).findById(buyerId);
-        }
-
-        @Test
-        @DisplayName("굿즈거래 판매글 거래완료 실패 - 동일한 판매자와 구매자")
-        void complete_goods_post_transaction_failed_with_same_seller_and_buyer() {
-            // given
-            Long sellerId = member.getId();
-            Long goodsPostId = goodsPost.getId();
-            Long buyerId = sellerId;        // 구매자와 판매자가 동일
-
-            given(memberRepository.findById(sellerId)).willReturn(Optional.of(member));
-            given(goodsPostRepository.findById(goodsPostId)).willReturn(Optional.of(goodsPost));
-            given(memberRepository.findById(buyerId)).willReturn(Optional.of(member));
-
-            // when & then
-            assertThatThrownBy(() -> goodsPostService.completeTransaction(sellerId, goodsPostId, buyerId))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage(ErrorCode.SELLER_CANNOT_BE_BUYER.getMessage());
-
-            verify(memberRepository, times(2)).findById(sellerId);
-            verify(goodsPostRepository).findById(goodsPostId);
         }
     }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 굿즈 거래완료 메시지 전송 기능 구현
- [x] 굿즈 거래완료 도메인 이동 (GoodsPost -> GoodsChat)
- [x] API 테스트
- [x] 테스트 코드 수정

## 💡 자세한 설명
굿즈 거래완료는 채팅방의 기능이기도 하고, 채팅방에 메시지를 전송하기 위해선 채팅방에 대한 의존성이 필요해서 패키지를 변경했습니다.

채팅방 엔티티에서 판매자 정보와 구매자 정보를 가지고 있기 때문에, `Controller`의 `buyerId` 파라미터도 삭제했습니다. 관련 사항은 프론트엔드 담장자분께 말씀드리도록 하겠습니당

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?