### PR TITLE
MATE-156 : [REFACTOR] 채팅내역 조회 기능을 No Offset 방식으로 변경

### DIFF
--- a/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/controller/GoodsChatRoomController.java
@@ -12,6 +12,7 @@ import com.example.mate.domain.member.dto.response.MemberSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -38,19 +39,19 @@ public class GoodsChatRoomController {
     public ResponseEntity<ApiResponse<GoodsChatRoomResponse>> createGoodsChatRoom(
             @AuthenticationPrincipal AuthMember member,
             @Parameter(description = "판매글 ID", required = true) @RequestParam Long goodsPostId
-            ) {
+    ) {
         GoodsChatRoomResponse response = goodsChatService.getOrCreateGoodsChatRoom(member.getMemberId(), goodsPostId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/{chatRoomId}/message")
     @Operation(summary = "굿즈거래 채팅방 메시지 조회", description = "지정된 채팅방의 메시지를 페이징 처리하여 조회합니다.")
-    public ResponseEntity<ApiResponse<PageResponse<GoodsChatMessageResponse>>> getGoodsChatRoomMessages(
+    public ResponseEntity<ApiResponse<List<GoodsChatMessageResponse>>> getGoodsChatRoomMessages(
             @AuthenticationPrincipal AuthMember member,
             @Parameter(description = "채팅방 ID", required = true) @PathVariable Long chatRoomId,
-            @Parameter(description = "페이징 정보") @ValidPageable(page = 1, size = 20) Pageable pageable
+            @Parameter(description = "마지막 채팅 메시지 전송 시간") @RequestParam(required = false) LocalDateTime lastSentAt
     ) {
-        PageResponse<GoodsChatMessageResponse> response = goodsChatService.getChatRoomMessages(chatRoomId, member.getMemberId(), pageable);
+        List<GoodsChatMessageResponse> response = goodsChatService.getChatRoomMessages(chatRoomId, member.getMemberId(), lastSentAt);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/example/mate/domain/goodsChat/document/GoodsChatMessage.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/document/GoodsChatMessage.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -16,6 +18,9 @@ import org.springframework.data.mongodb.core.mapping.Field;
 @Document(collection = "goods_chat_message")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@CompoundIndexes({
+        @CompoundIndex(name = "idx_chat_room_id_sent_at", def = "{ 'chat_room_id': 1, 'sent_at': -1 }")
+})
 public class GoodsChatMessage {
 
     @Id

--- a/src/main/java/com/example/mate/domain/goodsChat/dto/response/GoodsChatRoomResponse.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/dto/response/GoodsChatRoomResponse.java
@@ -1,10 +1,10 @@
 package com.example.mate.domain.goodsChat.dto.response;
 
-import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.constant.TeamInfo;
 import com.example.mate.domain.file.FileUtils;
-import com.example.mate.domain.goodsPost.entity.GoodsPost;
 import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
+import com.example.mate.domain.goodsPost.entity.GoodsPost;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -25,9 +25,9 @@ public class GoodsChatRoomResponse {
     private final String imageUrl;
     private final Long goodsSellerId;
 
-    private final PageResponse<GoodsChatMessageResponse> initialMessages;
+    private final List<GoodsChatMessageResponse> initialMessages;
 
-    public static GoodsChatRoomResponse of(GoodsChatRoom chatRoom, PageResponse<GoodsChatMessageResponse> initialMessages) {
+    public static GoodsChatRoomResponse of(GoodsChatRoom chatRoom, List<GoodsChatMessageResponse> initialMessages) {
         GoodsPost goodsPost = chatRoom.getGoodsPost();
         String mainImageUrl = goodsPost.getMainImageUrl();
         String teamName = getTeamName(goodsPost);

--- a/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepository.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepository.java
@@ -1,19 +1,14 @@
 package com.example.mate.domain.goodsChat.repository;
 
 import com.example.mate.domain.goodsChat.document.GoodsChatMessage;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
 
-public interface GoodsChatMessageRepository extends MongoRepository<GoodsChatMessage, String> {
+public interface GoodsChatMessageRepository
+        extends MongoRepository<GoodsChatMessage, String>, GoodsChatMessageRepositoryCustom {
 
     /**
-     * 특정 채팅방의 메시지를 페이징 처리하여 조회합니다.
-     * 메시지는 전송된 시간(sent_at) 기준으로 오름차순으로 정렬됩니다.
+     * 특정 채팅방에 속한 모든 메시지를 삭제합니다.
+     * @param chatRoomId 삭제할 채팅방 ID
      */
-    @Query(value = "{ 'chat_room_id': ?0 }", sort = "{ 'sent_at': -1 }")
-    Page<GoodsChatMessage> getChatMessages(Long chatRoomId, Pageable pageable);
-
     void deleteAllByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepositoryCustom.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.example.mate.domain.goodsChat.repository;
+
+import com.example.mate.domain.goodsChat.document.GoodsChatMessage;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface GoodsChatMessageRepositoryCustom {
+    List<GoodsChatMessage> getChatMessages(Long chatRoomId, LocalDateTime lastSentAt, int size);
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepositoryCustomImpl.java
@@ -4,7 +4,6 @@ import com.example.mate.domain.goodsChat.document.GoodsChatMessage;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -12,7 +11,6 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 @RequiredArgsConstructor
-@Slf4j
 public class GoodsChatMessageRepositoryCustomImpl implements GoodsChatMessageRepositoryCustom {
 
     private final MongoTemplate mongoTemplate;
@@ -38,9 +36,7 @@ public class GoodsChatMessageRepositoryCustomImpl implements GoodsChatMessageRep
     private Criteria createCriteria(Long chatRoomId, LocalDateTime lastSentAt) {
         Criteria criteria = Criteria.where("chat_room_id").is(chatRoomId);
 
-        log.info("last sent at : {}", lastSentAt);
-
-        // lastSentAt == null 일 경우, 최신 메시지 조회
+        // lastSentAt 가 null 일 경우, 최신 메시지 조회
         if (lastSentAt != null) {
             criteria = criteria.and("sent_at").lt(lastSentAt);
         }

--- a/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/repository/GoodsChatMessageRepositoryCustomImpl.java
@@ -1,0 +1,50 @@
+package com.example.mate.domain.goodsChat.repository;
+
+import com.example.mate.domain.goodsChat.document.GoodsChatMessage;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+@RequiredArgsConstructor
+@Slf4j
+public class GoodsChatMessageRepositoryCustomImpl implements GoodsChatMessageRepositoryCustom {
+
+    private final MongoTemplate mongoTemplate;
+
+    /**
+     * 주어진 chatRoomId의 메시지 중에서
+     * lastSentAt 보다 오래된 메시지를 최대 size 만큼 반환
+     * 메시지는 sent_at 기준으로 내림차순 정렬됩니다.
+     */
+    @Override
+    public List<GoodsChatMessage> getChatMessages(Long chatRoomId, LocalDateTime lastSentAt, int size) {
+        // 동적으로 조건 생성
+        Criteria criteria = createCriteria(chatRoomId, lastSentAt);
+
+        // Query 생성 및 조건 추가
+        Query query = new Query(criteria);
+        query.limit(size);
+        query.with(Sort.by(Direction.DESC, "sent_at"));
+
+        return mongoTemplate.find(query, GoodsChatMessage.class);
+    }
+
+    private Criteria createCriteria(Long chatRoomId, LocalDateTime lastSentAt) {
+        Criteria criteria = Criteria.where("chat_room_id").is(chatRoomId);
+
+        log.info("last sent at : {}", lastSentAt);
+
+        // lastSentAt == null 일 경우, 최신 메시지 조회
+        if (lastSentAt != null) {
+            criteria = criteria.and("sent_at").lt(lastSentAt);
+        }
+
+        return criteria;
+    }
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
@@ -28,6 +28,7 @@ import com.example.mate.domain.member.entity.Member;
 import com.example.mate.domain.member.repository.MemberRepository;
 import com.example.mate.domain.notification.entity.NotificationType;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -49,7 +50,7 @@ public class GoodsChatService {
     private final GoodsChatEventPublisher chatEventPublisher;
     private final GoodsPostEventPublisher notificationEventPublisher;
 
-    // 채팅방 생성 & 기존 채팅방 입장
+    // 판매글에서 채팅방 입장 - 채팅방 생성 or 기존 채팅방 입장
     public GoodsChatRoomResponse getOrCreateGoodsChatRoom(Long buyerId, Long goodsPostId) {
         // 구매자, 판매글, 판매자 조회 및 검증
         Member buyer = findMemberById(buyerId);
@@ -80,13 +81,14 @@ public class GoodsChatService {
 
     // 메시지 발신자 정보 조회 및 DTO 매핑
     private List<GoodsChatMessageResponse> mapMessagesToResponses(List<GoodsChatMessage> chatMessages) {
-        return chatMessages.stream()
-                .map(message -> {
-                    Long memberId = message.getMemberId();
-                    Member member = findMemberById(memberId);
-                    return GoodsChatMessageResponse.of(message, member);
-                })
-                .toList();
+        List<GoodsChatMessageResponse> goodsChatMessageResponses = new ArrayList<>();
+
+        for (GoodsChatMessage chatMessage : chatMessages) {
+            Long memberId = chatMessage.getMemberId();
+            Member member = findMemberById(memberId);
+            goodsChatMessageResponses.add(GoodsChatMessageResponse.of(chatMessage, member));
+        }
+        return goodsChatMessageResponses;
     }
 
     // 새 채팅방 생성
@@ -142,7 +144,7 @@ public class GoodsChatService {
                 .orElseThrow(() -> new CustomException(ErrorCode.GOODS_CHAT_OPPONENT_NOT_FOUND));
     }
 
-    // 채팅방 입장
+    // 채팅방 목록에서 채팅방 입장 - 기존 채팅방 입장
     @Transactional(readOnly = true)
     public GoodsChatRoomResponse getGoodsChatRoomInfo(Long memberId, Long chatRoomId) {
         validateMemberInChatRoom(memberId, chatRoomId);

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -13,6 +13,10 @@ spring:
         await-termination: true
         await-termination-period: 10s
 
+  data:
+    mongodb:
+      auto-index-creation: true
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html

--- a/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatServiceTest.java
@@ -161,12 +161,12 @@ class GoodsChatServiceTest {
             existingChatRoom.addChatParticipant(seller, Role.SELLER);
 
             GoodsChatMessage message = createMessage(existingChatRoom, "1", 0, "test Message", LocalDateTime.now());
-            PageImpl<GoodsChatMessage> goodsChatMessages = new PageImpl<>(List.of(message));
+            List<GoodsChatMessage> goodsChatMessages = List.of(message);
 
             when(memberRepository.findById(buyerId)).thenReturn(Optional.of(buyer));
             when(goodsPostRepository.findById(goodsPostId)).thenReturn(Optional.of(goodsPost));
             when(chatRoomRepository.findExistingChatRoom(goodsPostId, buyerId, Role.BUYER)).thenReturn(Optional.of(existingChatRoom));
-            when(messageRepository.getChatMessages(existingChatRoom.getId(), PageRequest.of(0, 20))).thenReturn(goodsChatMessages);
+            when(messageRepository.getChatMessages(existingChatRoom.getId(), null, 20)).thenReturn(goodsChatMessages);
 
             // when
             GoodsChatRoomResponse result = goodsChatService.getOrCreateGoodsChatRoom(buyerId, goodsPostId);
@@ -286,30 +286,28 @@ class GoodsChatServiceTest {
             chatRoom.addChatParticipant(member, Role.BUYER);
             chatRoom.addChatParticipant(member, Role.SELLER);
 
-            Pageable pageable = PageRequest.of(0, 10);
-
             GoodsChatMessage firstMessage = createMessage(chatRoom, "1", 0, "first message", LocalDateTime.now().minusMinutes(10));
             GoodsChatMessage secondMessage = createMessage(chatRoom, "2", 1, "second message", LocalDateTime.now());
 
-            Page<GoodsChatMessage> messagePage = new PageImpl<>(List.of(secondMessage, firstMessage));
+            List<GoodsChatMessage> messages = List.of(secondMessage, firstMessage);
 
             when(partRepository.existsById(goodsChatPartId)).thenReturn(true);
-            when(messageRepository.getChatMessages(chatRoomId, pageable)).thenReturn(messagePage);
+            when(messageRepository.getChatMessages(chatRoomId, null, 20)).thenReturn(messages);
             when(memberRepository.findById(2L)).thenReturn(Optional.of(member));
 
             // when
-            PageResponse<GoodsChatMessageResponse> result = goodsChatService.getChatRoomMessages(chatRoomId, memberId, pageable);
+            List<GoodsChatMessageResponse> result = goodsChatService.getChatRoomMessages(chatRoomId, memberId, null);
 
             // then
-            assertThat(result.getContent()).hasSize(2);
-            assertThat(result.getContent().get(0).getMessage()).isEqualTo(secondMessage.getContent());
-            assertThat(result.getContent().get(0).getChatMessageId()).isEqualTo(secondMessage.getId());
-            assertThat(result.getContent().get(0).getSenderId()).isEqualTo(memberId);
-            assertThat(result.getContent().get(1).getMessage()).isEqualTo(firstMessage.getContent());
-            assertThat(result.getContent().get(1).getChatMessageId()).isEqualTo(firstMessage.getId());
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getMessage()).isEqualTo(secondMessage.getContent());
+            assertThat(result.get(0).getChatMessageId()).isEqualTo(secondMessage.getId());
+            assertThat(result.get(0).getSenderId()).isEqualTo(memberId);
+            assertThat(result.get(1).getMessage()).isEqualTo(firstMessage.getContent());
+            assertThat(result.get(1).getChatMessageId()).isEqualTo(firstMessage.getId());
 
             verify(partRepository).existsById(goodsChatPartId);
-            verify(messageRepository).getChatMessages(chatRoomId, pageable);
+            verify(messageRepository).getChatMessages(chatRoomId, null, 20);
         }
 
         @Test
@@ -319,18 +317,17 @@ class GoodsChatServiceTest {
             Long chatRoomId = 1L;
             Long memberId = 2L;
             GoodsChatPartId goodsChatPartId = new GoodsChatPartId(memberId, chatRoomId);
-            Pageable pageable = PageRequest.of(0, 10);
 
             when(partRepository.existsById(goodsChatPartId)).thenReturn(false);
 
             // when
-            assertThatThrownBy(() -> goodsChatService.getChatRoomMessages(chatRoomId, memberId, pageable))
+            assertThatThrownBy(() -> goodsChatService.getChatRoomMessages(chatRoomId, memberId, null))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.GOODS_CHAT_NOT_FOUND_CHAT_PART.getMessage());
 
             // then
             verify(partRepository).existsById(goodsChatPartId);
-            verify(messageRepository, never()).getChatMessages(chatRoomId, pageable);
+            verify(messageRepository, never()).getChatMessages(chatRoomId, null, 20);
         }
     }
 
@@ -357,11 +354,11 @@ class GoodsChatServiceTest {
             GoodsChatMessage firstMessage = createMessage(chatRoom, "1", 0, "first message", LocalDateTime.now().minusMinutes(10));
             GoodsChatMessage secondMessage = createMessage(chatRoom, "2", 1, "second message", LocalDateTime.now());
 
-            Page<GoodsChatMessage> messages = new PageImpl<>(List.of(secondMessage, firstMessage));
+            List<GoodsChatMessage> messages = List.of(secondMessage, firstMessage);
 
             when(partRepository.existsById(goodsChatPartId)).thenReturn(true);
             when(chatRoomRepository.findByChatRoomId(chatRoomId)).thenReturn(Optional.of(chatRoom));
-            when(messageRepository.getChatMessages(chatRoomId, PageRequest.of(0, 20))).thenReturn(messages);
+            when(messageRepository.getChatMessages(chatRoomId, null, 20)).thenReturn(messages);
             when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
 
             // when
@@ -378,14 +375,14 @@ class GoodsChatServiceTest {
             assertThat(goodsChatRoomInfo.getChatRoomStatus()).isEqualTo(chatRoom.getIsActive().toString());
             assertThat(goodsChatRoomInfo.getImageUrl()).isEqualTo(FileUtils.getThumbnailImageUrl(goodsPost.getMainImageUrl()));
 
-            assertThat(goodsChatRoomInfo.getInitialMessages().getContent())
+            assertThat(goodsChatRoomInfo.getInitialMessages())
                     .hasSize(2)
                     .extracting(GoodsChatMessageResponse::getMessage)
                     .containsExactly("second message", "first message");
 
             verify(partRepository).existsById(goodsChatPartId);
             verify(chatRoomRepository).findByChatRoomId(chatRoomId);
-            verify(messageRepository).getChatMessages(chatRoomId, PageRequest.of(0, 20));
+            verify(messageRepository).getChatMessages(chatRoomId, null, 20);
         }
 
         @Test
@@ -409,7 +406,7 @@ class GoodsChatServiceTest {
             // then
             verify(partRepository).existsById(goodsChatPartId);
             verify(chatRoomRepository, never()).findByChatRoomId(chatRoomId);
-            verify(messageRepository, never()).getChatMessages(chatRoomId, PageRequest.of(0, 20));
+            verify(messageRepository, never()).getChatMessages(chatRoomId, null, 20);
         }
 
         @Test
@@ -433,7 +430,7 @@ class GoodsChatServiceTest {
             // then
             verify(partRepository).existsById(goodsChatPartId);
             verify(chatRoomRepository).findByChatRoomId(chatRoomId);
-            verify(messageRepository, never()).getChatMessages(chatRoomId, PageRequest.of(0, 20));
+            verify(messageRepository, never()).getChatMessages(chatRoomId, null, 20);
         }
     }
 
@@ -523,33 +520,32 @@ class GoodsChatServiceTest {
             Long chatRoomId = chatRoom.getId();
             Long buyerId = buyer.getId();
 
-            Pageable pageable = PageRequest.of(0, 20);
             GoodsChatPartId goodsChatPartId = new GoodsChatPartId(buyerId, chatRoomId);
 
             GoodsChatMessage firstMessage = createMessage(chatRoom, "1", 0, "First message", LocalDateTime.now().minusMinutes(10));
             GoodsChatMessage secondMessage = createMessage(chatRoom, "2", 1, "Second message", LocalDateTime.now());
 
-            Page<GoodsChatMessage> messagePage = new PageImpl<>(List.of(secondMessage, firstMessage), pageable, 2);
+            List<GoodsChatMessage> messages = List.of(secondMessage, firstMessage);
 
             when(partRepository.existsById(goodsChatPartId)).thenReturn(true);
-            when(messageRepository.getChatMessages(chatRoomId, pageable)).thenReturn(messagePage);
+            when(messageRepository.getChatMessages(chatRoomId, null, 20)).thenReturn(messages);
             when(memberRepository.findById(1L)).thenReturn(Optional.of(buyer));
             when(memberRepository.findById(2L)).thenReturn(Optional.of(seller));
 
             // when
-            PageResponse<GoodsChatMessageResponse> result = goodsChatService.getChatRoomMessages(chatRoomId, buyerId, pageable);
+            List<GoodsChatMessageResponse> result = goodsChatService.getChatRoomMessages(chatRoomId, buyerId, null);
 
             // then
-            assertThat(result.getContent()).hasSize(2);
-            assertThat(result.getContent().get(0).getMessage()).isEqualTo(secondMessage.getContent());
-            assertThat(result.getContent().get(0).getChatMessageId()).isEqualTo(secondMessage.getId());
-            assertThat(result.getContent().get(0).getSentAt()).isEqualTo(secondMessage.getSentAt());
-            assertThat(result.getContent().get(1).getMessage()).isEqualTo(firstMessage.getContent());
-            assertThat(result.getContent().get(1).getChatMessageId()).isEqualTo(firstMessage.getId());
-            assertThat(result.getContent().get(1).getSentAt()).isEqualTo(firstMessage.getSentAt());
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getMessage()).isEqualTo(secondMessage.getContent());
+            assertThat(result.get(0).getChatMessageId()).isEqualTo(secondMessage.getId());
+            assertThat(result.get(0).getSentAt()).isEqualTo(secondMessage.getSentAt());
+            assertThat(result.get(1).getMessage()).isEqualTo(firstMessage.getContent());
+            assertThat(result.get(1).getChatMessageId()).isEqualTo(firstMessage.getId());
+            assertThat(result.get(1).getSentAt()).isEqualTo(firstMessage.getSentAt());
 
             verify(partRepository).existsById(goodsChatPartId);
-            verify(messageRepository).getChatMessages(chatRoomId, pageable);
+            verify(messageRepository).getChatMessages(chatRoomId, null, 20);
         }
 
         @Test
@@ -565,19 +561,18 @@ class GoodsChatServiceTest {
             Long chatRoomId = chatRoom.getId();
             Long buyerId = buyer.getId();
 
-            Pageable pageable = PageRequest.of(0, 20);
             GoodsChatPartId goodsChatPartId = new GoodsChatPartId(buyerId, chatRoomId);
 
             when(partRepository.existsById(goodsChatPartId)).thenReturn(false);
 
             // when
-            assertThatThrownBy(() -> goodsChatService.getChatRoomMessages(chatRoomId, buyerId, pageable))
+            assertThatThrownBy(() -> goodsChatService.getChatRoomMessages(chatRoomId, buyerId, null))
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorCode.GOODS_CHAT_NOT_FOUND_CHAT_PART.getMessage());
 
             // then
             verify(partRepository).existsById(goodsChatPartId);
-            verify(messageRepository, never()).getChatMessages(anyLong(), any(Pageable.class));
+            verify(messageRepository, never()).getChatMessages(chatRoomId, null, 20);
         }
 
         @Nested


### PR DESCRIPTION
## 💡 작업 내용

- [x] GoodsChatMessage 인덱스 설정 추가
- [x] 커스텀 레포지토리 및 동적 쿼리 구현 (채팅내역 조회)
- [x] Controller, Service 레이어 코드 리팩토링, 관련 DTO 필드 수정
- [x] Postman API 테스트
- [x] 테스트 코드 수정

## 💡 자세한 설명

> 다음 작업으로는 채팅내역 조회에 레디스 캐싱 적용을 할 것 같습니당

### 페이지 반환의 문제점
채팅 서비스의 기능 중 채팅 내역 조회는 무한 스크롤 방식으로 구현되어 있어 사용자가 데이터를 계속해서 요청합니다. 이때마다 페이지 객체를 반환하는 구조에 성능적인 문제점이 있습니다.

첫째로 채팅 내역을 페이지로 반환할 때마다 발생하는 불필요한 카운트 쿼리는 성능은 성능이 매우 떨어지게 됩니다 (특히 데이터가 많을 때). 

둘째로 Redis 캐싱 기능을 도입할 경우, 인메모리 Redis DB에 최신 채팅 데이터가 존재하더라도 페이지 정보를 반환해야 하므로 데이터베이스를 다시 조회해서 count 쿼리를 날려야하는 문제가 있습니다.

### No Offset 방식 동작 원리
No Offset 방식은 요청 파라미터로 페이지 정보가 아닌 마지막 데이터의 정렬 기준 값을 사용합니다. 채팅 내역 조회에서는 데이터의 전송 시간을 기준으로 삼아 lastSentAt 값을 요청받습니다.

동작 원리 :

1. 클라이언트에서 `lastSentAt` 값을 요청합니다. 이는 사용자가 마지막으로 조회한 메시지의 전송 시간을 나타냅니다.
2. 서버는 `lastSentAt`보다 더 오래된 데이터들을 기준으로 `n개`의 데이터를 최신순으로 반환합니다.
3. 만약 사용자가 처음으로 채팅 데이터를 조회할 경우, 클라이언트에서 `lastSentAt` 값을 `null`로 전송하면, 서버는 가장 최신의 데이터를 `n개` 반환합니다.

### 인덱스 설정
복합 인덱스로 `chatRoomId`, `sentAt(내림차순)` 을 설정했습니다. MongoDB에는 채팅 데이터를 채팅방 ID 기준으로 오름차순으로 정렬하고, 채팅방 ID가 같은 채팅 데이터는 `sentAt`을 기준으로 내림차순으로 정렬하게 됩니다.

#### MongoDB 실행계획 확인

```shell
db.goods_chat_message.find(
    {
        chat_room_id: 1,
        sent_at: { $lt: ISODate("2025-01-21T15:49:58.32Z") }
    }
).sort(
    { sent_at: -1 }
).limit(20).explain("executionStats")
```

인덱스 설정 후, 위 채팅내역 조회 쿼리를 MongoDB shell을 통해 조회하면 해당 쿼리에 대한 실행계획을 알 수 있습니다.

#### 인덱스 추가 전
```shell
 winningPlan: {
      isCached: false,
      stage: 'SORT',
      sortPattern: {
        sent_at: -1
      },
      memLimit: 104857600,
      limitAmount: 20,
      type: 'simple',
      inputStage: {
        stage: 'COLLSCAN',     // 풀 컬렉션 스캔
        filter: {
          '$and': [
            {
              chat_room_id: {
                '$eq': 1
              }
            },
            {
              sent_at: {
                '$lt': 2025-01-21T15:49:58.320Z
              }
            }
          ]
        },
        direction: 'forward'
      }
    },

...

executionStats: {
    executionSuccess: true,
    nReturned: 20,
    executionTimeMillis: 57,            // 쿼리 조회 시간 57ms
    totalKeysExamined: 0,
    totalDocsExamined: 50000,      // 조회한 데이터 수 : 50000개
```


#### 복합 인덱스 추가 후

```shell
winningPlan: {
      isCached: false,
      stage: 'LIMIT',
      limitAmount: 20,
      inputStage: {
        stage: 'FETCH',
        inputStage: {
          stage: 'IXSCAN',         // 인덱스 스캔
          keyPattern: {
            chat_room_id: 1,
            sent_at: -1
          },
          indexName: 'idx_chat_room_id_sent_at',  // 복합 인덱스 사용
          isMultiKey: false,
          multiKeyPaths: {
            chat_room_id: [],
            sent_at: []
          },
          isUnique: false,
          isSparse: false,
          isPartial: false,
          indexVersion: 2,
          direction: 'forward',
          indexBounds: {
            chat_room_id: [
              '[1, 1]'
            ],
            sent_at: [
              '(new Date(1737474598320), new Date(-9223372036854775808)]'
            ]
          }
        }
      }
    },
...

 executionStats: {
    executionSuccess: true,
    nReturned: 20,
    executionTimeMillis: 2,        // 쿼리 조회 시간 2ms
    totalKeysExamined: 20,
    totalDocsExamined: 20,       // 조회한 문서 수 : 20개
```

5만개 채팅 데이터를 조회할 때 조회 속도는 **57ms -> 2ms 로 25배 이상** 빨라진 것을 알 수 있습니다.

`No Offset` 에 관한 더 자세한 내용은 참고 자료를 보시면 좋을 것 같습니당. 

## 📗 참고 자료 (선택)
[인프런CTO 향로님 블로그](https://jojoldu.tistory.com/528)
[offset 사용 spring code](https://hungseong.tistory.com/75)


## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?