### PR TITLE
MATE-158 : [FEAT] 메이트 채팅내역 조회 기능을 No Offset 방식으로 변경 

### DIFF
--- a/src/main/java/com/example/mate/domain/mateChat/controller/MateChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/mateChat/controller/MateChatRoomController.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -59,12 +60,12 @@ public class MateChatRoomController {
 
     @GetMapping("/{chatroomId}/messages")
     @Operation(summary = "채팅방 메세지 조회", description = "메시지 내역을 조회합니다.")
-    public ResponseEntity<ApiResponse<PageResponse<MateChatMessageResponse>>> getChatMessages(
+    public ResponseEntity<ApiResponse<List<MateChatMessageResponse>>> getChatMessages(
             @Parameter(description = "채팅방 ID") @PathVariable Long chatroomId,
             @AuthenticationPrincipal AuthMember member,
-            @Parameter(description = "페이지 정보") @ValidPageable(page = 1) Pageable pageable
-    ) {
-        PageResponse<MateChatMessageResponse> messages = chatRoomService.getChatMessages(chatroomId, member.getMemberId(), pageable);
+            @Parameter(description = "마지막 채팅 보낸 시간") @RequestParam LocalDateTime lastSentAt
+            ) {
+        List<MateChatMessageResponse> messages = chatRoomService.getChatMessages(chatroomId, member.getMemberId(), lastSentAt);
         return ResponseEntity.ok(ApiResponse.success(messages));
     }
 

--- a/src/main/java/com/example/mate/domain/mateChat/controller/MateChatRoomController.java
+++ b/src/main/java/com/example/mate/domain/mateChat/controller/MateChatRoomController.java
@@ -63,7 +63,7 @@ public class MateChatRoomController {
     public ResponseEntity<ApiResponse<List<MateChatMessageResponse>>> getChatMessages(
             @Parameter(description = "채팅방 ID") @PathVariable Long chatroomId,
             @AuthenticationPrincipal AuthMember member,
-            @Parameter(description = "마지막 채팅 보낸 시간") @RequestParam LocalDateTime lastSentAt
+            @Parameter(description = "마지막 채팅 보낸 시간") @RequestParam(required = false) LocalDateTime lastSentAt
             ) {
         List<MateChatMessageResponse> messages = chatRoomService.getChatMessages(chatroomId, member.getMemberId(), lastSentAt);
         return ResponseEntity.ok(ApiResponse.success(messages));

--- a/src/main/java/com/example/mate/domain/mateChat/document/MateChatMessage.java
+++ b/src/main/java/com/example/mate/domain/mateChat/document/MateChatMessage.java
@@ -4,7 +4,10 @@ import com.example.mate.common.BaseTimeEntity;
 import com.example.mate.domain.mateChat.message.MessageType;
 import jakarta.persistence.Id;
 import lombok.*;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.LocalDateTime;
 
@@ -13,13 +16,27 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
+@CompoundIndexes({
+        @CompoundIndex(name = "idx_chat_room_id_sent_at", def = "{ 'chat_room_id': 1, 'sent_at': -1 }")
+}
+)
 public class MateChatMessage extends BaseTimeEntity {
     @Id
     private String id;
 
+    @Field(name = "room_id")
     private Long roomId;
+
+    @Field(name = "sender_id")
     private Long senderId;
-    private MessageType type;
+
+    @Field(name = "content")
     private String content;
+
+    @Field(name = "send_time")
     private LocalDateTime sendTime;
+
+
+    @Field(name = "type")
+    private MessageType type;
 }

--- a/src/main/java/com/example/mate/domain/mateChat/document/MateChatMessage.java
+++ b/src/main/java/com/example/mate/domain/mateChat/document/MateChatMessage.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @CompoundIndexes({
-        @CompoundIndex(name = "idx_chat_room_id_sent_at", def = "{ 'chat_room_id': 1, 'sent_at': -1 }")
+        @CompoundIndex(name = "idx_chat_room_id_sent_at", def = "{ 'room_id': 1, 'send_time': -1 }")
 }
 )
 public class MateChatMessage extends BaseTimeEntity {

--- a/src/main/java/com/example/mate/domain/mateChat/dto/response/MateChatRoomResponse.java
+++ b/src/main/java/com/example/mate/domain/mateChat/dto/response/MateChatRoomResponse.java
@@ -1,10 +1,11 @@
 package com.example.mate.domain.mateChat.dto.response;
 
-import com.example.mate.common.response.PageResponse;
 import com.example.mate.domain.mateChat.entity.MateChatRoom;
 import com.example.mate.domain.mateChat.entity.MateChatRoomMember;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -17,12 +18,12 @@ public class MateChatRoomResponse {
     private Boolean isMessageable;
     private Boolean isAuthorLeft;
     private Boolean isAuthor;
-    private PageResponse<MateChatMessageResponse> initialMessages;
+    private List<MateChatMessageResponse> initialMessages;
 
     public static MateChatRoomResponse from(
             MateChatRoom chatRoom,
             MateChatRoomMember member,
-            PageResponse<MateChatMessageResponse> messages) {
+            List<MateChatMessageResponse> messages) {
         return MateChatRoomResponse.builder()
                 .roomId(chatRoom.getId())
                 .matePostId(chatRoom.getMatePost().getId())

--- a/src/main/java/com/example/mate/domain/mateChat/repository/MateChatMessageRepository.java
+++ b/src/main/java/com/example/mate/domain/mateChat/repository/MateChatMessageRepository.java
@@ -1,19 +1,8 @@
 package com.example.mate.domain.mateChat.repository;
 
 import com.example.mate.domain.mateChat.document.MateChatMessage;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
 
-import java.time.LocalDateTime;
+public interface MateChatMessageRepository extends MongoRepository<MateChatMessage, String>, MateChatMessageRepositoryCustom {
 
-public interface MateChatMessageRepository extends MongoRepository<MateChatMessage, String> {
-    // 채팅방의 특정 시간 이후 메시지 조회 (페이징)
-    @Query("{ 'roomId': ?0, 'sendTime': { $gt: ?1 } }")
-    Page<MateChatMessage> findByRoomIdAndSendTimeAfter(
-            Long roomId,
-            LocalDateTime enterTime,
-            Pageable pageable
-    );
 }

--- a/src/main/java/com/example/mate/domain/mateChat/repository/MateChatMessageRepositoryCustom.java
+++ b/src/main/java/com/example/mate/domain/mateChat/repository/MateChatMessageRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.example.mate.domain.mateChat.repository;
+
+import com.example.mate.domain.mateChat.document.MateChatMessage;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface MateChatMessageRepositoryCustom {
+
+    // 마지막 입장시간 이후 메세지 조회
+    List<MateChatMessage> getChatMessages(Long roomId, LocalDateTime lastEnterTime, LocalDateTime lastSentAt);
+}

--- a/src/main/java/com/example/mate/domain/mateChat/repository/MateChatMessageRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/mateChat/repository/MateChatMessageRepositoryCustomImpl.java
@@ -15,7 +15,6 @@ public class MateChatMessageRepositoryCustomImpl implements MateChatMessageRepos
 
     private final MongoTemplate mongoTemplate;
 
-
     /**
      * 주어진 chatRoomId의 메시지 중에서
      * lastEnterTime 이후에 보내졌으며

--- a/src/main/java/com/example/mate/domain/mateChat/repository/MateChatMessageRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/mateChat/repository/MateChatMessageRepositoryCustomImpl.java
@@ -36,11 +36,14 @@ public class MateChatMessageRepositoryCustomImpl implements MateChatMessageRepos
 
     private Criteria createCriteria(Long roomId, LocalDateTime lastEnterTime, LocalDateTime lastSentAt) {
         Criteria criteria = Criteria.where("room_id").is(roomId);
-        criteria.and("send_time").gt(lastEnterTime);
 
-        // lastSentAt 이 null 일 경우, 최신 메시지 조회
         if (lastSentAt != null) {
-            criteria = criteria.and("send_time").lt(lastSentAt);
+            criteria.andOperator(
+                    Criteria.where("send_time").gt(lastEnterTime),
+                    Criteria.where("send_time").lt(lastSentAt)
+            );
+        } else {
+            criteria.and("send_time").gt(lastEnterTime);
         }
 
         return criteria;

--- a/src/main/java/com/example/mate/domain/mateChat/repository/MateChatMessageRepositoryCustomImpl.java
+++ b/src/main/java/com/example/mate/domain/mateChat/repository/MateChatMessageRepositoryCustomImpl.java
@@ -1,0 +1,48 @@
+package com.example.mate.domain.mateChat.repository;
+
+import com.example.mate.domain.mateChat.document.MateChatMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MateChatMessageRepositoryCustomImpl implements MateChatMessageRepositoryCustom {
+
+    private final MongoTemplate mongoTemplate;
+
+
+    /**
+     * 주어진 chatRoomId의 메시지 중에서
+     * lastEnterTime 이후에 보내졌으며
+     * lastSentAt 보다 오래된 메시지를 최대 20개 반환
+     * 메시지는 send_time 기준으로 내림차순 정렬됩니다.
+     */
+    @Override
+    public List<MateChatMessage> getChatMessages(Long roomId, LocalDateTime lastEnterTime, LocalDateTime lastSentAt) {
+        // 동적으로 조건 생성
+        Criteria criteria = createCriteria(roomId, lastEnterTime, lastSentAt);
+
+        Query query = new Query(criteria);
+        query.limit(20);
+        query.with(Sort.by(Sort.Direction.DESC, "send_time"));
+
+        return mongoTemplate.find(query, MateChatMessage.class);
+    }
+
+    private Criteria createCriteria(Long roomId, LocalDateTime lastEnterTime, LocalDateTime lastSentAt) {
+        Criteria criteria = Criteria.where("room_id").is(roomId);
+        criteria.and("send_time").gt(lastEnterTime);
+
+        // lastSentAt 이 null 일 경우, 최신 메시지 조회
+        if (lastSentAt != null) {
+            criteria = criteria.and("send_time").lt(lastSentAt);
+        }
+
+        return criteria;
+    }
+}

--- a/src/test/java/com/example/mate/domain/mateChat/controller/MateChatControllerTest.java
+++ b/src/test/java/com/example/mate/domain/mateChat/controller/MateChatControllerTest.java
@@ -118,20 +118,17 @@ public class MateChatControllerTest {
     @DisplayName("메이트 채팅방 메시지 조회 성공")
     void getChatMessages() throws Exception {
         // given
-        List<MateChatMessageResponse> pageResponse = createMockChatMessagesResponse();
+        List<MateChatMessageResponse> messageList = createMockChatMessagesResponse();
         given(chatRoomService.getChatMessages(anyLong(), any(), any()))
-                .willReturn(pageResponse);
+                .willReturn(messageList);
 
         // when & then
         mockMvc.perform(get("/api/mates/chat/{chatroomId}/messages", 1L)
-                        .param("page", "0")
-                        .param("size", "20"))
+                        )
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.content[0].messageId").value(1L))
-                .andExpect(jsonPath("$.data.totalPages").value(1))
                 .andExpect(jsonPath("$.timestamp").isNotEmpty());
 
         verify(chatRoomService).getChatMessages(anyLong(), any(), any());

--- a/src/test/java/com/example/mate/domain/mateChat/controller/MateChatControllerTest.java
+++ b/src/test/java/com/example/mate/domain/mateChat/controller/MateChatControllerTest.java
@@ -118,8 +118,8 @@ public class MateChatControllerTest {
     @DisplayName("메이트 채팅방 메시지 조회 성공")
     void getChatMessages() throws Exception {
         // given
-        PageResponse<MateChatMessageResponse> pageResponse = createMockChatMessagesResponse();
-        given(chatRoomService.getChatMessages(anyLong(), anyLong(), any(Pageable.class)))
+        List<MateChatMessageResponse> pageResponse = createMockChatMessagesResponse();
+        given(chatRoomService.getChatMessages(anyLong(), any(), any()))
                 .willReturn(pageResponse);
 
         // when & then
@@ -134,7 +134,7 @@ public class MateChatControllerTest {
                 .andExpect(jsonPath("$.data.totalPages").value(1))
                 .andExpect(jsonPath("$.timestamp").isNotEmpty());
 
-        verify(chatRoomService).getChatMessages(anyLong(), anyLong(), any(Pageable.class));
+        verify(chatRoomService).getChatMessages(anyLong(), any(), any());
     }
 
     @Test
@@ -196,7 +196,7 @@ public class MateChatControllerTest {
                 .build();
     }
 
-    private PageResponse<MateChatMessageResponse> createMockChatMessagesResponse() {
+    private List<MateChatMessageResponse> createMockChatMessagesResponse() {
         MateChatMessageResponse message = MateChatMessageResponse.builder()
                 .messageId("1")
                 .roomId(1L)
@@ -208,14 +208,7 @@ public class MateChatControllerTest {
                 .sendTime(LocalDateTime.now())
                 .build();
 
-        return PageResponse.<MateChatMessageResponse>builder()
-                .content(List.of(message))
-                .totalPages(1)
-                .totalElements(1)
-                .hasNext(false)
-                .pageNumber(0)
-                .pageSize(20)
-                .build();
+        return List.of(message);
     }
 
     private List<MemberSummaryResponse> createMockMemberResponses() {

--- a/src/test/java/com/example/mate/domain/mateChat/service/MateChatServiceTest.java
+++ b/src/test/java/com/example/mate/domain/mateChat/service/MateChatServiceTest.java
@@ -81,8 +81,8 @@ class MateChatServiceTest {
 
         when(chatRoomMemberRepository.countByChatRoomIdAndIsActiveTrue(any()))
                 .thenReturn(2);
-        when(chatMessageRepository.findByRoomIdAndSendTimeAfter(any(), any(), any()))
-                .thenReturn(Page.empty());
+        when(chatMessageRepository.getChatMessages(any(), any(), any()))
+                .thenReturn(List.of());
 
         // When
         MateChatRoomResponse response = chatRoomService.createOrJoinChatRoomFromPost(


### PR DESCRIPTION
## 💡 작업 내용

- [x] 메이트 메세지 도큐먼트에 복합 인덱스 설정
- [x] 메이트 채팅내역 조회 기능 No Offset 방식으로 변경
- [x] 그에 따른 테스트 코드 수정

## 💡 자세한 설명
메이트 채팅내역 조회 기능 No Offset 방식으로 변경
![image](https://github.com/user-attachments/assets/d0367370-8434-467e-bd72-3dd8f8f78a76)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?