### PR TITLE
MATE-160 : [FEAT] Redis를 활용한 채팅 메시지 캐싱 기능 구현

### DIFF
--- a/src/main/java/com/example/mate/common/config/RedisConfig.java
+++ b/src/main/java/com/example/mate/common/config/RedisConfig.java
@@ -1,0 +1,49 @@
+package com.example.mate.common.config;
+
+import com.example.mate.domain.goodsChat.document.GoodsChatMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, String> jwtTokenRedisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, GoodsChatMessage> goodsChatCacheRedisTemplate() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
+        GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisTemplate<String, GoodsChatMessage> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(genericJackson2JsonRedisSerializer);
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatCacheManager.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatCacheManager.java
@@ -1,0 +1,78 @@
+package com.example.mate.domain.goodsChat.service;
+
+import com.example.mate.domain.goodsChat.document.GoodsChatMessage;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GoodsChatCacheManager {
+
+    private final RedisTemplate<String, GoodsChatMessage> redisTemplate;
+
+    private static final String CACHE_KEY_FORMAT = "goods_chat_message::%d";
+    private static final long DEFAULT_TTL_SECONDS = 3600;
+
+    public GoodsChatCacheManager(
+            @Qualifier("goodsChatCacheRedisTemplate") RedisTemplate<String, GoodsChatMessage> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // Redis Sorted Set 에 메시지를 저장
+    public void storeMessageInCache(Long chatRoomId, GoodsChatMessage message) {
+        String cacheKey = formatCacheKey(chatRoomId);
+        Double score = convertToScore(message.getSentAt());
+        redisTemplate.opsForZSet().add(cacheKey, message, score);
+        setTTL(cacheKey);
+    }
+
+    // Redis Sorted Set 에서 lastSentAt 이전의 메시지 size 만큼 조회
+    public List<GoodsChatMessage> fetchMessagesFromCache(Long chatRoomId, LocalDateTime lastSentAt, int size) {
+        String cacheKey = formatCacheKey(chatRoomId);
+        Set<GoodsChatMessage> messages;
+
+        // lastSentAt이 null 인 경우, 가장 최근 메시지 조회
+        if (lastSentAt == null) {
+             messages = redisTemplate.opsForZSet().reverseRange(cacheKey, 0, size - 1);
+        } else {
+            Double score = convertToScore(lastSentAt);
+            messages = redisTemplate.opsForZSet().rangeByScore(cacheKey, Double.NEGATIVE_INFINITY, score, 1, 20);
+        }
+        return new ArrayList<>(messages);
+    }
+
+    // Redis Sorted Set 에 메시지 List 저장
+    public void storeMessagesInCache(Long chatRoomId, List<GoodsChatMessage> messages) {
+        for (GoodsChatMessage message : messages) {
+            String cacheKey = formatCacheKey(chatRoomId);
+            Double score = convertToScore(message.getSentAt());
+            redisTemplate.opsForZSet().add(cacheKey, message, score);
+        }
+        setTTL(formatCacheKey(chatRoomId));
+    }
+
+    // Redis Sorted Set 에서 모든 메시지를 삭제
+    public void evictMessagesFromCache(Long chatRoomId) {
+        String cacheKey = formatCacheKey(chatRoomId);
+        redisTemplate.opsForZSet().removeRange(cacheKey, 0, -1);
+    }
+
+    // TTL 설정 - 1시간
+    private void setTTL(String cacheKey) {
+        redisTemplate.expire(cacheKey, DEFAULT_TTL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private String formatCacheKey(Long chatRoomId) {
+        return String.format(CACHE_KEY_FORMAT, chatRoomId);
+    }
+
+    private Double convertToScore(LocalDateTime sentAt) {
+        return (double) sentAt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    }
+}

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageService.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageService.java
@@ -29,9 +29,7 @@ public class GoodsChatMessageService {
     private final GoodsChatCacheManager goodsChatCacheManager;
     private final SimpMessagingTemplate messagingTemplate;
 
-
     private static final String GOODS_CHAT_SUBSCRIBE_PATH = "/sub/chat/goods/";
-
     private static final String MEMBER_ENTER_MESSAGE = "님이 대화를 시작했습니다.";
     private static final String MEMBER_LEAVE_MESSAGE = "님이 대화를 떠났습니다.";
     private static final String MEMBER_TRANSACTION_MESSAGE = "님이 거래를 완료했습니다. 상품에 대한 거래후기를 남겨주세요!";

--- a/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
+++ b/src/main/java/com/example/mate/domain/goodsChat/service/GoodsChatService.java
@@ -96,11 +96,11 @@ public class GoodsChatService {
             lastSentAt = chatMessages.get(chatMessages.size() - 1).getSentAt();
 
             // 3-2. 부족한 개수만큼 DB 에서 조회 후 추가
-            List<GoodsChatMessage> remainMessages = messageRepository.getChatMessages(chatRoomId, lastSentAt, size - chatMessages.size());
-            chatMessages.addAll(remainMessages);
+            List<GoodsChatMessage> additionalMessages = messageRepository.getChatMessages(chatRoomId, lastSentAt, size - chatMessages.size());
+            chatMessages.addAll(additionalMessages);
 
             // 3-3. redis 저장
-            goodsChatCacheManager.storeMessagesInCache(chatRoomId, remainMessages);
+            goodsChatCacheManager.storeMessagesInCache(chatRoomId, additionalMessages);
         }
         return chatMessages;
     }

--- a/src/main/java/com/example/mate/domain/member/service/LogoutRedisService.java
+++ b/src/main/java/com/example/mate/domain/member/service/LogoutRedisService.java
@@ -3,7 +3,7 @@ package com.example.mate.domain.member.service;
 import com.example.mate.common.error.CustomException;
 import com.example.mate.common.error.ErrorCode;
 import com.example.mate.common.security.util.JwtUtil;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -13,11 +13,18 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Service
-@RequiredArgsConstructor
 public class LogoutRedisService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final JwtUtil jwtUtil;
+
+    public LogoutRedisService(
+            @Qualifier("jwtTokenRedisTemplate") RedisTemplate<String, String> redisTemplate,
+            JwtUtil jwtUtil
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.jwtUtil = jwtUtil;
+    }
 
     // 로그아웃 시 액세스 토큰의 남은 시간만큼 블랙리스트에 추가
     public void addTokenToBlacklist(String authorizationHeader) {

--- a/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/integration/GoodsChatIntegrationTest.java
@@ -23,6 +23,7 @@ import com.example.mate.domain.goodsChat.entity.GoodsChatRoom;
 import com.example.mate.domain.goodsChat.repository.GoodsChatMessageRepository;
 import com.example.mate.domain.goodsChat.repository.GoodsChatPartRepository;
 import com.example.mate.domain.goodsChat.repository.GoodsChatRoomRepository;
+import com.example.mate.domain.goodsChat.service.GoodsChatCacheManager;
 import com.example.mate.domain.goodsPost.dto.response.LocationInfo;
 import com.example.mate.domain.goodsPost.entity.Category;
 import com.example.mate.domain.goodsPost.entity.GoodsPost;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -65,7 +67,7 @@ public class GoodsChatIntegrationTest extends AcceptanceTestWithMongo {
     @Autowired private GoodsChatMessageRepository messageRepository;
     @Autowired private ObjectMapper objectMapper;
     @Autowired private JdbcTemplate jdbcTemplate;
-
+    @MockBean private GoodsChatCacheManager goodsChatCacheManager;
 
     private Member seller;
     private Member buyer;

--- a/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatCacheManagerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatCacheManagerTest.java
@@ -93,7 +93,7 @@ public class GoodsChatCacheManagerTest {
         Double score = (double) lastSentAt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
 
         Set<GoodsChatMessage> mockMessages = new LinkedHashSet<>(Arrays.asList(message2, message1));
-        when(zSetOperations.rangeByScore(eq(cacheKey), eq(Double.NEGATIVE_INFINITY), eq(score), eq(1L), eq(20L)))
+        when(zSetOperations.reverseRangeByScore(eq(cacheKey), eq(Double.NEGATIVE_INFINITY), eq(score), eq(1L), eq(20L)))
                 .thenReturn(mockMessages);
 
         // when
@@ -102,7 +102,7 @@ public class GoodsChatCacheManagerTest {
         // then
         assertThat(result).hasSize(2);
         assertThat(result).containsExactly(message2, message1);
-        verify(zSetOperations).rangeByScore(eq(cacheKey), eq(Double.NEGATIVE_INFINITY), eq(score), eq(1L), eq(20L));
+        verify(zSetOperations).reverseRangeByScore(eq(cacheKey), eq(Double.NEGATIVE_INFINITY), eq(score), eq(1L), eq(20L));
     }
 
     @Test

--- a/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatCacheManagerTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatCacheManagerTest.java
@@ -1,0 +1,140 @@
+package com.example.mate.domain.goodsChat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.mate.domain.constant.MessageType;
+import com.example.mate.domain.goodsChat.document.GoodsChatMessage;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+@ExtendWith(MockitoExtension.class)
+public class GoodsChatCacheManagerTest {
+
+    @InjectMocks private GoodsChatCacheManager goodsChatCacheManager;
+    @Mock private RedisTemplate<String, GoodsChatMessage> redisTemplate;
+    @Mock private ZSetOperations<String, GoodsChatMessage> zSetOperations;
+
+    private GoodsChatMessage message1;
+    private GoodsChatMessage message2;
+
+    @BeforeEach
+    public void setUp() {
+        message1 = createGoodsChatMessage(LocalDateTime.now());
+        message2 = createGoodsChatMessage(LocalDateTime.now().minusMinutes(10));
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+    }
+
+    private GoodsChatMessage createGoodsChatMessage(LocalDateTime sentAt) {
+        return GoodsChatMessage.builder()
+                .content("test message")
+                .chatRoomId(1L)
+                .memberId(1L)
+                .messageType(MessageType.TALK)
+                .sentAt(sentAt)
+                .build();
+    }
+
+    @Test
+    @DisplayName("단건 채팅 메시지를 Redis 캐시에 저장한다.")
+    public void store_message_in_cache_success() {
+        // given
+        Long chatRoomId = 1L;
+        String cacheKey = String.format("goods_chat_message::%d", chatRoomId);
+
+        // when
+        goodsChatCacheManager.storeMessageInCache(chatRoomId, message1);
+
+        // then
+        verify(zSetOperations).add(eq(cacheKey), eq(message1), any(Double.class));
+        verify(redisTemplate).expire(eq(cacheKey), eq(3600L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    @DisplayName("다수의 채팅 메시지를 Redis 캐시에 저장한다.")
+    public void store_messages_in_cache_success() {
+        // given
+        Long chatRoomId = 1L;
+        String cacheKey = String.format("goods_chat_message::%d", chatRoomId);
+
+        // when
+        goodsChatCacheManager.storeMessagesInCache(chatRoomId, Arrays.asList(message1, message2));
+
+        // then
+        verify(zSetOperations).add(eq(cacheKey), eq(message1), any(Double.class));
+        verify(zSetOperations).add(eq(cacheKey), eq(message2), any(Double.class));
+        verify(redisTemplate).expire(eq(cacheKey), eq(3600L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    @DisplayName("Redis 캐시에서 마지막 메시지를 기준으로 오래된 메시지를 조회한다.")
+    public void fetch_messages_from_cache_with_last_sent_at_success() {
+        // given
+        Long chatRoomId = 1L;
+        String cacheKey = String.format("goods_chat_message::%d", chatRoomId);
+        LocalDateTime lastSentAt = LocalDateTime.now();
+        Double score = (double) lastSentAt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+
+        Set<GoodsChatMessage> mockMessages = new LinkedHashSet<>(Arrays.asList(message2, message1));
+        when(zSetOperations.rangeByScore(eq(cacheKey), eq(Double.NEGATIVE_INFINITY), eq(score), eq(1L), eq(20L)))
+                .thenReturn(mockMessages);
+
+        // when
+        List<GoodsChatMessage> result = goodsChatCacheManager.fetchMessagesFromCache(chatRoomId, lastSentAt, 20);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).containsExactly(message2, message1);
+        verify(zSetOperations).rangeByScore(eq(cacheKey), eq(Double.NEGATIVE_INFINITY), eq(score), eq(1L), eq(20L));
+    }
+
+    @Test
+    @DisplayName("마지막 메시지가 없는 경우, Redis 캐시에서 최신 메시지를 조회한다.")
+    public void fetch_messages_from_cache_success() {
+        // given
+        Long chatRoomId = 1L;
+        String cacheKey = String.format("goods_chat_message::%d", chatRoomId);
+
+        Set<GoodsChatMessage> mockMessages = new LinkedHashSet<>(Arrays.asList(message2, message1));
+        when(zSetOperations.reverseRange(eq(cacheKey), eq(0L), eq(19L))).thenReturn(mockMessages);
+
+        // when
+        List<GoodsChatMessage> result = goodsChatCacheManager.fetchMessagesFromCache(chatRoomId, null, 20);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).containsExactly(message2, message1);
+        verify(zSetOperations).reverseRange(eq(cacheKey), eq(0L), eq(19L));
+    }
+
+    @Test
+    @DisplayName("Redis 캐시에서 모든 채팅 메시지를 삭제한다.")
+    public void evict_messages_from_cache_success() {
+        // given
+        Long chatRoomId = 1L;
+        String cacheKey = String.format("goods_chat_message::%d", chatRoomId);
+
+        // when
+        goodsChatCacheManager.evictMessagesFromCache(chatRoomId);
+
+        // then
+        verify(zSetOperations).removeRange(cacheKey, 0, -1);
+    }
+}

--- a/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatMessageServiceTest.java
@@ -49,6 +49,9 @@ class GoodsChatMessageServiceTest {
     @Mock
     private SimpMessagingTemplate messagingTemplate;
 
+    @Mock
+    private GoodsChatCacheManager goodsChatCacheManager;
+
     private Member createMember(Long id, String name, String nickname) {
         return Member.builder()
                 .id(id)

--- a/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatServiceTest.java
+++ b/src/test/java/com/example/mate/domain/goodsChat/service/GoodsChatServiceTest.java
@@ -82,6 +82,9 @@ class GoodsChatServiceTest {
     @Mock
     private GoodsPostEventPublisher postEventPublisher;
 
+    @Mock
+    private GoodsChatCacheManager goodsChatCacheManager;
+
     private Member createMember(Long id, String name, String nickname) {
         return Member.builder()
                 .id(id)

--- a/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/com/example/mate/domain/member/integration/MemberIntegrationTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -113,6 +114,7 @@ class MemberIntegrationTest {
     private LogoutRedisService logoutRedisService;
 
     @MockBean
+    @Qualifier("jwtTokenRedisTemplate")
     private RedisTemplate<String, String> redisTemplate;
 
     @MockBean


### PR DESCRIPTION
## 💡 작업 내용

- [x] RedisConfig 구현
- [x] 채팅 메시지 캐싱 로직 구현(GoodsCahtCacheManager)
- [x] 실제 서비스 로직에 반영 및 Postman API 테스트
- [x] 테스트 코드 작성

## 💡 자세한 설명

> 저는 앞으로 `MongoDB 관련 트랜잭션 적용 안되는 문제 해결`, `README 작성`을 차례로 할 것 같습니당


## 캐싱 전략
캐싱 전략으로 `Look Aside 패턴` + `Write Through 패턴`을 조합하여 사용했습니다.

### 1. **캐시 데이터 저장 흐름 (Write Through 패턴)**
`Write Through 패턴`은 데이터를 캐시와 데이터베이스에 동시에 저장하여 데이터의 정합성을 유지합니다.  
채팅 메시지가 전송될 때 다음과 같은 흐름으로 저장됩니다.

1. **채팅 메시지 전송**
   - 사용자가 채팅 메시지를 전송하면, 서버는 해당 메시지를 처리합니다.

2. **Redis 캐시에 저장**
   - 메시지는 `GoodsChatCacheManager`의 `storeMessageInCache()` 메서드를 통해 Redis 캐시에 저장됩니다.
   - Redis는 `Sorted Set` 자료구조를 사용하며, `sent_at`(전송 시간)을 `score`로 설정하여 메시지를 정렬합니다.
   - 저장된 메시지는 TTL(Time-To-Live)이 1시간으로 설정됩니다.

3. **MongoDB에 저장**
   - 동시에 메시지는 MongoDB에 저장됩니다. 이는 `Write Through 패턴`의 특징으로, 캐시와 데이터베이스 간의 데이터 정합성을 보장합니다.

4. **TTL 갱신**
   - Redis 캐시에 저장된 메시지의 TTL이 1시간으로 갱신됩니다. 이는 같은 `chatRoomId`를 가진 메시지 Set의 생명주기를 동일하게 유지하기 위함입니다.

---

### 2. **캐시 데이터 읽기 흐름 (Look Aside 패턴)**
`Look Aside 패턴`은 데이터를 조회할 때 캐시를 먼저 확인하고, 캐시에 데이터가 없을 경우 데이터베이스에서 조회하는 방식입니다.  
채팅 내역을 조회할 때 다음과 같은 흐름으로 동작합니다.

1. **채팅 내역 조회 요청**
   - 사용자가 특정 채팅방의 채팅 내역을 조회합니다. 이때, `lastSentAt`(마지막으로 조회한 메시지의 전송 시간)과 `size`(조회할 메시지 개수)가 파라미터로 전달됩니다.

2. **Redis 캐시에서 조회**
   - `GoodsChatCacheManager`의 `fetchMessagesFromCache()` 메서드를 통해 Redis 캐시에서 메시지를 조회합니다.
   - Redis는 `Sorted Set`의 `reverseRange` 또는 `reverseRangeByScore` 메서드를 사용하여 `lastSentAt`을 기준으로 최신 메시지를 조회합니다.
   - 조회된 메시지가 요청한 `size`만큼 충분하다면, 해당 메시지를 반환합니다.

3. **Redis 캐시에 데이터가 없는 경우**
   - Redis 캐시에 데이터가 없거나 요청한 `size`만큼 충분하지 않은 경우, MongoDB에서 추가 데이터를 조회합니다.

4. **MongoDB에서 조회**
   - MongoDB에서 `lastSentAt`을 기준으로 추가 메시지를 조회합니다.

5. **Redis 캐시에 데이터 저장**
   - MongoDB에서 조회한 추가 데이터를 Redis 캐시에 저장합니다. 이는 이후 동일한 요청이 들어왔을 때 Redis 캐시에서 바로 데이터를 제공할 수 있도록 하기 위함입니다.

6. **데이터 반환**
   - Redis 캐시와 MongoDB에서 조회한 데이터를 합쳐서 사용자에게 반환합니다.

[자세한 캐싱 전략 소개 블로그](https://inpa.tistory.com/entry/REDIS-%F0%9F%93%9A-%EC%BA%90%EC%8B%9CCache-%EC%84%A4%EA%B3%84-%EC%A0%84%EB%9E%B5-%EC%A7%80%EC%B9%A8-%EC%B4%9D%EC%A0%95%EB%A6%AC#write_through_%ED%8C%A8%ED%84%B4)

---

### Redis 자료구조 - Sorted Set

채팅 메시지의 전송 시간(`sent_at`)을 기준으로 정렬된 데이터를 효율적으로 사용하기 위해 `Sorted Set` 자료구조를 사용했습니다.

- Redis에서 제공하는 `Sorted Set`은 데이터가 `score`와 `value` 쌍으로 저장됩니다. `Sorted Set`은 데이터를 `score`를 기준으로 자동으로 정렬합니다. (우선순위 큐와 동작 방식이 유사함)
  - `GoodsChatMessage`의 `sent_at`을 `score`로 설정하여 채팅 메시지를 **전송 시간 기준**으로 항상 정렬할 수 있습니다.
  
- `Sorted Set`은 범위 조회를 매우 효율적으로 처리할 수 있습니다.
  - 로직에서 사용한 `reverseRange`나 `reverseRangeByScore` 메서드는 특정 범위 내 메시지를 쉽게 조회할 수 있습니다.
  - 특히 `reverseRangeByScore` 메서드는 **score(전송 시간)**을 기준으로 특정 범위와 정렬 조건을 정하여 메시지를 조회할 수 있기 때문에 불필요한 로직을 줄일 수 있습니다.
  

---

### RedisConfig
```java
@Configuration
@RequiredArgsConstructor
public class RedisConfig {

    private final RedisProperties redisProperties;

    @Bean
    public RedisConnectionFactory redisConnectionFactory() {
        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
    }

    @Bean
    public RedisTemplate<String, String> jwtTokenRedisTemplate() {
        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
        redisTemplate.setConnectionFactory(redisConnectionFactory());
        redisTemplate.setKeySerializer(new StringRedisSerializer());
        redisTemplate.setValueSerializer(new StringRedisSerializer());
        return redisTemplate;
    }

    @Bean
    public RedisTemplate<String, GoodsChatMessage> goodsChatCacheRedisTemplate() {
        ObjectMapper objectMapper = new ObjectMapper();
        objectMapper.registerModule(new JavaTimeModule());
        objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
        GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);

        RedisTemplate<String, GoodsChatMessage> redisTemplate = new RedisTemplate<>();
        redisTemplate.setConnectionFactory(redisConnectionFactory());
        redisTemplate.setKeySerializer(new StringRedisSerializer());
        redisTemplate.setValueSerializer(genericJackson2JsonRedisSerializer);
        return redisTemplate;
    }
}
```
- `private final RedisProperties redisProperties`
  - `application.yml`에서 redis 관련 연결 정보를 가져옵니다.
  - `@Value`를 통해 구현할 수 있었지만, 배포 환경에 환경 변수를 추가해줘야 하는 번거로움이 있어서 `RedisProperties`를 사용했습니다.
- `jwtTokenRedisTemplate()`
  - 원주님께서 구현하신 `RedisTemplate` 입니다. 기존에는 별다른 설정이 없었지만 `goodsChatCacheRedisTemplate`이 추가로 생기면서 설정을 추가했습니다. (모두 기본 설정입니다.)
- `goodsChatCacheRedisTemplate()`
  - `redisTemplate.setKeySerializer(new StringRedisSerializer());`
    - redis 에 `key` 값을 저장할 때 쓰이는 `serializer` 입니다. (문자열로 저장하기 때문에 기본 `serializer` 사용)
  - `redisTemplate.setValueSerializer(genericJackson2JsonRedisSerializer); `
    -  redis 에 `value` 값을 저장할 때 쓰이는 `serializer` 입니다.
    - `GenericJackson2JsonRedisSerializer`는 객체를 JSON 형태로 저장할 수 있는 `serializer`입니다.
    - 날짜 타입(`LocalDateTIme`)을 지원을 하지 않기 때문에 `ObjectMapper`를 통해 커스텀 설정을 추가했습니다.

---

 ### GoodsChatCacheManager

```java
@Component
public class GoodsChatCacheManager {

    private final RedisTemplate<String, GoodsChatMessage> redisTemplate;

    private static final String CACHE_KEY_FORMAT = "goods_chat_message::%d";
    private static final long DEFAULT_TTL_SECONDS = 3600;

    public GoodsChatCacheManager(
            @Qualifier("goodsChatCacheRedisTemplate") RedisTemplate<String, GoodsChatMessage> redisTemplate) {
        this.redisTemplate = redisTemplate;
    }

    // Redis Sorted Set 에 메시지를 저장
    public void storeMessageInCache(Long chatRoomId, GoodsChatMessage message) {
        storeMessagesInCache(chatRoomId, List.of(message));
    }

    // Redis Sorted Set 에 메시지 List 저장
    public void storeMessagesInCache(Long chatRoomId, List<GoodsChatMessage> messages) {
        for (GoodsChatMessage message : messages) {
            String cacheKey = formatCacheKey(chatRoomId);
            Double score = convertToScore(message.getSentAt());
            redisTemplate.opsForZSet().add(cacheKey, message, score);
        }
        setTTL(formatCacheKey(chatRoomId));
    }

    /**
     * Redis 에서 특정 채팅방의 메시지를 lastSentAt 기준으로 최신순으로 정렬하여 조회합니다.
     * @param chatRoomId 채팅방 ID (해당 채팅방의 메시지를 조회합니다.)
     * @param lastSentAt 메시지를 조회할 기준 시간 (null 일 경우 가장 최근 메시지를 조회합니다.)
     * @param size 조회할 메시지의 개수
     * @return 최신순으로 정렬된 조회된 메시지 List (메시지가 없으면 빈 리스트를 반환합니다.)
     */
    public List<GoodsChatMessage> fetchMessagesFromCache(Long chatRoomId, LocalDateTime lastSentAt, int size) {
        String cacheKey = formatCacheKey(chatRoomId);
        Set<GoodsChatMessage> messages;

        // lastSentAt이 null 인 경우, 가장 최근 메시지 조회
        if (lastSentAt == null) {
             messages = redisTemplate.opsForZSet().reverseRange(cacheKey, 0, size - 1);
        // lastSentAt을 기준으로 이전의 메시지를 최신순으로 정렬하여 조회
        } else {
            Double score = convertToScore(lastSentAt);
            messages = redisTemplate.opsForZSet().reverseRangeByScore(cacheKey, Double.NEGATIVE_INFINITY, score, 1, size);
        }

        if (messages == null || messages.isEmpty()) {
            return Collections.emptyList();
        }

        return new ArrayList<>(messages);
    }

    // Redis Sorted Set 에서 모든 메시지를 삭제
    public void evictMessagesFromCache(Long chatRoomId) {
        String cacheKey = formatCacheKey(chatRoomId);
        redisTemplate.opsForZSet().removeRange(cacheKey, 0, -1);
    }

    // TTL 설정 - 1시간
    private void setTTL(String cacheKey) {
        redisTemplate.expire(cacheKey, DEFAULT_TTL_SECONDS, TimeUnit.SECONDS);
    }

    private String formatCacheKey(Long chatRoomId) {
        return String.format(CACHE_KEY_FORMAT, chatRoomId);
    }

    // LocalDateTime 을 Redis Sorted Set 에서 사용하는 score 값으로 변환
    private Double convertToScore(LocalDateTime sentAt) {
        return (double) sentAt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
    }
}
```

- storeMessageInCache(), storeMessagesInCache()
  - 채팅 메시지를 캐시에 저장합니다. 이때 매번 TTL을 1시간으로 초기화합니다.
  - 같은 `chatRoomId` 가진 메시지 Set의 생명주기를 동일하게 맞춰서 데이터 정합성을 유지했습니다.
  - 위 메서드는 채팅 전송, 채팅 내역 조회(MongoDB에서 가져온 데이터 저장)시 사용됩니다.
- fetchMessagesFromCache()
  - Redis 캐시로부터 메시지를 조회합니다. `MongoRespository`에서  `lastSentAt`을 기준으로 동적 쿼리를 만들었던 로직과 동일합니다.
- evictMessagesFromCache()
  - 채팅방을 삭제할 때, 해당 메서드가 호출되어  같은 `chatRoomId` 가진 메시지 Set을 삭제합니다.
- convertToScore()
  - 채팅 전송 시간 `sent_At`을 Double 타입으로 변환하여 `Sorted Set`에서 쓰이는 `score`로 변환합니다.

---



## 📗 참고 자료 (선택)
[REDIS📚캐시 설계 전략 지침 총정리](https://inpa.tistory.com/entry/REDIS-%F0%9F%93%9A-%EC%BA%90%EC%8B%9CCache-%EC%84%A4%EA%B3%84-%EC%A0%84%EB%9E%B5-%EC%A7%80%EC%B9%A8-%EC%B4%9D%EC%A0%95%EB%A6%AC#write_through_%ED%8C%A8%ED%84%B4)

[Redis Sorted Set](https://jupiny.com/2020/03/29/redis-sorted-set/)

## 📢 리뷰 요구 사항 (선택)
로직에서 잘못된 부분이 있는지 확인해주시면 감사하겠습니다!
아 그리고 `Medis` 라는 Redis GUI 앱이 있는데 되게 편리하더라구요 나중에 Redis 관련 개발하시면 사용하시는거 추천드립니당

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] Assignees, Reviewers, Labels 를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?