### PR TITLE
MATE-159 : [FEAT] 회원정보 조회 및 팔로우 관련 응답 필드 수정

### DIFF
--- a/src/main/java/com/example/mate/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/mate/domain/member/controller/MemberController.java
@@ -64,8 +64,9 @@ public class MemberController {
     @Operation(summary = "다른 회원 프로필 조회", description = "다른 회원의 프로필 페이지를 조회합니다.")
     @GetMapping("/{memberId}")
     public ResponseEntity<ApiResponse<MemberProfileResponse>> findMemberInfo(
+            @Parameter(description = "회원 로그인 정보") @AuthenticationPrincipal AuthMember authMember,
             @Parameter(description = "회원 ID") @PathVariable Long memberId) {
-        return ResponseEntity.ok(ApiResponse.success(memberService.getMemberProfile(memberId)));
+        return ResponseEntity.ok(ApiResponse.success(memberService.getMemberProfile(memberId, authMember.getMemberId())));
     }
 
     @Operation(summary = "회원 내 정보 수정", description = "프로필 사진 및 회원 정보를 수정합니다.")

--- a/src/main/java/com/example/mate/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MemberProfileResponse.java
@@ -23,9 +23,10 @@ public class MemberProfileResponse {
     private Integer followerCount;
     private Integer reviewsCount;
     private Integer goodsSoldCount;
+    private Boolean isFollowing;
 
     public static MemberProfileResponse of(Member member, int followingCount, int followerCount,
-                                           int reviewsCount, int goodsSoldCount) {
+                                           int reviewsCount, int goodsSoldCount, boolean isFollowing) {
         return MemberProfileResponse.builder()
                 .nickname(member.getNickname())
                 .imageUrl(FileUtils.getThumbnailImageUrl(member.getImageUrl()))
@@ -36,6 +37,7 @@ public class MemberProfileResponse {
                 .followerCount(followerCount)
                 .reviewsCount(reviewsCount)
                 .goodsSoldCount(goodsSoldCount)
+                .isFollowing(isFollowing)
                 .build();
     }
 }

--- a/src/main/java/com/example/mate/domain/member/dto/response/MemberSummaryResponse.java
+++ b/src/main/java/com/example/mate/domain/member/dto/response/MemberSummaryResponse.java
@@ -1,5 +1,6 @@
 package com.example.mate.domain.member.dto.response;
 
+import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.file.FileUtils;
 import com.example.mate.domain.member.entity.Member;
 import lombok.AccessLevel;
@@ -15,12 +16,14 @@ public class MemberSummaryResponse {
     private Long memberId;
     private String nickname;
     private String imageUrl;
+    private String teamName;
 
     public static MemberSummaryResponse from(Member member) {
         return MemberSummaryResponse.builder()
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .imageUrl(FileUtils.getThumbnailImageUrl(member.getImageUrl()))
+                .teamName(TeamInfo.getById(member.getTeamId()).shortName)
                 .build();
     }
 }

--- a/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
@@ -60,14 +60,22 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
 
-    @Autowired private MockMvc mockMvc;
-    @Autowired private MemberRepository memberRepository;
-    @Autowired private GoodsPostRepository goodsPostRepository;
-    @Autowired private GoodsChatRoomRepository chatRoomRepository;
-    @Autowired private GoodsChatPartRepository chatPartRepository;
-    @Autowired private GoodsChatMessageRepository messageRepository;
-    @Autowired private ObjectMapper objectMapper;
-    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private GoodsPostRepository goodsPostRepository;
+    @Autowired
+    private GoodsChatRoomRepository chatRoomRepository;
+    @Autowired
+    private GoodsChatPartRepository chatPartRepository;
+    @Autowired
+    private GoodsChatMessageRepository messageRepository;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
 
     private Member seller;
@@ -115,12 +123,15 @@ public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
                 .andExpect(jsonPath("$.data.category").value(goodsPost.getCategory().getValue()))
                 .andExpect(jsonPath("$.data.price").value(goodsPost.getPrice()))
                 .andExpect(jsonPath("$.data.postStatus").value(goodsPost.getStatus().getValue()))
-                .andExpect(jsonPath("$.data.imageUrl").value(FileUtils.getThumbnailImageUrl(goodsPost.getGoodsPostImages().get(0).getImageUrl())))
+                .andExpect(jsonPath("$.data.imageUrl").value(
+                        FileUtils.getThumbnailImageUrl(goodsPost.getGoodsPostImages().get(0).getImageUrl())))
                 .andReturn()
                 .getResponse();
 
         result.setCharacterEncoding("UTF-8");
-        ApiResponse<GoodsChatRoomResponse> apiResponse = objectMapper.readValue(result.getContentAsString(), new TypeReference<>() {});
+        ApiResponse<GoodsChatRoomResponse> apiResponse = objectMapper.readValue(result.getContentAsString(),
+                new TypeReference<>() {
+                });
         GoodsChatRoomResponse actualResponse = apiResponse.getData();
 
         // then
@@ -179,7 +190,9 @@ public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
                 .getResponse();
 
         result.setCharacterEncoding("UTF-8");
-        ApiResponse<GoodsChatRoomResponse> apiResponse = objectMapper.readValue(result.getContentAsString(), new TypeReference<>() {});
+        ApiResponse<GoodsChatRoomResponse> apiResponse = objectMapper.readValue(result.getContentAsString(),
+                new TypeReference<>() {
+                });
         GoodsChatRoomResponse response = apiResponse.getData();
 
         // then
@@ -216,8 +229,10 @@ public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
                 .andExpect(jsonPath("$.data.content[0].opponentNickname").value(seller.getNickname()))
                 .andExpect(jsonPath("$.data.content[0].lastChatContent").value(chatRoom.getLastChatContent()))
                 .andExpect(jsonPath("$.data.content[0].placeName").value(goodsPost.getLocation().getPlaceName()))
-                .andExpect(jsonPath("$.data.content[0].goodsMainImageUrl").value(FileUtils.getThumbnailImageUrl(goodsPost.getMainImageUrl())))
-                .andExpect(jsonPath("$.data.content[0].opponentImageUrl").value(FileUtils.getThumbnailImageUrl(seller.getImageUrl())))
+                .andExpect(jsonPath("$.data.content[0].goodsMainImageUrl").value(
+                        FileUtils.getThumbnailImageUrl(goodsPost.getMainImageUrl())))
+                .andExpect(jsonPath("$.data.content[0].opponentImageUrl").value(
+                        FileUtils.getThumbnailImageUrl(seller.getImageUrl())))
                 .andReturn()
                 .getResponse();
     }
@@ -244,7 +259,9 @@ public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
                 .getResponse();
 
         response.setCharacterEncoding("UTF-8");
-        ApiResponse<PageResponse<GoodsChatMessageResponse>> apiResponse = objectMapper.readValue(response.getContentAsString(), new TypeReference<>() {});
+        ApiResponse<PageResponse<GoodsChatMessageResponse>> apiResponse = objectMapper.readValue(
+                response.getContentAsString(), new TypeReference<>() {
+                });
         List<GoodsChatMessageResponse> expectMessages = apiResponse.getData().getContent();
 
         // 실제 데이터 조회
@@ -281,7 +298,8 @@ public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
         GoodsChatRoom goodsChatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow();
         assertThat(goodsChatRoom.isRoomActive()).isFalse();
 
-        GoodsChatPart goodsChatPart = chatPartRepository.findById(new GoodsChatPartId(memberId, chatRoomId)).orElseThrow();
+        GoodsChatPart goodsChatPart = chatPartRepository.findById(new GoodsChatPartId(memberId, chatRoomId))
+                .orElseThrow();
         assertThat(goodsChatPart.getIsActive()).isFalse();
     }
 
