### PR TITLE
MATE-157 : [FEAT] 알림 읽음 처리 기능 구현 및 알림 엔티티 수정

### DIFF
--- a/src/main/java/com/example/mate/common/error/ErrorCode.java
+++ b/src/main/java/com/example/mate/common/error/ErrorCode.java
@@ -148,7 +148,9 @@ public enum ErrorCode {
     INVALID_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "CHAT011", "잘못된 메시지 타입입니다."),
 
     // Notification
-    NOTIFICATION_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "N001", "알림 전송에 실패했습니다.");
+    NOTIFICATION_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "N001", "알림 전송에 실패했습니다."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "N002", "존재하지 않는 알림입니다."),
+    INVALID_RECEIVER(HttpStatus.BAD_REQUEST, "N003", "알림 회원이 일치하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/mate/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/mate/domain/notification/controller/NotificationController.java
@@ -15,6 +15,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,5 +47,15 @@ public class NotificationController {
         PageResponse<NotificationResponse> response = notificationService.getNotificationsPage(type,
                 authMember.getMemberId(), pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "알림 읽음 상태 변경", description = "알림 페이지에서 해당 알림을 읽음 상태로 변경합니다.")
+    @PostMapping("/api/notifications/{notificationId}")
+    public ResponseEntity<ApiResponse<Void>> readNotification(
+            @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember,
+            @Parameter(description = "알림 ID") @PathVariable Long notificationId
+    ) {
+        notificationService.readNotification(authMember.getMemberId(), notificationId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/example/mate/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/mate/domain/notification/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.notification.entity;
 
+import com.example.mate.common.BaseTimeEntity;
 import com.example.mate.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "notification")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Notification {
+public class Notification extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,5 +53,9 @@ public class Notification {
         this.url = url;
         this.receiver = receiver;
         this.isRead = false;
+    }
+
+    public void changeIsRead(Boolean isRead) {
+        this.isRead = isRead;
     }
 }

--- a/src/main/java/com/example/mate/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/mate/domain/notification/repository/NotificationRepository.java
@@ -1,41 +1,9 @@
 package com.example.mate.domain.notification.repository;
 
 import com.example.mate.domain.notification.entity.Notification;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
-
-    @Query("""
-            SELECT n
-            FROM Notification n
-            WHERE n.receiver.id = :receiverId
-            AND (n.notificationType = 'MATE_CLOSED' OR n.notificationType = 'MATE_COMPLETE')
-            ORDER BY n.id DESC
-            """)
-    Page<Notification> findMateNotificationsByReceiverId(@Param("receiverId") Long receiverId,
-                                                         Pageable pageable);
-
-    @Query("""
-            SELECT n
-            FROM Notification n
-            WHERE n.receiver.id = :receiverId
-            AND n.notificationType = 'GOODS_CLOSED'
-            ORDER BY n.id DESC
-            """)
-    Page<Notification> findGoodsNotificationsByReceiverId(@Param("receiverId") Long receiverId,
-                                                          Pageable pageable);
-
-    @Query("""
-            SELECT n
-            FROM Notification n
-            WHERE n.receiver.id = :receiverId
-            ORDER BY n.id DESC
-            """)
-    Page<Notification> findNotificationsByReceiverId(@Param("receiverId") Long receiverId, Pageable pageable);
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
 }

--- a/src/main/java/com/example/mate/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/example/mate/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.mate.domain.notification.repository;
+
+import com.example.mate.domain.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface NotificationRepositoryCustom {
+
+    Page<Notification> findNotificationsPage(String type, Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/example/mate/domain/notification/repository/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/notification/repository/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,56 @@
+package com.example.mate.domain.notification.repository;
+
+import static com.example.mate.domain.notification.entity.QNotification.notification;
+
+import com.example.mate.domain.notification.dto.response.NotificationResponse;
+import com.example.mate.domain.notification.entity.Notification;
+import com.example.mate.domain.notification.entity.NotificationType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Notification> findNotificationsPage(String type, Long memberId, Pageable pageable) {
+        BooleanBuilder conditions = buildConditions(type, memberId);
+
+        List<Notification> content = queryFactory
+                .selectFrom(notification)
+                .where(conditions)
+                .orderBy(notification.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> total = queryFactory
+                .select(notification.count())
+                .from(notification)
+                .where(conditions);
+
+        return PageableExecutionUtils.getPage(content, pageable, total::fetchOne);
+    }
+
+    private BooleanBuilder buildConditions(String type, Long memberId) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(notification.receiver.id.eq(memberId));
+
+        if (type.equals("mate")) {
+            builder.and(notification.notificationType.in(NotificationType.MATE_COMPLETE, NotificationType.MATE_CLOSED));
+        } else if (type.equals("goods")) {
+            builder.and(notification.notificationType.eq(NotificationType.GOODS_CLOSED));
+        }
+        return builder;
+    }
+}

--- a/src/main/java/com/example/mate/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/mate/domain/notification/service/NotificationService.java
@@ -13,6 +13,7 @@ import com.example.mate.domain.notification.repository.NotificationRepository;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -116,5 +117,21 @@ public class NotificationService {
     private void validateMemberId(Long memberId) {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND_BY_ID));
+    }
+
+    // 회원 알림 읽음 처리
+    public void readNotification(Long memberId, Long notificationId) {
+        Notification notification = validateNotification(memberId, notificationId);
+        notification.changeIsRead(true);
+    }
+
+    private Notification validateNotification(Long memberId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!Objects.equals(notification.getReceiver().getId(), memberId)) {
+            throw new CustomException(ErrorCode.INVALID_RECEIVER);
+        }
+        return notification;
     }
 }

