### PR TITLE
MATE-161 : [REFACTOR] MongoDB 인덱스 자동 생성 설정 삭제

### DIFF
--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -13,10 +13,6 @@ spring:
         await-termination: true
         await-termination-period: 10s
 
-  data:
-    mongodb:
-      auto-index-creation: true
-
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
@@ -25,8 +21,6 @@ springdoc:
   packages-to-scan: com.example.mate
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
-
-
 
 oauth:
   naver_client_id: ${NAVER_CLIENT_ID}


### PR DESCRIPTION
## 💡 작업 내용

- [x] GitHub Actions 배포 문제 해결 
- [x] MongoDB 인덱스 자동 생성 설정 삭제

## 💡 자세한 설명
application-common.yml 에 자동 인덱스 생성 설정을 추가하고 나니 테스트 코드를 실행할 때, MongoTimeoutException 이 발생하여 Github Actions 배포를 실패하는 문제가 있었습니니다.

원인은 **bwaldvogel** 라이브러리의 내장 몽고 디비가 인덱스 생성을 지원하지 않는 것 같습니다. 그래서 application-dev.yml 로 설정을 옮기고 common 에서는 설정을 삭제했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?