@@ -329,7 +347,9 @@ public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
         response.setCharacterEncoding("UTF-8");
 
         // then
-        ApiResponse<List<MemberSummaryResponse>> apiResponse = objectMapper.readValue(response.getContentAsString(), new TypeReference<>() {});
+        ApiResponse<List<MemberSummaryResponse>> apiResponse = objectMapper.readValue(response.getContentAsString(),
+                new TypeReference<>() {
+                });
         List<MemberSummaryResponse> actualMembers = apiResponse.getData();
 
         // 실제 데이터 조회
@@ -344,7 +364,8 @@ public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
 
             assertThat(actualMember.getMemberId()).isEqualTo(expectedMember.getId());
             assertThat(actualMember.getNickname()).isEqualTo(expectedMember.getNickname());
-            assertThat(actualMember.getImageUrl()).isEqualTo(FileUtils.getThumbnailImageUrl(expectedMember.getImageUrl()));
+            assertThat(actualMember.getImageUrl()).isEqualTo(
+                    FileUtils.getThumbnailImageUrl(expectedMember.getImageUrl()));
         }
     }
 
@@ -363,12 +384,12 @@ public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
                 .getResponse();
         result.setCharacterEncoding("UTF-8");
 
-        ApiResponse<Void> apiResponse = objectMapper.readValue(result.getContentAsString(), new TypeReference<>() {});
+        ApiResponse<Void> apiResponse = objectMapper.readValue(result.getContentAsString(), new TypeReference<>() {
+        });
 
         // then
         assertThat(apiResponse.getCode()).isEqualTo(200);
         assertThat(apiResponse.getStatus()).isEqualTo("SUCCESS");