--- a/src/main/java/com/example/mate/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/mate/domain/notification/service/NotificationService.java
@@ -99,14 +99,7 @@ public class NotificationService {
     public PageResponse<NotificationResponse> getNotificationsPage(String type, Long memberId, Pageable pageable) {
         validateMemberId(memberId);
 
-        Page<Notification> notificationsPage;
-        switch (type) {
-            case "mate" ->
-                    notificationsPage = notificationRepository.findMateNotificationsByReceiverId(memberId, pageable);
-            case "goods" ->
-                    notificationsPage = notificationRepository.findGoodsNotificationsByReceiverId(memberId, pageable);
-            default -> notificationsPage = notificationRepository.findNotificationsByReceiverId(memberId, pageable);
-        }
+        Page<Notification> notificationsPage = notificationRepository.findNotificationsPage(type, memberId, pageable);
         List<NotificationResponse> content = notificationsPage.getContent().stream()
                 .map(notification -> NotificationResponse.of(notification, null))
                 .toList();

--- a/src/test/java/com/example/mate/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/example/mate/domain/notification/service/NotificationServiceTest.java
@@ -147,7 +147,7 @@ class NotificationServiceTest {
             Pageable pageable = PageRequest.of(0, 10);
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-            given(notificationRepository.findNotificationsByReceiverId(memberId, pageable))
+            given(notificationRepository.findNotificationsPage(type, memberId, pageable))
                     .willReturn(notificationPage);
 
             // when
@@ -164,7 +164,7 @@ class NotificationServiceTest {
                     notification1.getNotificationType().getValue());
 
             verify(memberRepository).findById(memberId);
-            verify(notificationRepository).findNotificationsByReceiverId(memberId, pageable);
+            verify(notificationRepository).findNotificationsPage(type, memberId, pageable);
         }
 
         @Test
@@ -180,7 +180,7 @@ class NotificationServiceTest {
             Pageable pageable = PageRequest.of(0, 10);
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-            given(notificationRepository.findMateNotificationsByReceiverId(memberId, pageable))
+            given(notificationRepository.findNotificationsPage(type, memberId, pageable))
                     .willReturn(notificationPage);
 
             // when
@@ -197,7 +197,7 @@ class NotificationServiceTest {
                     notification1.getNotificationType().getValue());
 
             verify(memberRepository).findById(memberId);
-            verify(notificationRepository).findMateNotificationsByReceiverId(memberId, pageable);
+            verify(notificationRepository).findNotificationsPage(type, memberId, pageable);
         }
 
         @Test
@@ -213,7 +213,7 @@ class NotificationServiceTest {
             Pageable pageable = PageRequest.of(0, 10);
 
             given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
-            given(notificationRepository.findGoodsNotificationsByReceiverId(memberId, pageable))
+            given(notificationRepository.findNotificationsPage(type, memberId, pageable))
                     .willReturn(notificationPage);
 
             // when
@@ -230,7 +230,7 @@ class NotificationServiceTest {
                     notification1.getNotificationType().getValue());
 
             verify(memberRepository).findById(memberId);
-            verify(notificationRepository).findGoodsNotificationsByReceiverId(memberId, pageable);
+            verify(notificationRepository).findNotificationsPage(type, memberId, pageable);
         }
     }
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] 알림 도메인에 생성/수정 시간 필드 추가
- [x] 알림 읽음 상태로 변경 기능 추가
- [x] 알림 페이징 조회 로직 리팩토링

## 💡 자세한 설명

### 알림 도메인에 생성/수정 시간 필드 및 상태 변경 메서드 추가

- 현재는 구현되어 있지 않지만, 각 알림이 어느 시점에 왔는지 확인할 수 있도록 필드 추가
- 기본적으로 `Boolean isRead = false`인 값을 알림 조회 후 `true`로 변경하는 메서드 추가

### 알림 읽음 상태로 변경 기능 구현

![스크린샷 2025-01-17 오후 5 54 05](https://github.com/user-attachments/assets/bbe2b983-f40c-412a-baf2-d3ac8ad1b63b)

- "해당 알림이 존재하는지 / 다른 회원의 알림은 아닌지" 검증한 후 알림 상태 읽음으로 변경

### 알림 페이징 조회 동적 쿼리로 변경

- 변경 전 서비스 로직

![스크린샷 2025-01-17 오후 5 57 08](https://github.com/user-attachments/assets/fdd8948f-9968-4683-a8be-a598a005a433)

- 변경 후 서비스 및 레포지토리 로직

![스크린샷 2025-01-17 오후 5 55 22](https://github.com/user-attachments/assets/1f654376-7b1b-41b5-8952-87d565938cf7)

![스크린샷 2025-01-17 오후 5 55 44](https://github.com/user-attachments/assets/52b6a624-1a6a-42e2-b854-e1e7df8c5da6)

- 3개의 레포지토리 메서드를 사용하여, 전체/메이트/굿즈 알림을 조회하던 로직을 QueryDSL을 통해 하나의 메서드로 통합

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?