-
 
         GoodsPost completedPost = chatRoomRepository.findByChatRoomId(chatRoomId).orElseThrow().getGoodsPost();
         assertThat(completedPost.getStatus()).isEqualTo(Status.CLOSED);
@@ -390,6 +411,7 @@ public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
                 .gender(Gender.FEMALE)
                 .age(25)
                 .manner(0.3f)
+                .teamId(1L)
                 .build());
     }
 

--- a/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatServiceTest.java
@@ -87,6 +87,7 @@ class GoodsChatServiceTest {
                 .id(id)
                 .name(name)
                 .nickname(nickname)
+                .teamId(1L)
                 .build();
     }
 

--- a/src/test/java/com/example/mate/domain/mateChat/service/MateChatServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mateChat/service/MateChatServiceTest.java
@@ -252,6 +252,7 @@ class MateChatServiceTest {
                 .age(age)
                 .gender(gender)
                 .nickname("nickname" + id)
+                .teamId(1L)
                 .build();
     }
 

--- a/src/test/java/com/example/mate/domain/member/controller/FollowControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/FollowControllerTest.java
@@ -62,6 +62,7 @@ class FollowControllerTest {
                 .nickname("tester1")
                 .memberId(1L)
                 .imageUrl("tester1.png")
+                .teamName("KIA")
                 .build();
     }
 

--- a/src/test/java/com/example/mate/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/mate/domain/member/controller/MemberControllerTest.java
@@ -84,6 +84,7 @@ class MemberControllerTest {
                 .followerCount(20)
                 .reviewsCount(5)
                 .goodsSoldCount(15)
+                .isFollowing(false)
                 .build();
     }
 
@@ -250,10 +251,11 @@ class MemberControllerTest {
     @DisplayName("다른 회원 프로필 조회")
     void find_member_info_success() throws Exception {
         // given
-        Long memberId = 1L;
+        Long memberId = 2L;
+        Long loginId = 1L;
         MemberProfileResponse response = createMemberProfileResponse();
 
-        given(memberService.getMemberProfile(memberId)).willReturn(response);
+        given(memberService.getMemberProfile(memberId, loginId)).willReturn(response);
 
         // when & then
         mockMvc.perform(get("/api/members/{memberId}", memberId)

--- a/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
@@ -362,11 +362,12 @@ class MemberIntegrationTest {
 
     @Test
     @DisplayName("다른 회원 프로필 조회 성공")
+    @WithAuthMember(userId = "customUser", memberId = 1L)
     void find_member_info_success() throws Exception {
-        mockMvc.perform(get("/api/members/" + member.getId()))
+        mockMvc.perform(get("/api/members/" + member2.getId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.nickname").value("tester"))
+                .andExpect(jsonPath("$.data.nickname").value("tester2"))
                 .andExpect(jsonPath("$.data.imageUrl").value(FileUtils.getThumbnailImageUrl("default.jpg")))
                 .andExpect(jsonPath("$.data.manner").value(0.300F))
                 .andDo(print());

--- a/src/test/java/com/example/mate/domain/member/service/FollowServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/FollowServiceTest.java
@@ -271,7 +271,9 @@ class FollowServiceTest {
             assertThat(response.getTotalElements()).isEqualTo(2);
             assertThat(response.getContent()).hasSize(2);
             assertThat(response.getContent().get(0).getNickname()).isEqualTo("tester1");
+            assertThat(response.getContent().get(0).getTeamName()).isEqualTo("KIA");
             assertThat(response.getContent().get(1).getNickname()).isEqualTo("tester2");
+            assertThat(response.getContent().get(1).getTeamName()).isEqualTo("LG");
 
             verify(memberRepository, times(1)).findById(memberId);
             verify(followRepository, times(1))
@@ -325,7 +327,9 @@ class FollowServiceTest {
             assertThat(response.getTotalElements()).isEqualTo(2);
             assertThat(response.getContent()).hasSize(2);
             assertThat(response.getContent().get(0).getNickname()).isEqualTo("tester1");
+            assertThat(response.getContent().get(0).getTeamName()).isEqualTo("KIA");
             assertThat(response.getContent().get(1).getNickname()).isEqualTo("tester2");
+            assertThat(response.getContent().get(1).getTeamName()).isEqualTo("LG");
 
             verify(memberRepository, times(1)).findById(memberId);
             verify(followRepository, times(1))

--- a/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/mate/domain/member/service/MemberServiceTest.java
@@ -297,6 +297,7 @@ class MemberServiceTest {
         void get_member_profile_success() {
             // given
             Long memberId = 1L;
+            Long loginId = 2L;
             int followCount = 10;
             int followerCount = 20;
             int goodsReviewsCount = 7;
@@ -311,9 +312,10 @@ class MemberServiceTest {
             given(mateReviewRepository.countByRevieweeId(memberId)).willReturn(mateReviewsCount);
             given(goodsPostRepository.countGoodsPostsBySellerIdAndStatus(memberId, Status.CLOSED)).
                     willReturn(goodsSoldCount);
+            given(followRepository.existsByFollowerIdAndFollowingId(loginId, memberId)).willReturn(true);
 
             // when
-            MemberProfileResponse result = memberService.getMemberProfile(memberId);
+            MemberProfileResponse result = memberService.getMemberProfile(memberId, loginId);
 
             // then
             assertThat(result).isNotNull();
@@ -322,6 +324,7 @@ class MemberServiceTest {
             assertThat(result.getFollowerCount()).isEqualTo(followerCount);
             assertThat(result.getReviewsCount()).isEqualTo(reviewsCount);
             assertThat(result.getGoodsSoldCount()).isEqualTo(goodsSoldCount);
+            assertThat(result.getIsFollowing()).isEqualTo(true);
         }
 
         @Test
@@ -329,11 +332,12 @@ class MemberServiceTest {
         void get_member_profile_fail_member_id_not_found() {
             // given
             Long memberId = 1L;
+            Long loginId = 2L;
 
             given(memberRepository.findByIdAndNotDeleted(memberId)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> memberService.getMemberProfile(memberId))
+            assertThatThrownBy(() -> memberService.getMemberProfile(memberId, loginId))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.MEMBER_NOT_FOUND_BY_ID.getMessage());
         }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 다른 회원 프로필 조회 시 해당 회원에 대한 팔로잉 여부 필드 추가
- [x] 팔로잉/팔로워 리스트 조회 시 각 회원의 마이팀 필드 추가
- [x] 관련 테스트 코드 수정

## 💡 자세한 설명

### 다른 회원 프로필 조회 응답에 팔로잉 여부 확인

- 프론트엔드 요청으로 해당 회원에 대한 현재 팔로잉 여부 검증 필드 `Boolean isFollowing` 추가
- 해당 회원을 팔로우 중이면 `true`, 팔로우하고 있지 않으면 `false` 반환

### 회원 프로필에서 팔로잉/팔로워 리스트 조회 시 각 회원의 마이팀 이름 조회

- 반환 객체에 해당 회원의 마이팀 이름 `String teamName` 추가


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?